### PR TITLE
Skip Validation for Empty Email Field to Allow Submission with Optional Email

### DIFF
--- a/wp-content/themes/goonj-crm/validation.js
+++ b/wp-content/themes/goonj-crm/validation.js
@@ -18,13 +18,11 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Phone validation code commented out for now. Uncomment when needed.
-    /*
       const phoneValue = phoneInput.value;
       if (!/^\d{10}$/.test(phoneValue)) {
           valid = false;
           showError(phoneInput, "Phone number must be exactly 10 digits.");
       }
-      */
 
     if (!valid) {
       event.preventDefault();

--- a/wp-content/themes/goonj-crm/validation.js
+++ b/wp-content/themes/goonj-crm/validation.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Validate email
     const emailValue = emailInput.value;
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
+    if (emailValue !== "" && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
       valid = false;
       showError(emailInput, "The e-mail address entered is invalid.");
     }


### PR DESCRIPTION
 Modifies the form validation logic to ensure that the email field is treated as optional. Previously, the form would trigger a validation error if the email field was left blank, even though the field is not required. With this change, the validation will only be performed on the email field if a value is present.