### PR TITLE
Limit collection camp state dropdown to indian states only

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -34,6 +34,7 @@ class CollectionCampService extends AutoSubscriber {
         ['generateCollectionCampQr'],
       ],
       '&hook_civicrm_custom' => 'setOfficeDetails',
+      '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
     ];
   }
 
@@ -439,6 +440,43 @@ class CollectionCampService extends AutoSubscriber {
     $coordinator = $fallbackCoordinators->itemAt($randomIndex);
 
     return $coordinator;
+  }
+
+  /**
+   *
+   */
+  public static function setIndianStateOptions(string $entity, string $field, array &$options, array $params) {
+    if ($entity !== 'Eck_Collection_Camp') {
+      return;
+    }
+
+    $intentStateFields = CustomField::get(FALSE)
+      ->addWhere('custom_group_id:name', '=', 'Collection_Camp_Intent_Details')
+      ->addWhere('name', '=', 'State')
+      ->execute();
+
+    $stateField = $intentStateFields->first();
+
+    $statefieldId = $stateField['id'];
+
+    if ($field !== "custom_$statefieldId") {
+      return;
+    }
+
+    $indianStates = StateProvince::get(FALSE)
+      ->addWhere('country_id.iso_code', '=', 'IN')
+      ->addOrderBy('name', 'ASC')
+      ->execute();
+
+    $stateOptions = [];
+    foreach ($indianStates as $state) {
+      if ($state['is_active']) {
+        $stateOptions[$state['id']] = $state['name'];
+      }
+    }
+
+    $options = $stateOptions;
+
   }
 
 }


### PR DESCRIPTION
This PR dynamicall adds options to the state select-type field in collection camp intent. The options are list of states limited to India.