### PR TITLE
Fix subtype comparison logic to handle type coercion

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -396,7 +396,7 @@ class CollectionCampService extends AutoSubscriber {
       ->execute()->single();
 
     // Subtype for 'Dropping Centre'.
-    if ($subtypeId === $optionValue['value']) {
+    if ($subtypeId == $optionValue['value']) {
       return $objectRef['Dropping_Centre.State'] ?? NULL;
     }
     return $objectRef['Collection_Camp_Intent_Details.State'] ?? NULL;


### PR DESCRIPTION
Changed the comparison in the conditional to use == for type coercion.
This allows the integer subtypeId to correctly match the string optionValue.