### PR TITLE
Show the serial number according to the state

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/CivirulesAction/CreateEventForContact.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/CivirulesAction/CreateEventForContact.php
@@ -120,7 +120,19 @@ class CRM_Goonjcustom_CivirulesAction_CreateEventForContact extends CRM_Civirule
 		// Find the state code from the config
 		$stateCode = $goonjStateCode[$stateAbbreviation] ?? 'UNKNOWN';
 
-		return "$createdYear/$stateCode/CC";
+		// Fetch existing collection camps for the state
+		try {
+			$existingCamps = \Civi\Api4\Event::get(FALSE)
+				->addSelect('title')
+				->addWhere('title', 'LIKE', "$createdYear/$stateCode/CC/%")
+				->execute();
+	
+			$serialNumber = $existingCamps->count() + 1;
+		} catch (Exception $e) {
+			throw new Exception($e->getMessage());
+		}
+
+		return "$createdYear/$stateCode/CC/$serialNumber";
 	}
 
 	/**


### PR DESCRIPTION
Show the serial number according to the state.

For example: This will be based on the number of camps created for a particular state. For example, the Jharkhand 1th collection camp will have the name 2024/JRD/CC/1 and the Jharkand 2th collection camp will have the name 2024/JRD/CC/2

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/c309b42d-df3b-4821-beff-cfac64448e40">
