### PR TITLE
MMT email functionality

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -55,6 +55,11 @@ class CollectionBaseService extends AutoSubscriber {
       "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fevent-volunteer",
     );
 
+    // URL for the material dispatch authorizationtab.
+    $materialAuthorisation = \CRM_Utils_System::url(
+      "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Facknowledgement-for-logistics-data",
+    );
+
     // Add the event volunteer tab.
     $tabs['eventVolunteers'] = [
       'title' => ts('Event Volunteers'),

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -55,11 +55,6 @@ class CollectionBaseService extends AutoSubscriber {
       "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fevent-volunteer",
     );
 
-    // URL for the material dispatch authorizationtab.
-    $materialAuthorisation = \CRM_Utils_System::url(
-      "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Facknowledgement-for-logistics-data",
-    );
-
     // Add the event volunteer tab.
     $tabs['eventVolunteers'] = [
       'title' => ts('Event Volunteers'),
@@ -77,7 +72,6 @@ class CollectionBaseService extends AutoSubscriber {
       'active' => 1,
       'current' => FALSE,
     ];
-
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1000,8 +1000,8 @@ class CollectionCampService extends AutoSubscriber {
    *
    */
   public static function goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId) {
-    $homeUrl = get_home_url();
-    $materialdispatchUrl = $homeUrl . '/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=materialAuthorisation#?intent_id=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $mmtId;
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+    $materialdispatchUrl = $homeUrl . 'wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=materialAuthorisation#?intent_id=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $mmtId;
 
     $html = "
     <p>Dear $contactName,</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -52,7 +52,7 @@ class CollectionCampService extends AutoSubscriber {
       '&hook_civicrm_custom' => [
         ['setOfficeDetails'],
         ['linkInductionWithCollectionCamp'],
-        ['mailNotificationToMMT'],
+        ['mailNotificationToMmt'],
 
       ],
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
@@ -88,7 +88,7 @@ class CollectionCampService extends AutoSubscriber {
     );
 
     // URL for the material dispatch authorizationtab.
-    $materialAuthorisation = \CRM_Utils_System::url(
+    $materialAuthorization = \CRM_Utils_System::url(
       "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Facknowledgement-for-logistics-data",
     );
 
@@ -120,9 +120,9 @@ class CollectionCampService extends AutoSubscriber {
     ];
 
     // Add the material dispatch authorization tab.
-    $tabs['materialAuthorisation'] = [
+    $tabs['materialAuthorization'] = [
       'title' => ts('Material Authorization'),
-      'link' => $materialAuthorisation,
+      'link' => $materialAuthorization,
       'valid' => 1,
       'active' => 1,
       'current' => FALSE,
@@ -933,7 +933,7 @@ class CollectionCampService extends AutoSubscriber {
    * @param object $objectRef
    *   The parameters that were sent into the calling function.
    */
-  public static function mailNotificationToMMT($op, $groupID, $entityID, &$params) {
+  public static function mailNotificationToMmt($op, $groupID, $entityID, &$params) {
     if ($op !== 'create') {
       return;
     }
@@ -943,14 +943,14 @@ class CollectionCampService extends AutoSubscriber {
     }
 
     $goonjFieldId = $goonjField['value'];
-    $vehicleDispatcheId = $goonjField['entity_id'];
+    $vehicleDispatchId = $goonjField['entity_id'];
 
-    $collectionSourceVehicleDispatche = EckEntity::get('Collection_Source_Vehicle_Dispatch', FALSE)
+    $collectionSourceVehicleDispatch = EckEntity::get('Collection_Source_Vehicle_Dispatch', FALSE)
       ->addSelect('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id')
-      ->addWhere('id', '=', $vehicleDispatcheId)
+      ->addWhere('id', '=', $vehicleDispatchId)
       ->execute()->first();
 
-    $collectionCampId = $collectionSourceVehicleDispatche['Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id'];
+    $collectionCampId = $collectionSourceVehicleDispatch['Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id'];
 
     $coordinators = Relationship::get(FALSE)
       ->addWhere('contact_id_b', '=', $goonjFieldId)
@@ -983,7 +983,7 @@ class CollectionCampService extends AutoSubscriber {
     ];
     $result = \CRM_Utils_Mail::send($mailParams);
 
-    $updatemmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)
+    $updateMmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)
       ->addValue('Acknowledgement_For_Logistics.Filled_by', $mmtId)
       ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id', '=', $collectionCampId)
       ->execute();

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -982,7 +982,6 @@ class CollectionCampService extends AutoSubscriber {
       'html' => self::goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId),
         // 'messageTemplateID' => 76, // Uncomment if using a message template
     ];
-    error_log("mailParams: " . print_r($mailParams, TRUE));
     $result = \CRM_Utils_Mail::send($mailParams);
 
     $updatemmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -976,7 +976,7 @@ class CollectionCampService extends AutoSubscriber {
    */
   public static function goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId) {
     $homeUrl = get_home_url();
-    $materialdispatchUrl = $homeUrl . '/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=vehicleDispatch#?intent_id=' . $collectionCampId;
+    $materialdispatchUrl = $homeUrl . '/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=campOutcome#?intent_id=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $mmtId;
 
     $html = "
     <p>Dear $contactName,</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -987,7 +987,7 @@ class CollectionCampService extends AutoSubscriber {
       'html' => self::goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId),
         // 'messageTemplateID' => 76, // Uncomment if using a message template
     ];
-    $result = \CRM_Utils_Mail::send($mailParams);
+    \CRM_Utils_Mail::send($mailParams);
 
     $updateMmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)
       ->addValue('Acknowledgement_For_Logistics.Filled_by', $mmtId)

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -87,6 +87,11 @@ class CollectionCampService extends AutoSubscriber {
       "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fadmin-camp-outcome-form",
     );
 
+    // URL for the material dispatch authorizationtab.
+    $materialAuthorisation = \CRM_Utils_System::url(
+      "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Facknowledgement-for-logistics-data",
+    );
+
     // Add the Logistics tab.
     $tabs['logistics'] = [
       'title' => ts('Logistics'),
@@ -109,6 +114,15 @@ class CollectionCampService extends AutoSubscriber {
     $tabs['campOutcome'] = [
       'title' => ts('Camp Outcome'),
       'link' => $campOutcome,
+      'valid' => 1,
+      'active' => 1,
+      'current' => FALSE,
+    ];
+
+    // Add the material dispatch authorization tab.
+    $tabs['materialAuthorisation'] = [
+      'title' => ts('Material Authorization'),
+      'link' => $materialAuthorisation,
       'valid' => 1,
       'active' => 1,
       'current' => FALSE,

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -972,12 +972,18 @@ class CollectionCampService extends AutoSubscriber {
     $mmtEmail = $email['email'];
     $contactName = $email['contact_id.display_name'];
 
+    $fromEmail = OptionValue::get(FALSE)
+    ->addSelect('label')
+    ->addWhere('option_group_id:name', '=', 'from_email_address')
+    ->addWhere('is_default', '=', TRUE)
+    ->execute()->single();
+
     // Email to material management team member.
     $mailParams = [
       'subject' => 'New Entry For Matrial Dispatch Notification',
-      'from' => 'urban.ops@goonj.org',
+      'from' => $fromEmail['label'],
       'toEmail' => $mmtEmail,
-      'replyTo' => 'urban.ops@goonj.org',
+      'replyTo' => $fromEmail['label'],
       'html' => self::goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId),
         // 'messageTemplateID' => 76, // Uncomment if using a message template
     ];

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -945,7 +945,7 @@ class CollectionCampService extends AutoSubscriber {
     $goonjFieldId = $goonjField['value'];
     $vehicleDispatcheId = $goonjField['entity_id'];
 
-    $collectionSourceVehicleDispatche = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
+    $collectionSourceVehicleDispatche = EckEntity::get('Collection_Source_Vehicle_Dispatch', FALSE)
       ->addSelect('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id')
       ->addWhere('id', '=', $vehicleDispatcheId)
       ->execute()->first();
@@ -960,16 +960,12 @@ class CollectionCampService extends AutoSubscriber {
 
     $mmtId = $coordinators['contact_id_a'];
 
-    $updatemmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)
-      ->addValue('Acknowledgement_For_Logistics.Filled_by', $mmtId)
-      ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id', '=', $collectionCampId)
-      ->execute();
 
     if (empty($mmtId)) {
       return;
     }
 
-    $email = Email::get(TRUE)
+    $email = Email::get(FALSE)
       ->addSelect('email', 'contact_id.display_name')
       ->addWhere('contact_id', '=', $mmtId)
       ->execute()->single();
@@ -988,6 +984,12 @@ class CollectionCampService extends AutoSubscriber {
     ];
     error_log("mailParams: " . print_r($mailParams, TRUE));
     $result = \CRM_Utils_Mail::send($mailParams);
+
+    $updatemmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)
+    ->addValue('Acknowledgement_For_Logistics.Filled_by', $mmtId)
+    ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id', '=', $collectionCampId)
+    ->execute();
+
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -960,6 +960,11 @@ class CollectionCampService extends AutoSubscriber {
 
     $mmtId = $coordinators['contact_id_a'];
 
+    $updatemmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)
+      ->addValue('Acknowledgement_For_Logistics.Filled_by', $mmtId)
+      ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id', '=', $collectionCampId)
+      ->execute();
+
     if (empty($mmtId)) {
       return;
     }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -981,7 +981,7 @@ class CollectionCampService extends AutoSubscriber {
       'html' => self::goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId),
         // 'messageTemplateID' => 76, // Uncomment if using a message template
     ];
-    // error_log("mailParams: " . print_r($mailParams, TRUE));.
+    error_log("mailParams: " . print_r($mailParams, TRUE));
     $result = \CRM_Utils_Mail::send($mailParams);
   }
 
@@ -990,7 +990,7 @@ class CollectionCampService extends AutoSubscriber {
    */
   public static function goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId) {
     $homeUrl = get_home_url();
-    $materialdispatchUrl = $homeUrl . '/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=campOutcome#?intent_id=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $mmtId;
+    $materialdispatchUrl = $homeUrl . '/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=materialAuthorisation#?intent_id=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $mmtId;
 
     $html = "
     <p>Dear $contactName,</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -973,10 +973,10 @@ class CollectionCampService extends AutoSubscriber {
     $contactName = $email['contact_id.display_name'];
 
     $fromEmail = OptionValue::get(FALSE)
-    ->addSelect('label')
-    ->addWhere('option_group_id:name', '=', 'from_email_address')
-    ->addWhere('is_default', '=', TRUE)
-    ->execute()->single();
+      ->addSelect('label')
+      ->addWhere('option_group_id:name', '=', 'from_email_address')
+      ->addWhere('is_default', '=', TRUE)
+      ->execute()->single();
 
     // Email to material management team member.
     $mailParams = [

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -52,7 +52,7 @@ class CollectionCampService extends AutoSubscriber {
       '&hook_civicrm_custom' => [
         ['setOfficeDetails'],
         ['linkInductionWithCollectionCamp'],
-            ['mailNotificationToMMT'],
+        ['mailNotificationToMMT'],
 
       ],
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1001,7 +1001,7 @@ class CollectionCampService extends AutoSubscriber {
    */
   public static function goonjcustom_material_management_email_html($mmtId, $contactName, $collectionCampId) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
-    $materialdispatchUrl = $homeUrl . 'wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=materialAuthorisation#?intent_id=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $mmtId;
+    $materialdispatchUrl = $homeUrl . 'wp-admin/admin.php?page=CiviCRM&q=civicrm%2Feck%2Fentity&reset=1&type=Collection_Camp&id=' . $collectionCampId . '&selectedChild=materialAuthorization#?intent_id=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $mmtId;
 
     $html = "
     <p>Dear $contactName,</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -960,7 +960,6 @@ class CollectionCampService extends AutoSubscriber {
 
     $mmtId = $coordinators['contact_id_a'];
 
-
     if (empty($mmtId)) {
       return;
     }
@@ -985,9 +984,9 @@ class CollectionCampService extends AutoSubscriber {
     $result = \CRM_Utils_Mail::send($mailParams);
 
     $updatemmtId = EckEntity::update('Collection_Source_Vehicle_Dispatch', FALSE)
-    ->addValue('Acknowledgement_For_Logistics.Filled_by', $mmtId)
-    ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id', '=', $collectionCampId)
-    ->execute();
+      ->addValue('Acknowledgement_For_Logistics.Filled_by', $mmtId)
+      ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id', '=', $collectionCampId)
+      ->execute();
 
   }
 


### PR DESCRIPTION
This PR contains the changes where:
1. Add the material dispatch authorization tab
2. Add a material management relationship with goonj office.
3. Send mail to MMT: An email notification will be sent out to the MMT each time a new entry of camp vehicle dispatch form is submitted.
4. The link for this form sent to the MMT of the Goonj Office mentioned in the authorisation step.
5. sending custom email, because we need to send some custom ids to the URL for autofilling the material details