### PR TITLE
Fix undefined variable name coordinators

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -433,10 +433,10 @@ class CollectionCampService extends AutoSubscriber {
       ->addWhere('is_current', '=', FALSE)
       ->execute();
 
-    $coordinatorCount = $coordinators->count();
+    $coordinatorCount = $fallbackCoordinators->count();
 
     $randomIndex = rand(0, $coordinatorCount - 1);
-    $coordinator = $coordinators->itemAt($randomIndex);
+    $coordinator = $fallbackCoordinators->itemAt($randomIndex);
 
     return $coordinator;
   }


### PR DESCRIPTION
- Resolve the issue of the undefined variable `$coordinators` in the Collection Camp service file.