### PR TITLE
add collection share links

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
@@ -41,6 +41,7 @@ class CRM_Goonjcustom_Form_CollectionCampLinks extends CRM_Core_Form {
     $this->_contactId = CRM_Utils_Request::retrieve('gcid', 'Positive', $this);
     $this->_processingCenterId = CRM_Utils_Request::retrieve('puid', 'Positive', $this);
 
+    $this->setTitle('Collection Camp Links');
     parent::preProcess();
   }
 

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * @file
+ * Form controller class.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
+ */
+
+/**
+ *
+ */
+class CRM_Goonjcustom_Form_CollectionCampLinks extends CRM_Core_Form {
+
+  /**
+   * Collection Camp Id.
+   *
+   * @var int
+   */
+  public $_collectionCampId;
+
+  /**
+   * Goonj coordinator contact Id.
+   *
+   * @var int
+   */
+  public $_contactId;
+
+  /**
+   * Goonj processing unit center id.
+   *
+   * @var int
+   */
+  public $_processingCenterId;
+
+  /**
+   * Preprocess .
+   */
+  public function preProcess() {
+    $this->_collectionCampId = CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
+    $this->_contactId = CRM_Utils_Request::retrieve('gcid', 'Positive', $this);
+    $this->_processingCenterId = CRM_Utils_Request::retrieve('puid', 'Positive', $this);
+
+    parent::preProcess();
+  }
+
+  /**
+   * Set default values for the form.
+   *
+   * For edit/view mode the default values are retrieved from the database.
+   *
+   * @return array
+   */
+  public function setDefaultValues() {
+    $defaults = [];
+
+    if (!empty($this->_contactId)) {
+      $defaults['contact_id'] = $this->_contactId;
+      $this->generateLinks($this->_contactId);
+    }
+
+    return $defaults;
+  }
+
+  /**
+   * Function to generate collection camp related links.
+   *
+   * @param int $contactId
+   *   Contact Id.
+   *
+   * @return void
+   */
+  public function generateLinks($contactId):void {
+
+    Civi::log()->debug('Contact Id: ' . $contactId);
+    // Generate collection camp links.
+    $links = [
+        [
+          'label' => 'Vehicle Dispatch',
+          'url' => self::createUrl('civicrm/camp-vehicle-dispatch-form', ["Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id" => $this->_collectionCampId, "Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent" => $this->_processingCenterId], $contactId),
+        ],
+        [
+          'label' => 'Camp Outcome',
+          'url' => self::createUrl('civicrm/camp-outcome-form', ["Eck_Collection_Camp1" => $this->_collectionCampId], $contactId),
+        ],
+    ];
+
+    $this->assign('collectionCampLinks', $links);
+  }
+
+  /**
+   * Generate an authenticated URL for viewing this form.
+   *
+   * @param string $path
+   * @param array $params
+   * @param int $contactId
+   *
+   * @return string
+   *
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public static function createUrl($path, $params, $contactId): string {
+    $expires = \CRM_Utils_Time::time() +
+      (\Civi::settings()->get('checksum_timeout') * 24 * 60 * 60);
+
+    /** @var \Civi\Crypto\CryptoJwt $jwt */
+    $jwt = \Civi::service('crypto.jwt');
+
+    $bearerToken = "Bearer " . $jwt->encode([
+      'exp' => $expires,
+      'sub' => "cid:" . $contactId,
+      'scope' => 'authx',
+    ] + $params);
+
+    $url = \CRM_Utils_System::url($path,
+      ['_authx' => $bearerToken, '_authxSes' => 1],
+      TRUE,
+      NULL,
+      FALSE,
+      TRUE
+    );
+
+    return $url;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function buildQuickForm(): void {
+
+    // Add form elements.
+    $this->addEntityRef('contact_id', ts('Contact to send'), [], TRUE);
+
+    $this->addButtons([
+    [
+      'type' => 'submit',
+      'name' => \CRM_Goonjcustom_ExtensionUtil::ts('Generate Links'),
+      'isDefault' => TRUE,
+    ],
+    ]);
+
+    // Export form elements.
+    $this->assign('elementNames', $this->getRenderableElementNames());
+    parent::buildQuickForm();
+  }
+
+  /**
+   *
+   */
+  public function postProcess(): void {
+    $values = $this->exportValues();
+
+    if (!empty($values['contact_id'])) {
+      $this->generateLinks($values['contact_id']);
+    }
+
+    parent::postProcess();
+  }
+
+  /**
+   * Get the fields/elements defined in this form.
+   *
+   * @return array (string)
+   */
+  public function getRenderableElementNames(): array {
+    // The _elements list includes some items which should not be
+    // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
+    // items don't have labels.  We'll identify renderable by filtering on
+    // the 'label'.
+    $elementNames = [];
+    foreach ($this->_elements as $element) {
+      /** @var HTML_QuickForm_Element $element */
+      $label = $element->getLabel();
+      if (!empty($label)) {
+        $elementNames[] = $element->getName();
+      }
+    }
+    return $elementNames;
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
@@ -77,11 +77,11 @@ class CRM_Goonjcustom_Form_CollectionCampLinks extends CRM_Core_Form {
     $links = [
         [
           'label' => 'Vehicle Dispatch',
-          'url' => self::createUrl('civicrm/camp-vehicle-dispatch-form', ["Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id" => $this->_collectionCampId, "Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent" => $this->_processingCenterId], $contactId),
+          'url' => self::createUrl('civicrm/camp-vehicle-dispatch-form', "Camp_Vehicle_Dispatch.Collection_Camp_Intent_Id={$this->_collectionCampId}&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent={$this->_processingCenterId}", $contactId),
         ],
         [
           'label' => 'Camp Outcome',
-          'url' => self::createUrl('civicrm/camp-outcome-form', ["Eck_Collection_Camp1" => $this->_collectionCampId], $contactId),
+          'url' => self::createUrl('civicrm/camp-outcome-form', "Eck_Collection_Camp1={$this->_collectionCampId}", $contactId),
         ],
     ];
 
@@ -92,7 +92,7 @@ class CRM_Goonjcustom_Form_CollectionCampLinks extends CRM_Core_Form {
    * Generate an authenticated URL for viewing this form.
    *
    * @param string $path
-   * @param array $params
+   * @param string $params
    * @param int $contactId
    *
    * @return string
@@ -110,12 +110,10 @@ class CRM_Goonjcustom_Form_CollectionCampLinks extends CRM_Core_Form {
       'exp' => $expires,
       'sub' => "cid:" . $contactId,
       'scope' => 'authx',
-    ] + $params);
+    ]);
 
-    $url = \CRM_Utils_System::url($path,
-      ['_authx' => $bearerToken, '_authxSes' => 1],
-      TRUE,
-      NULL,
+    $params = "{$params}&_authx={$bearerToken}&_authxSes=1";
+    $url = \CRM_Utils_System::url($path, $params, TRUE, NULL,
       FALSE,
       TRUE
     );

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Form/CollectionCampLinks.php
@@ -113,10 +113,9 @@ class CRM_Goonjcustom_Form_CollectionCampLinks extends CRM_Core_Form {
     ]);
 
     $params = "{$params}&_authx={$bearerToken}&_authxSes=1";
-    $url = \CRM_Utils_System::url($path, $params, TRUE, NULL,
-      FALSE,
-      TRUE
-    );
+    // $url = \CRM_Utils_System::url($path, $params, TRUE, NULL, FALSE, TRUE);
+    $config = CRM_Core_Config::singleton();
+    $url = $config->userFrameworkBaseURL . $path . '#?' . $params;
 
     return $url;
   }

