### PR TITLE
redirection to correct flow after new individual creation

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -350,7 +350,7 @@ class InductionService extends AutoSubscriber {
       return FALSE;
     }
 
-    $newSubtypes = $params['contact_sub_type'];
+    $newSubtypes = $params['contact_sub_type'] ?? [];
 
     // Check if "Volunteer" is present in the contact_sub_type array.
     if (!in_array('Volunteer', $newSubtypes)) {

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -429,12 +429,12 @@ function goonj_collection_camp_past_data() {
 	return ob_get_clean();
 }
 
-add_action( 'template_redirect', 'goonj_redirect_after_individual_cration' );
-function goonj_redirect_after_individual_cration() {
+add_action( 'template_redirect', 'goonj_redirect_after_individual_creation' );
+function goonj_redirect_after_individual_creation() {
 	if (
-		! isset( $_REQUEST['goonjAction'] ) ||
-		$_REQUEST['goonjAction'] !== 'individualCreated' ||
-		! isset( $_REQUEST['individualId'] )
+		! isset( $_GET['goonjAction'] ) ||
+		$_GET['goonjAction'] !== 'individualCreated' ||
+		! isset( $_GET['individualId'] )
 	) {
 		return;
 	}
@@ -445,7 +445,7 @@ function goonj_redirect_after_individual_cration() {
 		->addJoin( 'Phone AS phone', 'LEFT' )
 		->addWhere( 'email.is_primary', '=', true )
 		->addWhere( 'phone.is_primary', '=', true )
-		->addWhere( 'id', '=', absint( $_REQUEST['individualId'] ) )
+		->addWhere( 'id', '=', absint( $_GET['individualId'] ) )
 		->setLimit( 1 )
 		->execute()->single();
 
@@ -455,6 +455,8 @@ function goonj_redirect_after_individual_cration() {
 	if ( ! $source ) {
 		return;
 	}
+
+	$redirectPath = '';
 
 	switch ( $creationFlow ) {
 		case 'material-contribution':

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -198,10 +198,11 @@ function goonj_handle_user_identification_form() {
 				// Redirect to individual registration with option for volunteering.
 				case 'material-contribution':
 					$individual_volunteer_registration_form_path = sprintf(
-						'/individual-registration-with-volunteer-option/#?email=%s&phone=%s&source=%s',
+						'/individual-registration-with-volunteer-option/#?email=%s&phone=%s&source=%s&Individual_fields.Creation_Flow=%s',
 						$email,
 						$phone,
 						$source,
+						'material-contribution',
 					);
 					$redirect_url = $individual_volunteer_registration_form_path;
 					break;

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -427,3 +427,60 @@ function goonj_collection_camp_past_data() {
 	get_template_part( 'templates/collection-camp-data' );
 	return ob_get_clean();
 }
+
+add_action( 'template_redirect', 'goonj_redirect_after_individual_cration' );
+function goonj_redirect_after_individual_cration() {
+	if (
+		! isset( $_REQUEST['goonjAction'] ) ||
+		$_REQUEST['goonjAction'] !== 'individualCreated' ||
+		! isset( $_REQUEST['individualId'] )
+	) {
+		return;
+	}
+
+	$individual = \Civi\Api4\Contact::get( false )
+		->addSelect( 'source', 'Individual_fields.Creation_Flow', 'email.email', 'phone.phone' )
+		->addJoin( 'Email AS email', 'LEFT' )
+		->addJoin( 'Phone AS phone', 'LEFT' )
+		->addWhere( 'email.is_primary', '=', true )
+		->addWhere( 'phone.is_primary', '=', true )
+		->addWhere( 'id', '=', absint( $_REQUEST['individualId'] ) )
+		->setLimit( 1 )
+		->execute()->single();
+
+	$creationFlow = $individual['Individual_fields.Creation_Flow'];
+	$source = $individual['source'];
+
+	if ( ! $source ) {
+		return;
+	}
+
+	switch ( $creationFlow ) {
+		case 'material-contribution':
+			// If the individual was created while in the process of material contribution,
+			// then we need to find out from WHERE was she trying to contribute.
+
+			// First, we check if the source of Individual is Colllection Camp (or Dropping Center).
+			$collectionCamp = \Civi\Api4\EckEntity::get( 'Collection_Camp', false )
+				->addWhere( 'title', '=', $source )
+				->setLimit( 1 )
+				->execute()->first();
+
+			if ( ! empty( $collectionCamp['id'] ) ) {
+				$redirectPath = sprintf(
+					'/material-contribution/#?email=%s&phone=%s&Material_Contribution.Collection_Camp=%s&source_contact_id=%s',
+					$individual['email.email'],
+					$individual['phone.phone'],
+					$collectionCamp['id'],
+					$individual['id']
+				);
+				break;
+			}
+	}
+
+	if ( empty( $redirectPath ) ) {
+		return;
+	}
+
+	wp_safe_redirect( $redirectPath );
+}


### PR DESCRIPTION
- This PR adds a template redirect when a new individual is created.
- After that it reads the `Creation_Flow` for the individual and the `source` to decide what to do: keep it on the same page redirect to something new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new action hook for seamless redirection after creating an individual, enhancing user experience based on specific conditions.
  
- **Bug Fixes**
	- Maintained existing functionalities related to user identification and login handling without issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->