### PR TITLE
Refactor to fetch Contribution Receipt Reminder ID dynamically

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -20,7 +20,7 @@ class MaterialContributionService extends AutoSubscriber {
         ->addWhere('name', '=', 'Material_Contribution_Receipt')
         ->execute()->single();
           
-      return (int) $materialContributionReceiptReminder['id'];
+      return $materialContributionReceiptReminder['id'];
     } catch (\Exception $e) {
       \CRM_Core_Error::debug_log_message('Error fetching Contribution Receipt Reminder ID: ' . $e->getMessage());
       return NULL;

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -10,7 +10,7 @@ use Civi\Core\Service\AutoSubscriber;
  */
 class MaterialContributionService extends AutoSubscriber {
   const ACTIVITY_SOURCE_RECORD_TYPE_ID = 2;
-  
+
   /**
    * Fetch the Material Contribution Receipt Reminder ID.
    */
@@ -50,6 +50,7 @@ class MaterialContributionService extends AutoSubscriber {
     if ($context !== 'singleEmail' || $reminderId !== $contributionReceiptReminderId) {
       return;
     }
+
     // Hack: Retrieve the most recent "Material Contribution" activity for this contact.
     $activities = Activity::get(TRUE)
       ->addSelect('*', 'contact.display_name', 'Material_Contribution.Delivered_By', 'Material_Contribution.Delivered_By_Contact')

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -46,11 +46,10 @@ class MaterialContributionService extends AutoSubscriber {
 
     $reminderId = (int) $params['entity_id'];
     $contributionReceiptReminderId = self::getContributionReceiptReminderId();
-    
+
     if ($context !== 'singleEmail' || $reminderId !== $contributionReceiptReminderId) {
       return;
     }
-
     // Hack: Retrieve the most recent "Material Contribution" activity for this contact.
     $activities = Activity::get(TRUE)
       ->addSelect('*', 'contact.display_name', 'Material_Contribution.Delivered_By', 'Material_Contribution.Delivered_By_Contact')

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -9,10 +9,23 @@ use Civi\Core\Service\AutoSubscriber;
  *
  */
 class MaterialContributionService extends AutoSubscriber {
-  // See: CiviCRM > Administer > Communications > Schedule Reminders.
-  const CONTRIBUTION_RECEIPT_REMINDER_ID = 6;
-
   const ACTIVITY_SOURCE_RECORD_TYPE_ID = 2;
+  
+  /**
+   * Fetch the Material Contribution Receipt Reminder ID.
+   */
+  public static function getContributionReceiptReminderId() {
+    try {
+      $materialContributionReceiptReminder = \Civi\Api4\ActionSchedule::get(TRUE)
+        ->addWhere('name', '=', 'Material_Contribution_Receipt')
+        ->execute()->single();
+          
+      return (int) $materialContributionReceiptReminder['id'];
+    } catch (\Exception $e) {
+      \CRM_Core_Error::debug_log_message('Error fetching Contribution Receipt Reminder ID: ' . $e->getMessage());
+      return NULL;
+    }
+  }
 
   /**
    *
@@ -32,8 +45,9 @@ class MaterialContributionService extends AutoSubscriber {
     }
 
     $reminderId = (int) $params['entity_id'];
-
-    if ($context !== 'singleEmail' || $reminderId !== self::CONTRIBUTION_RECEIPT_REMINDER_ID) {
+    $contributionReceiptReminderId = self::getContributionReceiptReminderId();
+    
+    if ($context !== 'singleEmail' || $reminderId !== $contributionReceiptReminderId) {
       return;
     }
 


### PR DESCRIPTION
This PR refactors the `MaterialContributionService` to replace the hardcoded `CONTRIBUTION_RECEIPT_REMINDER_ID` with a dynamic ID fetched from API.