--- a/wp-content/civi-extensions/goonjcustom/README.md
+++ b/wp-content/civi-extensions/goonjcustom/README.md
@@ -1,12 +1,7 @@
 # goonjcustom
-(*FIXME: In one or two paragraphs, describe what the extension does and why one would download it. *)
+
+This extension handles customizations specific to Gooj
 
 This is an [extension for CiviCRM](https://docs.civicrm.org/sysadmin/en/latest/customize/extensions/), licensed under [AGPL-3.0](LICENSE.txt).
 
-## Getting Started
-
-(* FIXME: Where would a new user navigate to get started? What changes would they see? *)
-
-## Known Issues
-
-(* FIXME *)
+## TODOS

--- a/wp-content/civi-extensions/goonjcustom/templates/CRM/Goonjcustom/Form/CollectionCampLinks.tpl
+++ b/wp-content/civi-extensions/goonjcustom/templates/CRM/Goonjcustom/Form/CollectionCampLinks.tpl
@@ -1,0 +1,21 @@
+{foreach from=$elementNames item=elementName}
+  <div class="crm-section">
+    <div class="label">{$form.$elementName.label}</div>
+    <div class="content">{$form.$elementName.html}</div>
+    <div class="clear"></div>
+  </div>
+{/foreach}
+
+{if $collectionCampLinks}
+  {foreach from=$collectionCampLinks item=campLink}
+    <div class="crm-section">
+      <div class="label">{$campLink.label}</div>
+      <div class="content"><a href="{$campLink.url}">{$campLink.url}</a></div>
+      <div class="clear"></div>
+    </div>
+  {/foreach}
+{/if}
+
+<div class="crm-submit-buttons">
+  {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/wp-content/civi-extensions/goonjcustom/xml/Menu/goonjcustom.xml
+++ b/wp-content/civi-extensions/goonjcustom/xml/Menu/goonjcustom.xml
@@ -6,4 +6,10 @@
     <title>Manage_Event_Qr</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/collectioncamp/links</path>
+    <page_callback>CRM_Goonjcustom_Form_CollectionCampLinks</page_callback>
+    <title>CollectionCampLinks</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This implements the collection camp share links feature.
* Allows to share the link for Goonj Contact
* Allows to generate links to any other contact

We can update the collection camp listing SK and add below link:
`civicrm/collectioncamp/links?ccid=[id]&gcid=[Collection_Camp_Intent_Details.Coordinating_Urban_POC]&puid=[Collection_Camp_Intent_Details.Goonj_Office]`

<img width="1293" alt="Screenshot 2024-09-28 at 22 48 32" src="https://github.com/user-attachments/assets/09bc5381-6cd9-42e6-8193-17996dcfad35">

<img width="212" alt="Screenshot 2024-09-28 at 22 43 36" src="https://github.com/user-attachments/assets/845a914c-5d09-4160-8897-5f02ebc0910f">

<img width="1642" alt="Screenshot 2024-09-28 at 22 50 16" src="https://github.com/user-attachments/assets/f4bcd837-692f-45c2-896a-681ca5dcb06e">
