### PR TITLE
turn off api auth when fetching activity type of induction

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -538,7 +538,7 @@ class CollectionCampService extends AutoSubscriber {
 
     $contactId = $collectionCamp['Collection_Camp_Core_Details.Contact_Id'];
 
-    $optionValue = OptionValue::get(TRUE)
+    $optionValue = OptionValue::get(FALSE)
       ->addWhere('option_group_id:name', '=', 'activity_type')
       ->addWhere('label', '=', 'Induction')
       ->execute()->single();


### PR DESCRIPTION
fixes the authorization error that happens when a non-logged in user creates a collection camp