### PR TITLE
collection camp token scaffolding

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
@@ -4,6 +4,8 @@
  *
  */
 
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
 use Civi\Api4\EckEntity;
 use Civi\Token\AbstractTokenSubscriber;
 use Civi\Token\TokenProcessor;
@@ -13,6 +15,8 @@ use Civi\Token\TokenRow;
  *
  */
 class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
+
+  const ACTIVITY_TARGET_RECORD_TYPE_ID = 3;
 
   public function __construct() {
     parent::__construct('collection_camp', [
@@ -48,7 +52,7 @@ class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
     }
 
     $collectionSource = EckEntity::get('Collection_Camp', FALSE)
-      ->addSelect('title', 'Collection_Camp_Intent_Details.*')
+      ->addSelect('title', 'Collection_Camp_Intent_Details.*', 'Collection_Camp_Core_Details.Contact_Id')
       ->addWhere('id', '=', $row->context['collectionSourceId'])
       ->execute()->single();
 
@@ -65,7 +69,7 @@ class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
         break;
 
       case 'volunteers':
-        $value = 'volunteers of collection camp';
+        $value = $this->formatVolunteers($collectionSource);
         break;
 
       case 'goonj_team':
@@ -107,6 +111,35 @@ class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
     $endTime = $end->format('h:i A');
 
     return "$startTime to $endTime";
+  }
+
+  /**
+   *
+   */
+  private function formatVolunteers($collectionSource) {
+    $initiatorId = $collectionSource['Collection_Camp_Core_Details.Contact_Id'];
+    $volunteeringActivities = Activity::get(FALSE)
+      ->addSelect('activity_contact.contact_id')
+      ->addJoin('ActivityContact AS activity_contact', 'LEFT')
+      ->addWhere('activity_type_id:name', '=', 'Volunteering')
+      ->addWhere('Volunteering_Activity.Collection_Camp', '=', $collectionSource['id'])
+      ->addWhere('activity_contact.record_type_id', '=', self::ACTIVITY_TARGET_RECORD_TYPE_ID)
+      ->execute();
+
+    $volunteerIds = array_merge([$initiatorId], $volunteeringActivities->column('activity_contact.contact_id'));
+
+    $volunteers = Contact::get(FALSE)
+      ->addSelect('phone.phone', 'display_name')
+      ->addJoin('Phone AS phone', 'LEFT')
+      ->addWhere('phone.is_primary', '=', FALSE)
+      ->addWhere('id', 'IN', $volunteerIds)
+      ->execute();
+
+    $volunteersWithPhone = array_map(
+        fn ($volunteer) => sprintf('%1$s (%2$s)', $volunteer['display_name'], $volunteer['phone.phone']), $volunteers->jsonSerialize()
+    );
+
+    return join(',', $volunteersWithPhone);
   }
 
 }

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
@@ -4,6 +4,7 @@
  *
  */
 
+use Civi\Api4\EckEntity;
 use Civi\Token\AbstractTokenSubscriber;
 use Civi\Token\TokenProcessor;
 use Civi\Token\TokenRow;
@@ -57,11 +58,10 @@ class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
         break;
 
       case 'date':
-        $value = 'date of collection camp';
-        break;
-
       case 'time':
-        $value = 'time of collection camp';
+        $start = new DateTime($collectionSource['Collection_Camp_Intent_Details.Start_Date']);
+        $end = new DateTime($collectionSource['Collection_Camp_Intent_Details.End_Date']);
+        $value = $field === 'date' ? $this->formatDate($start, $end) : $this->formatTime($start, $end);
         break;
 
       case 'volunteers':
@@ -81,6 +81,32 @@ class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
     $row->format('text/plain')->tokens($entity, $field, $value);
     return;
 
