### PR TITLE
Fix contact email and phone not saved

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -195,7 +195,7 @@ class InductionService extends AutoSubscriber {
       return;
     }
 
-    $assignee = Contact::get(TRUE)
+    $assignee = Contact::get(FALSE)
       ->addSelect('email.email')
       ->addJoin('Email AS email', 'LEFT')
       ->addWhere('id', '=', $inductionsFields['Assign']['value'])


### PR DESCRIPTION
- Update query parameter in Contact::get() from TRUE to FALSE