### PR TITLE
Disable Induction Activity to Prevent Multiple Inductions in CRM

### DIFF
--- a/wp-content/themes/goonj-crm/admin-style.css
+++ b/wp-content/themes/goonj-crm/admin-style.css
@@ -10,3 +10,6 @@
 #wpbody .wpbody-content #crm-container .crm-accordion-header:not(.crm-master-accordion-header)+.crm-accordion-body, .crm-container .crm-accordion-bold>.crm-accordion-body {
     box-shadow: none !important;
 }
+.crm-contact-actions-list-inner .crm-contact_activities-list .crm-activity-type_4 {
+    display: none !important;
+}


### PR DESCRIPTION
This PR disables the "Induction" activity under the CRM contact actions. The reason for this change is to prevent the possibility of scheduling multiple induction activities for the same contact.