+  }
+
+  /**
+   *
+   */
+  private function formatDate($start, $end) {
+
+    $startFormatted = $start->format('M jS, Y (l)');
+    $endFormatted = $end->format('M jS, Y (l)');
+
+    if ($start->format('Y-m-d') === $end->format('Y-m-d')) {
+      return $startFormatted;
+    }
+
+    return "$startFormatted - $endFormatted";
+  }
+
+  /**
+   *
+   */
+  private function formatTime($start, $end) {
+
+    $startTime = $start->format('h:i A');
+    $endTime = $end->format('h:i A');
+
+    return "$startTime to $endTime";
   }
 
 }

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ *
+ */
+
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\TokenRow;
+
+/**
+ *
+ */
+class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
+
+  public function __construct() {
+    parent::__construct('collection_camp', [
+      'venue' => \CRM_Goonjcustom_ExtensionUtil::ts('Venue'),
+      'date' => \CRM_Goonjcustom_ExtensionUtil::ts('Date'),
+      'time' => \CRM_Goonjcustom_ExtensionUtil::ts('Time'),
+      'volunteers' => \CRM_Goonjcustom_ExtensionUtil::ts('Volunteers'),
+      'goonj_team' => \CRM_Goonjcustom_ExtensionUtil::ts('Goonj Team'),
+    ]);
+  }
+
+  // Public function checkActive(\Civi\Token\TokenProcessor $processor) {
+  //     return !empty($processor->context['campagnodonTransactionId'])
+  //       || !empty($processor->context['campagnodonTransaction'])
+  //       || in_array('campagnodonTransactionId', $processor->context['schema'])
+  //       || in_array('campagnodonTransaction', $processor->context['schema']);.
+
+  /**
+   * }.
+   */
+  public function evaluateToken(
+    TokenRow $row,
+    $entity,
+    $field,
+    $prefetch = NULL,
+  ) {
+
+    switch ($field) {
+      case 'venue':
+        $value = 'Venue of the camp';
+        break;
+
+      case 'date':
+        $value = 'date of collection camp';
+        break;
+
+      case 'time':
+        $value = 'time of collection camp';
+        break;
+
+      case 'volunteers':
+        $value = 'volunteers of collection camp';
+        break;
+
+      case 'goonj_team':
+        $value = 'goonj team members of collection camp';
+        break;
+
+      default:
+        $value = '';
+
+    }
+
+    // If (empty($row->context['campagnodonTransaction'])) {
+    //   Civi::log()->debug(__CLASS__.'::'.__METHOD__ . ' There is no campagnodonTransaction in the context, you cant use campagnodonTransaction tokens.');
+    //   $row->format('text/plain')->tokens($entity, $field, '');
+    //   return;
+    // }.
+    // If ($field === 'payment_url') {
+    //   $url = $row->context['campagnodonTransaction']['payment_url'] ?? '';
+    //   // For text mode, we have to replace &amp; by & (see for example CRM_Utils_Token::getActionTokenReplacement)
+    //   $row->format('text/plain')->tokens($entity, $field, str_replace('&amp;', '&', $url));
+    //   $row->format('text/html')->tokens($entity, $field, $url);
+    //   return;
+    // }.
+    // $value = '';
+    // if (in_array($field, ['email', 'first_name', 'last_name'])) {
+    //   // For these fields, it can have been cleaned from the CampagnodonTransaction.
+    //   // In such cache, we must search on the contact data.
+    //   $value = $row->context['campagnodonTransaction'][$field];
+    //   if (empty($value) && !empty($row->context['contact'])) {
+    //     $value = $row->context['contact'][$field];
+    //   }
+    //   if (empty($value) && !empty($row->context['contactId'])) {
+    //     $contact = \Civi\Api4\Contact::get()
+    //       ->setCheckPermissions(false)
+    //       ->addSelect('*')
+    //       ->addWhere('id', '=', $row->context['contactId'])
+    //       ->execute()
+    //       ->first();
+    //     if ($contact) {
+    //       $value = $contact[$field];
+    //     }
+    //   }
+    // }.
+    $row->format('text/plain')->tokens($entity, $field, $value ?? '');
+    return;
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -69,7 +69,7 @@ class DroppingCenterService extends AutoSubscriber {
       'current' => FALSE,
     ];
 
-     // Add the Donation Box/Register Tracking tab.
+    // Add the Donation Box/Register Tracking tab.
     $tabs['donation tracking'] = [
       'title' => ts('Donation Tracking'),
       'link' => $donationTrackingUrl,
@@ -86,7 +86,7 @@ class DroppingCenterService extends AutoSubscriber {
       'active' => 1,
       'current' => FALSE,
     ];
-    
+
     // Add the outcome tab.
     $tabs['outcome'] = [
       'title' => ts('Outcome'),

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 function goonjcustom_civicrm_config(&$config): void {
   _goonjcustom_civix_civicrm_config($config);
+
+  \Civi::dispatcher()->addSubscriber(new CRM_Goonjcustom_Token_CollectionCamp());
 }
 
 /**


### PR DESCRIPTION
This PR covers that following

1. It introduces 5 new tokens for collection camp:
   1. `venue`
   2. `date`
   3. `time`
   4. `volunteers`
   5. `goonj_team`

2. It then use the message template linked with the collection camp to generate the poster and save it in the poster file field