### PR TITLE
ACL for collection camp

### DIFF
--- a/wp-content/civi-extensions/de.systopia.eck/CRM/Eck/DAO/Entity.php
+++ b/wp-content/civi-extensions/de.systopia.eck/CRM/Eck/DAO/Entity.php
@@ -244,14 +244,6 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
   /**
    * {@inheritDoc}
    */
-  public static function getSelectWhereClause($tableAlias = NULL, $entityName = NULL, $conditions = []): array {
-    // TODO: ECK entities do not implement ACLs
-    return [];
-  }
-
-  /**
-   * {@inheritDoc}
-   */
   public static function writeRecord(array $record): CRM_Core_DAO {
     $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
     if ($loggedInContactID) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -14,6 +14,7 @@ use Civi\Core\Service\AutoSubscriber;
 class CollectionBaseService extends AutoSubscriber {
 
   const ENTITY_NAME = 'Collection_Camp';
+  const INTENT_CUSTOM_GROUP_NAME = 'Collection_Camp_Intent_Details';
 
   /**
    *
@@ -107,8 +108,7 @@ class CollectionBaseService extends AutoSubscriber {
   private static function getStateFieldDbDetails() {
     $customGroups = CustomGroup::get(FALSE)
       ->addSelect('table_name')
-      ->addWhere('name', '=', 'Collection_Camp_Intent_Details')
-      ->setLimit(25)
+      ->addWhere('name', '=', self::INTENT_CUSTOM_GROUP_NAME)
       ->execute();
 
     $customGroup = $customGroups->first();
@@ -116,7 +116,7 @@ class CollectionBaseService extends AutoSubscriber {
 
     $customFields = CustomField::get(FALSE)
       ->addSelect('column_name')
-      ->addWhere('custom_group_id:name', '=', 'Collection_Camp_Intent_Details')
+      ->addWhere('custom_group_id:name', '=', self::INTENT_CUSTOM_GROUP_NAME)
       ->addWhere('name', '=', 'state')
       ->execute();
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -68,8 +68,11 @@ class CollectionBaseService extends AutoSubscriber {
 
     if (!$teamGroupContact) {
       \Civi::log()->debug('no chapter team group found for user: ' . $userId);
-
-      return;
+      // @todo we should handle it in a better way.
+      // if there is no chapter assigned to the contact
+      // then ideally she should not see any collection camp which
+      // can be done but then it limits for the admin user as well.
+      return FALSE;
     }
 
     $groupId = $teamGroupContact['group_id'];
@@ -84,7 +87,8 @@ class CollectionBaseService extends AutoSubscriber {
 
     if (empty($statesControlled)) {
       // Handle the case when the group is not controlling any state.
-      return;
+      $clauses['id'][] = 'IN (null)';
+      return TRUE;
     }
 
     $statesControlled = array_unique($statesControlled);
@@ -100,6 +104,7 @@ class CollectionBaseService extends AutoSubscriber {
     );
 
     $clauses['id'][] = $clauseString;
+    return TRUE;
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -88,16 +88,6 @@ class CollectionBaseService extends AutoSubscriber {
     else {
       $clauses['`Collection_Camp_Intent_Details_4`.`state_261`'][] = "IN (NULL)";
     }
-
-    // \Civi::log()->debug($entity, [
-    //   [
-    //     'conditions'=>$conditions,
-    //     'groupId' => $groupId,
-    //     'statesControlled' => $statesControlled,
-    //     'statesList' => $statesList,
-    //     'clauses' => $clauses,
-    //   ],
-    // ]);
   }
 
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -2,6 +2,8 @@
 
 namespace Civi;
 
+use Civi\Api4\Group;
+use Civi\Api4\GroupContact;
 use Civi\Core\Service\AutoSubscriber;
 
 /**
@@ -17,6 +19,7 @@ class CollectionBaseService extends AutoSubscriber {
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_tabset' => 'collectionBaseTabset',
+      '&hook_civicrm_selectWhereClause' => 'aclCollectionCamp',
     ];
   }
 
@@ -41,7 +44,58 @@ class CollectionBaseService extends AutoSubscriber {
       'active' => 1,
       'current' => FALSE,
     ];
+  }
 
+  /**
+   *
+   */
+  public static function aclCollectionCamp($entity, &$clauses, $userId, $conditions) {
+    if ($entity !== 'Eck_Collection_Camp') {
+      return;
+    }
+
+    $teamGroupContacts = GroupContact::get(FALSE)
+      ->addSelect('group_id')
+      ->addWhere('contact_id', '=', $userId)
+      ->addWhere('status', '=', 'Added')
+      ->addWhere('group_id.Chapter_Contact_Group.Use_Case', '=', 'chapter-team')
+      ->execute();
+
+    $teamGroupContact = $teamGroupContacts->first();
+
+    if (!$teamGroupContact) {
+      \Civi::log()->debug('no chapter team group found for user: ' . $userId);
+
+      return;
+    }
+
+    $groupId = $teamGroupContact['group_id'];
+
+    $chapterGroups = Group::get(FALSE)
+      ->addSelect('Chapter_Contact_Group.States_controlled')
+      ->addWhere('id', '=', $groupId)
+      ->execute();
+
+    $group = $chapterGroups->first();
+    $statesControlled = $group['Chapter_Contact_Group.States_controlled'];
+
+    if (!empty($statesControlled)) {
+      $statesControlled = array_unique($statesControlled);
+      $statesList = implode(',', array_map('intval', $statesControlled));
+
+      $clauses['custom_261'][] = "IN ($statesList)";
+    }
+    else {
+      $clauses['custom_261'][] = "IN (NULL)";
+    }
+
+    \Civi::log()->debug($entity, [
+      [
+        'groupId' => $groupId,
+        'statesControlled' => $statesControlled,
+        'statesList' => $statesList,
+      ],
+    ]);
   }
 
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -83,19 +83,21 @@ class CollectionBaseService extends AutoSubscriber {
       $statesControlled = array_unique($statesControlled);
       $statesList = implode(',', array_map('intval', $statesControlled));
 
-      $clauses['custom_261'][] = "IN ($statesList)";
+      $clauses['`Collection_Camp_Intent_Details_4`.`state_261`'][] = "IN ($statesList)";
     }
     else {
-      $clauses['custom_261'][] = "IN (NULL)";
+      $clauses['`Collection_Camp_Intent_Details_4`.`state_261`'][] = "IN (NULL)";
     }
 
-    \Civi::log()->debug($entity, [
-      [
-        'groupId' => $groupId,
-        'statesControlled' => $statesControlled,
-        'statesList' => $statesList,
-      ],
-    ]);
+    // \Civi::log()->debug($entity, [
+    //   [
+    //     'conditions'=>$conditions,
+    //     'groupId' => $groupId,
+    //     'statesControlled' => $statesControlled,
+    //     'statesList' => $statesList,
+    //     'clauses' => $clauses,
+    //   ],
+    // ]);
   }
 
 }

