### PR TITLE
Redirect url fixes for collection camp and dropping center

### DIFF
--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -161,7 +161,7 @@ function goonj_handle_user_identification_form() {
 		// If the user does not exist in the Goonj database
 		// redirect to the volunteer registration form.
 		$volunteer_registration_form_path = sprintf(
-			'/volunteer-registration/#?email=%s&phone=%s&message=%s&Volunteer_fields.Which_activities_are_you_interested_in_=%s',
+			'/volunteer-registration/form/#?email=%s&phone=%s&message=%s&Volunteer_fields.Which_activities_are_you_interested_in_=%s',
 			$email,
 			$phone,
 			'not-inducted-volunteer',
@@ -176,7 +176,7 @@ function goonj_handle_user_identification_form() {
 		);
 
 		$dropping_center_volunteer_registration_form_path = sprintf(
-			'/volunteer-registration/#?email=%s&phone=%s&message=%s',
+			'/volunteer-registration/form/#?email=%s&phone=%s&message=%s',
 			$email,
 			$phone,
 			'not-inducted-for-dropping-center'

--- a/wp-content/themes/goonj-crm/templates/collection-landing-page.php
+++ b/wp-content/themes/goonj-crm/templates/collection-landing-page.php
@@ -19,6 +19,6 @@ Template Name: Collection Landing Page
 		</li>
 	</ol>
 	<div class="login-submit w-100p mt-36">
-		<a class="button button-primary d-flex justify-content-center align-items-center" href="<?php echo esc_url(get_permalink(get_page_by_path('collection-camp/check-user'))); ?>">Continue</a>
+		<a class="button button-primary d-flex justify-content-center align-items-center text-decoration-none" href="<?php echo esc_url(get_permalink(get_page_by_path('collection-camp/check-user'))); ?>">Continue</a>
 	</div>
 </div>


### PR DESCRIPTION
Redirect url fixes for collection camp and dropping center

Remove the underline from the button
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/116fd428-364a-4ac4-b25a-66d2a5056a98">
