### PR TITLE
Fix the individual contact type and fix the waiting induction url app…

### DIFF
--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -129,17 +129,13 @@ function goonj_handle_user_identification_form() {
             'phone' => $phone,
             'is_deleted' => 0,
             'contact_type' => 'Individual',
+            'contact_sub_type' => 'Volunteer'
         ]);
 
         $foundContacts = $contactResult['values'];
 
-        // Filter contacts to get those with the 'Volunteer' contact subtype
-        $volunteerContacts = array_filter($foundContacts, function($contact) {
-            return is_array($contact['contact_sub_type']) && in_array('Volunteer', $contact['contact_sub_type']);
-        });
-
         // If the user does not exist in the Goonj database 
-        // and dont have Volunteer contact type then
+        // and does not have the Volunteer contact type then
         // redirect to the volunteer registration form.
         $volunteer_registration_form_path = sprintf(
             '/volunteer-registration/#?email=%1$s&phone=%2$s',
@@ -147,8 +143,7 @@ function goonj_handle_user_identification_form() {
             $phone,
         );
 
-
-        if ( empty( $volunteerContacts ) ) {
+        if ( empty( $foundContacts ) ) {
             // We are currently hardcoding the path of the volunteer registration page.
             // If this path changes, then this code needs to be updated.
             wp_redirect( $volunteer_registration_form_path );

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -132,7 +132,14 @@ function goonj_handle_user_identification_form() {
         ]);
 
         $foundContacts = $contactResult['values'];
-        // If the user does not exist in the Goonj database then
+
+        // Filter contacts to get those with the 'Volunteer' contact subtype
+        $volunteerContacts = array_filter($foundContacts, function($contact) {
+            return is_array($contact['contact_sub_type']) && in_array('Volunteer', $contact['contact_sub_type']);
+        });
+
+        // If the user does not exist in the Goonj database 
+        // and dont have Volunteer contact type then
         // redirect to the volunteer registration form.
         $volunteer_registration_form_path = sprintf(
             '/volunteer-registration/#?email=%1$s&phone=%2$s',
@@ -141,7 +148,7 @@ function goonj_handle_user_identification_form() {
         );
 
 
-        if ( empty( $foundContacts ) ) {
+        if ( empty( $volunteerContacts ) ) {
             // We are currently hardcoding the path of the volunteer registration page.
             // If this path changes, then this code needs to be updated.
             wp_redirect( $volunteer_registration_form_path );
@@ -150,14 +157,6 @@ function goonj_handle_user_identification_form() {
 
         $contact = $foundContacts[0];
 
-        // If we are here, then it means the contact of type "Individual" exists.
-        // We need to now check if the contact sub_type is "Volunteer".
-        // If the Individual is not a Volunteer, then again we redirect it to
-        // volunteer registration form.
-        if ( ! in_array( 'Volunteer', $contact['contact_sub_type'] ) ) {
-            wp_redirect( $volunteer_registration_form_path );
-            exit;
-        }
 
         // If we are here, then it means Volunteer exists in our system.
         // Now we need to check if the volunteer is inducted or not.
@@ -165,10 +164,21 @@ function goonj_handle_user_identification_form() {
         //   1. Trigger an email for Induction 
         //   2. Change volunteer status to "Waiting for Induction"
         if ( ! goonj_is_volunteer_inducted( $contact ) ) {
-            // Use CiviCRM email API to send the induction email.
-            // Use CiviCRM contact API to update the contact status (custom data).
-            // Redirect back to the same page with a message.
-            wp_redirect( wp_get_referer() . '?message=waiting-induction' );
+            $referer_url = wp_get_referer();
+            $parsed_url = parse_url($referer_url);
+            $query_params = [];
+
+            // If there is a query string, parse it
+            if (isset($parsed_url['query'])) {
+                parse_str($parsed_url['query'], $query_params);
+            }
+
+            // Set the message parameter
+            $query_params['message'] = 'waiting-induction';
+
+            // Build and redirect to the new URL
+            $redirect_url = $parsed_url['path'] . '?' . http_build_query($query_params);
+            wp_redirect($redirect_url);
             exit;
         }
 


### PR DESCRIPTION
**Fixes in this PR**

1. When saving the form for an individual contact, an error occurred because the previous code only checked volunteer array and didn't check for those users that are moved from individual to volunteer because it created a new entry for those user. I have updated the code to verify whether a volunteer entry exists redirect the user accordingly.
2. Fixed the issue where the waiting-induction URL was being appended multiple times whenever a user submitted their details. This fix ensures that messages are displayed correctly based on the query parameters.