--- a/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php
+++ b/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php
@@ -3294,20 +3294,11 @@ SELECT contact_id
             $formattedClauses[] = "(`$tableAlias`.`$fieldName` " . implode(" OR `$tableAlias`.`$fieldName` ", $subClause) . ')';
           }
           else {
-            $needsAlias = strpos($fieldName, '.') === false;
-            if ($needsAlias) {
-              $formattedClauses[] = "(`$tableAlias`.`$fieldName` " . $subClause . ')';
-            } else {
-              list($customTableAlias, $customFieldName) = explode('.', $fieldName);
-              $formattedClauses[] = "($customTableAlias.$customFieldName " . $subClause . ')';
-            }
+            $formattedClauses[] = "(`$tableAlias`.`$fieldName` " . $subClause . ')';
           }
         }
-
-        $needsAlias = strpos($fieldName, '.') === false;
-
         $finalClauses[$fieldName] = '(' . implode(' AND ', $formattedClauses) . ')';
-        if (empty($fields[$fieldName]['required']) && $needsAlias) {
+        if (empty($fields[$fieldName]['required'])) {
           $finalClauses[$fieldName] = "(`$tableAlias`.`$fieldName` IS NULL OR {$finalClauses[$fieldName]})";
         }
       }

--- a/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php
+++ b/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php
@@ -3300,34 +3300,20 @@ SELECT contact_id
             if ($needsAlias) {
               $formattedClauses[] = "(`$tableAlias`.`$fieldName` " . $subClause . ')';
             } else {
-              list($tableAlias, $fieldName) = explode('.', $fieldName);
-              $formattedClauses[] = "($tableAlias.$fieldName " . $subClause . ')';
+              list($tA, $fN) = explode('.', $fieldName);
+              $formattedClauses[] = "($tA.$fN " . $subClause . ')';
             }
           }
         }
 
