### PR TITLE
Update Dropping Center Redirect Url Link  + Add Outcome Tab for dropping Center

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -47,6 +47,10 @@ class DroppingCenterService extends AutoSubscriber {
       "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fdropping-center%2Flogistics-coordination",
     );
 
+    $outcome = \CRM_Utils_System::url(
+      "wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fdropping-center-outcome",
+    );
+
     // Add the Status tab.
     $tabs['status'] = [
       'title' => ts('Status'),
@@ -78,6 +82,15 @@ class DroppingCenterService extends AutoSubscriber {
     $tabs['logistics coordination'] = [
       'title' => ts('Logistics Coordination'),
       'link' => $logisticsCoordinationUrl,
+      'valid' => 1,
+      'active' => 1,
+      'current' => FALSE,
+    ];
+    
+    // Add the outcome tab.
+    $tabs['outcome'] = [
+      'title' => ts('Outcome'),
+      'link' => $outcome,
       'valid' => 1,
       'active' => 1,
       'current' => FALSE,

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -317,7 +317,7 @@ function goonj_handle_user_identification_form() {
 		//   2. Change volunteer status to "Waiting for Induction"
 		if ( ! goonj_is_volunteer_inducted( $found_contacts ) ) {
 			if ($purpose === 'dropping-center') {
-				$redirect_url = home_url('/dropping-centre-waiting-induction/');
+				$redirect_url = home_url('/dropping-center/waiting-induction/');
 			} elseif ($purpose === 'volunteer-registration') {
 				$redirect_url = home_url('/volunteer-registration/waiting-induction/');
 			} else {


### PR DESCRIPTION
1. We have already created this page in the CRM with the current URL `dropping-center/waiting-induction/` To ensure it redirects to the correct destination, the redirect URL has been updated accordingly
2. Add Outcome Tab for dropping center