-        $finalClauses[$fieldName] = '(' . implode(' AND ', $formattedClauses) . ')';
-        if (empty($fields[$fieldName]['required'])) {
-          $needsAlias = strpos($fieldName, '.') === false;
-          if ($needsAlias) {
-            if (strpos($tableAlias, '`') !== false) {
-              $tableAlias = trim($tableAlias, '`');
-            }
-            if (strpos($fieldName, '`') !== false) {
-              $fieldName = trim($fieldName, '`');
-            }
+        $needsAlias = strpos($fieldName, '.') === false;
 
-            if ($finalClauses[$fieldName]) {
-              $finalClauses[$fieldName] = "(`$tableAlias`.`$fieldName` IS NULL OR {$finalClauses[$fieldName]})";
-            }
-          } else {
-            list($tableAlias, $fieldName) = explode('.', $fieldName);
-            $finalClauses[$fieldName] = "($tableAlias.$fieldName IS NULL OR {$finalClauses[$fieldName]})";
-          }
+        $finalClauses[$fieldName] = '(' . implode(' AND ', $formattedClauses) . ')';
+        if (empty($fields[$fieldName]['required']) && $needsAlias) {
+          $finalClauses[$fieldName] = "(`$tableAlias`.`$fieldName` IS NULL OR {$finalClauses[$fieldName]})";
         }
       }
     }
-
     return $finalClauses;
   }
 

--- a/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php
+++ b/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php
@@ -3288,7 +3288,6 @@ SELECT contact_id
           $fieldClauses = (array) $fieldClauses;
         }
         $formattedClauses = [];
-
         foreach (CRM_Utils_SQL::prefixFieldNames($fieldClauses, array_keys($fields), $tableAlias) as $subClause) {
           // Arrays of arrays get joined with OR (similar to CRM_Core_Permission::check)
           if (is_array($subClause)) {
@@ -3296,12 +3295,11 @@ SELECT contact_id
           }
           else {
             $needsAlias = strpos($fieldName, '.') === false;
-
             if ($needsAlias) {
               $formattedClauses[] = "(`$tableAlias`.`$fieldName` " . $subClause . ')';
             } else {
-              list($tA, $fN) = explode('.', $fieldName);
-              $formattedClauses[] = "($tA.$fN " . $subClause . ')';
+              list($customTableAlias, $customFieldName) = explode('.', $fieldName);
+              $formattedClauses[] = "($customTableAlias.$customFieldName " . $subClause . ')';
             }
           }
         }


### PR DESCRIPTION
In this PR, we hook into the Civi's [`hook_civicrm_selectWhereClause`](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_selectWhereClause/) and put restriction on the collection camp.

After hooking into it, we implement a geography-based restriction to the on Civi groups and 


### Part 1:

1. Contact belongs to a Group
2. This group has a custom field called `States Controlled` that stores a list of `state_province_id`
3. This group has also custom field `Use Case` which is set to `chapter-team` to identify these special groups for geography-based teams

### Part 2:

1. Custom Entity has a custom field called State that keeps the single `state_province_id` of the entity


**The ACL applied is: A contact can view/edit the custom entity if the States controlled by its group contains the State of the entity.**