### PR TITLE
Add shortcode for wish to volunteer field

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
@@ -149,14 +149,14 @@ class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
     $volunteerIds = array_merge([$initiatorId], $volunteeringActivities->column('activity_contact.contact_id'));
 
     $volunteers = Contact::get(FALSE)
-      ->addSelect('phone.phone', 'first_name')
+      ->addSelect('phone.phone', 'display_name')
       ->addJoin('Phone AS phone', 'LEFT')
       ->addWhere('phone.is_primary', '=', TRUE)
       ->addWhere('id', 'IN', $volunteerIds)
       ->execute();
 
     $volunteersWithPhone = array_map(
-        fn ($volunteer) => sprintf('%1$s (%2$s)', $volunteer['first_name'], $volunteer['phone.phone']), $volunteers->jsonSerialize()
+        fn ($volunteer) => sprintf('%1$s (%2$s)', $volunteer['display_name'], $volunteer['phone.phone']), $volunteers->jsonSerialize()
     );
 
     return join(',', $volunteersWithPhone);

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -34,12 +34,12 @@ class CollectionBaseService extends AutoSubscriber {
       '&hook_civicrm_tabset' => 'collectionBaseTabset',
       '&hook_civicrm_selectWhereClause' => 'aclCollectionCamp',
       '&hook_civicrm_pre' => [
-        ['handleAuthorizationEmails'],
+        // ['handleAuthorizationEmails'],
         ['checkIfPosterNeedsToBeGenerated'],
       ],
       '&hook_civicrm_post' => [
         ['maybeGeneratePoster', 20],
-        ['handleAuthorizationEmailsPost', 10],
+        // ['handleAuthorizationEmailsPost', 10],
       ],
     ];
   }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -74,12 +74,12 @@ class CollectionCampService extends AutoSubscriber {
     }
 
     $tabConfigs = [
-      'activities' => [
-        'title' => ts('Activities'),
-        'module' => 'afsearchCollectionCampActivity',
-        'directive' => 'afsearch-collection-camp-activity',
-        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      ],
+      // 'activities' => [
+      //   'title' => ts('Activities'),
+      //   'module' => 'afsearchCollectionCampActivity',
+      //   'directive' => 'afsearch-collection-camp-activity',
+      //   'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      // ],
       'logistics' => [
         'title' => ts('Logistics'),
         'module' => 'afformLogisticsCoordination',

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -115,6 +115,7 @@ class MaterialContributionService extends AutoSubscriber {
     $html = self::generateContributionReceiptHtml($contribution, $email, $phone, $locationAreaOfCamp);
     $fileName = 'material_contribution_' . $contribution['id'] . '.pdf';
     $params['attachments'][] = \CRM_Utils_Mail::appendPDF($fileName, $html);
+    $params['cc'] = 'crm@goonj.org';
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -4,6 +4,8 @@
  * @file
  */
 
+use Civi\Api4\Job;
+
 /**
  * Goonjcustom.CollectionCampCron API specification (optional)
  * This is used for documentation and validation.
@@ -13,7 +15,7 @@
  *
  * @return void
  */
-function _civicrm_api3_goonjcustom_update_scheduled_cron_spec(&$spec) {
+function _civicrm_api3_goonjcustom_update_scheduled_time_cron_spec(&$spec) {
   // There are no parameters for the Goonjcustom cron.
 }
 
@@ -29,14 +31,44 @@ function _civicrm_api3_goonjcustom_update_scheduled_cron_spec(&$spec) {
  *
  * @throws \CRM_Core_Exception
  */
-function civicrm_api3_goonjcustom_update_scheduled_cron($params) {
+function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
   $returnValues = [];
   try {
-    
+    $currentDate = new DateTime();
+    $formattedToday = $currentDate->format('Y-m-d H:i:s');
+    $todayDate = $currentDate->format('Y-m-d');
+
+    // Fetch the scheduled run date.
+    $jobs = Job::get(TRUE)
+      ->addSelect('scheduled_run_date')
+      ->addWhere('api_action', '=', 'collection_camp_cron')
+      ->execute()->single();
+
+    $scheduledRunDate = $jobs['scheduled_run_date'];
+    // Convert it to a DateTime object.
+    $scheduledDateTime = new DateTime($scheduledRunDate);
+    $scheduledDate = $scheduledDateTime->format('Y-m-d');
+
+    if ($todayDate == $scheduledDate) {
+      error_log("Hello");
+      return;
+    }
+
+    if ($formattedToday > $scheduledRunDate) {
+      $nextScheduledDate = new DateTime();
+      // Set time to 10:00 AM.
+      $nextScheduledDate->setTime(10, 0, 0);
+
+      $results = Job::update(TRUE)
+        ->addValue('scheduled_run_date', $nextScheduledDate->format('Y-m-d H:i:s'))
+        ->addWhere('api_action', '=', 'collection_camp_cron')
+        ->execute();
+    }
+
   }
   catch (Exception $e) {
-    \Civi::log()->info("Error is there" . $e->getMessage());
+    \Civi::log()->info("Error is there: " . $e->getMessage());
   }
 
-  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'update_scheduled_cron');
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'update_scheduled_time_cron');
 }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -35,7 +35,6 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
   $returnValues = [];
   try {
     $currentDate = new DateTime();
-    $formattedToday = $currentDate->format('Y-m-d H:i:s');
     // Set time to 10:00 AM.
     $currentDate->setTime(10, 0, 0);
     $todayDateTimeForLogistics = $currentDate->format('Y-m-d H:i:s');
@@ -60,24 +59,18 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
 
     $volunteerScheduledRunDate = $feedbackJob['scheduled_run_date'];
 
-    if ($formattedToday > $logisticScheduledRunDate && $logisticScheduledRunDate != $todayDateTimeForLogistics) {
-      $nextScheduledDate = new DateTime();
-      // Set time to 10:00 AM.
-      $nextScheduledDate->setTime(10, 0, 0);
-
+    // Update the scheduled run time for logistics mail
+    if ($logisticScheduledRunDate != $todayDateTimeForLogistics) {
       $results = Job::update(TRUE)
-        ->addValue('scheduled_run_date', $nextScheduledDate->format('Y-m-d H:i:s'))
+        ->addValue('scheduled_run_date', $todayDateTimeForLogistics)
         ->addWhere('api_action', '=', 'collection_camp_cron')
         ->execute();
     }
 
-    if ($formattedToday > $volunteerScheduledRunDate && $volunteerScheduledRunDate != $todayDateTimeForFeedback) {
-      $nextScheduledDate = new DateTime();
-      // Set time to 10:00 AM.
-      $nextScheduledDate->setTime(14, 0, 0);
-
+    // Update the scheduled run time for volunteer feedback mail
+    if ($volunteerScheduledRunDate != $todayDateTimeForFeedback) {
       $results = Job::update(TRUE)
-        ->addValue('scheduled_run_date', $nextScheduledDate->format('Y-m-d H:i:s'))
+        ->addValue('scheduled_run_date', $todayDateTimeForFeedback)
         ->addWhere('api_action', '=', 'volunteer_feedback_collection_camp_cron')
         ->execute();
     }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -68,7 +68,7 @@ function updateJobScheduledTime($apiAction, $scheduledRunDate) {
   $scheduledRunDateFromDb = $job['scheduled_run_date'];
 
   // Update the scheduled run time if it differs from the current value.
-  if ($scheduledRunDateFromDb != $scheduledRunDate) {
+  if ($scheduledRunDateFromDb !== $scheduledRunDate) {
     Job::update(TRUE)
       ->addValue('scheduled_run_date', $scheduledRunDate)
       ->addWhere('api_action', '=', $apiAction)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ * Goonjcustom.CollectionCampCron API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_update_scheduled_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.CollectionCampCron API.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_update_scheduled_cron($params) {
+  $returnValues = [];
+  try {
+    
+  }
+  catch (Exception $e) {
+    \Civi::log()->info("Error is there" . $e->getMessage());
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'update_scheduled_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -84,7 +84,10 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
 
   }
   catch (Exception $e) {
-    \Civi::log()->info("Error is there: " . $e->getMessage());
+    \Civi::log()->error('Error in Goonjcustom.UpdateScheduledTimeCron job: {error}', [
+      'error' => $e->getMessage(),
+      'trace' => $e->getTraceAsString(),
+    ]);
   }
 
   return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'update_scheduled_time_cron');

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -36,7 +36,6 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
   try {
     $currentDate = new DateTime();
     $formattedToday = $currentDate->format('Y-m-d H:i:s');
-    $todayDate = $currentDate->format('Y-m-d');
 
     // Fetch the scheduled run date.
     $jobs = Job::get(TRUE)
@@ -47,11 +46,6 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
     $scheduledRunDate = $jobs['scheduled_run_date'];
     // Convert it to a DateTime object.
     $scheduledDateTime = new DateTime($scheduledRunDate);
-    $scheduledDate = $scheduledDateTime->format('Y-m-d');
-
-    if ($todayDate == $scheduledDate) {
-      return;
-    }
 
     if ($formattedToday > $scheduledRunDate) {
       $nextScheduledDate = new DateTime();

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -50,7 +50,6 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
     $scheduledDate = $scheduledDateTime->format('Y-m-d');
 
     if ($todayDate == $scheduledDate) {
-      error_log("Hello");
       return;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -36,6 +36,8 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
   try {
     $currentDate = new DateTime();
     $formattedToday = $currentDate->format('Y-m-d H:i:s');
+    $currentDate->setTime(10, 0, 0);
+    $todayDateTime = $currentDate->format('Y-m-d H:i:s');
 
     // Fetch the scheduled run date.
     $jobs = Job::get(TRUE)
@@ -44,8 +46,11 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
       ->execute()->single();
 
     $scheduledRunDate = $jobs['scheduled_run_date'];
-    // Convert it to a DateTime object.
-    $scheduledDateTime = new DateTime($scheduledRunDate);
+
+    if ($scheduledRunDate == $todayDateTime) {
+      error_log("Hello");
+      return;
+    }
 
     if ($formattedToday > $scheduledRunDate) {
       $nextScheduledDate = new DateTime();

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -59,7 +59,7 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
 
     $volunteerScheduledRunDate = $feedbackJob['scheduled_run_date'];
 
-    // Update the scheduled run time for logistics mail
+    // Update the scheduled run time for logistics mail.
     if ($logisticScheduledRunDate != $todayDateTimeForLogistics) {
       $results = Job::update(TRUE)
         ->addValue('scheduled_run_date', $todayDateTimeForLogistics)
@@ -67,7 +67,7 @@ function civicrm_api3_goonjcustom_update_scheduled_time_cron($params) {
         ->execute();
     }
 
-    // Update the scheduled run time for volunteer feedback mail
+    // Update the scheduled run time for volunteer feedback mail.
     if ($volunteerScheduledRunDate != $todayDateTimeForFeedback) {
       $results = Job::update(TRUE)
         ->addValue('scheduled_run_date', $todayDateTimeForFeedback)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateScheduledTimeCron.php
@@ -7,7 +7,7 @@
 use Civi\Api4\Job;
 
 /**
- * Goonjcustom.CollectionCampCron API specification (optional)
+ * Goonjcustom.UpdateScheduledTimeCron API specification (optional)
  * This is used for documentation and validation.
  *
  * @param array $spec
@@ -20,7 +20,7 @@ function _civicrm_api3_goonjcustom_update_scheduled_time_cron_spec(&$spec) {
 }
 
 /**
- * Goonjcustom.CollectionCampCron API.
+ * Goonjcustom.UpdateScheduledTimeCron API.
  *
  * @param array $params
  *

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -452,10 +452,10 @@ function render_volunteer_button() {
 		return;
 	}
 	// Create the base URL for the volunteer form
-	$base_url = home_url('/material-contribution/volunteer-signup/');
+	$baseUrl = home_url('/material-contribution/volunteer-signup/');
 
-	$button_url = esc_url(
-		$base_url . '#?' . http_build_query(array(
+	$buttonUrl = esc_url(
+		$baseUrl . '#?' . http_build_query(array(
 			'Individual1' => $individualId,
 			'message' => 'individual-user'
 		))
@@ -465,7 +465,7 @@ function render_volunteer_button() {
 	return '
 		<div style="display: flex; justify-content: center; align-items: center; border-style:none; border-width:0px; border-radius:5px;">
 			<a class="wp-block-button__link has-white-color has-vivid-red-background-color has-text-color has-background has-link-color wp-element-button" 
-			   href="' . $button_url . '" 
+			   href="' . $buttonUrl . '" 
 			   style="border-style:none;border-width:0px;border-radius:5px">
 			   Join Us as a Volunteer (If not a Volunteer)
 			</a>

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -423,7 +423,7 @@ add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
 
 function render_volunteer_button() {
 
-	// Get the individual ID from the URL parameters
+	// Get the activity ID from the URL parameters
 	$activityId = isset($_GET['activityId']) ? sanitize_text_field($_GET['activityId']) : '';
 
 	$activities = \Civi\Api4\Activity::get(FALSE)
@@ -436,8 +436,17 @@ function render_volunteer_button() {
 		return;
 	}
 	$individualId = $activities['source_contact_id'];
-	\Civi::log()->info('activityId',['activityId'=>$individualId]);
 
+	$contacts = \Civi\Api4\Contact::get(FALSE)
+	->addSelect('contact_sub_type')
+	->addWhere('id', '=', $individualId)
+	->execute();
+
+	$contactSubTypes = $contacts[0]['contact_sub_type'];
+
+    if (in_array('Volunteer', $contactSubTypes)) {
+        return; // Exit or return early if the contact is a volunteer
+    }
 	// Create the base URL for the volunteer form
 	$base_url = home_url('/volunteer-form/#');
 

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -421,9 +421,22 @@ function goonj_custom_message_placeholder() {
 }
 add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
 
-function dynamic_button_shortcode() {
+function render_volunteer_button() {
+
 	// Get the individual ID from the URL parameters
-	$individualId = isset($_GET['individualId']) ? sanitize_text_field($_GET['individualId']) : '';
+	$activityId = isset($_GET['activityId']) ? sanitize_text_field($_GET['activityId']) : '';
+
+	$activities = \Civi\Api4\Activity::get(FALSE)
+	->addSelect('source_contact_id')
+	->addJoin('ActivityContact AS activity_contact', 'LEFT')
+	->addWhere('id', '=', $activityId)
+	->addWhere('activity_type_id:label', '=', 'Material Contribution')
+	->execute()->single();
+	if (empty($activities)) {
+		return;
+	}
+	$individualId = $activities['source_contact_id'];
+	\Civi::log()->info('activityId',['activityId'=>$individualId]);
 
 	// Create the base URL for the volunteer form
 	$base_url = home_url('/volunteer-form/#');
@@ -433,13 +446,6 @@ function dynamic_button_shortcode() {
 
 	// Return the button HTML
 	return '
-		<div>
-			<p class="has-text-align-center">
-				<mark style="background-color:rgba(0, 0, 0, 0);color:#d64631" class="has-inline-color">
-					<strong>Thank you for your contribution</strong>
-				</mark>
-			</p>
-		</div>
 		<div style="display: flex; justify-content: center; align-items: center; border-style:none; border-width:0px; border-radius:5px;">
 			<a class="wp-block-button__link has-white-color has-vivid-red-background-color has-text-color has-background has-link-color wp-element-button" 
 			   href="' . $button_url . '" 
@@ -449,7 +455,7 @@ function dynamic_button_shortcode() {
 		</div>';
 }
 
-add_shortcode('dynamic_button', 'dynamic_button_shortcode');
+add_shortcode('goonj_volunteer_registration_button', 'render_volunteer_button');
 
 
 

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -432,9 +432,11 @@ function render_volunteer_button() {
 	->addWhere('id', '=', $activityId)
 	->addWhere('activity_type_id:label', '=', 'Material Contribution')
 	->execute()->single();
+
 	if (empty($activities)) {
 		return;
 	}
+
 	$individualId = $activities['source_contact_id'];
 
 	$contacts = \Civi\Api4\Contact::get(FALSE)
@@ -442,16 +444,24 @@ function render_volunteer_button() {
 	->addWhere('id', '=', $individualId)
 	->execute();
 
-	$contactSubTypes = $contacts[0]['contact_sub_type'];
+    $contactSubTypes = $contacts[0]['contact_sub_type'] ?? null;
 
-    if (in_array('Volunteer', $contactSubTypes)) {
-        return; // Exit or return early if the contact is a volunteer
+    // Check if contact_sub_type is not null or empty and contains 'Volunteer'
+    if (!empty($contactSubTypes) && in_array('Volunteer', $contactSubTypes)) {
+        return;
     }
 	// Create the base URL for the volunteer form
-	$base_url = home_url('/volunteer-form/#');
+	$base_url = home_url('/volunteer-form/');
 
-	// Construct the dynamic button URL with parameters
-	$button_url = esc_url($base_url . "?Individual1=$individualId&message=individual-user");
+	$button_url = esc_url(
+		add_query_arg(
+			array(
+				'Individual1' => $individualId,
+				'message' => 'individual-user'
+			),
+			$base_url
+		)
+	);	
 
 	// Return the button HTML
 	return '

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -419,6 +419,7 @@ function goonj_is_volunteer_inducted( $volunteer ) {
 function goonj_custom_message_placeholder() {
 	return '<div id="custom-message" class="ml-24"></div>';
 }
+
 add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
 
 function render_volunteer_button() {
@@ -444,12 +445,12 @@ function render_volunteer_button() {
 	->addWhere('id', '=', $individualId)
 	->execute();
 
-    $contactSubTypes = $contacts[0]['contact_sub_type'] ?? null;
+	$contactSubTypes = $contacts[0]['contact_sub_type'] ?? null;
 
-    // Check if contact_sub_type is not null or empty and contains 'Volunteer'
-    if (!empty($contactSubTypes) && in_array('Volunteer', $contactSubTypes)) {
-        return;
-    }
+	// Check if contact_sub_type is not null or empty and contains 'Volunteer'
+	if (!empty($contactSubTypes) && in_array('Volunteer', $contactSubTypes)) {
+		return;
+	}
 	// Create the base URL for the volunteer form
 	$base_url = home_url('/volunteer-form/');
 

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -421,6 +421,38 @@ function goonj_custom_message_placeholder() {
 }
 add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
 
+function dynamic_button_shortcode() {
+	// Get the individual ID from the URL parameters
+	$individualId = isset($_GET['individualId']) ? sanitize_text_field($_GET['individualId']) : '';
+
+	// Create the base URL for the volunteer form
+	$base_url = home_url('/volunteer-form/#');
+
+	// Construct the dynamic button URL with parameters
+	$button_url = esc_url($base_url . "?Individual1=$individualId&message=individual-user");
+
+	// Return the button HTML
+	return '
+		<div>
+			<p class="has-text-align-center">
+				<mark style="background-color:rgba(0, 0, 0, 0);color:#d64631" class="has-inline-color">
+					<strong>Thank you for your contribution</strong>
+				</mark>
+			</p>
+		</div>
+		<div style="display: flex; justify-content: center; align-items: center; border-style:none; border-width:0px; border-radius:5px;">
+			<a class="wp-block-button__link has-white-color has-vivid-red-background-color has-text-color has-background has-link-color wp-element-button" 
+			   href="' . $button_url . '" 
+			   style="border-style:none;border-width:0px;border-radius:5px">
+			   Join Us as a Volunteer (If not a Volunteer)
+			</a>
+		</div>';
+}
+
+add_shortcode('dynamic_button', 'dynamic_button_shortcode');
+
+
+
 function goonj_collection_camp_landing_page() {
 	ob_start();
 	get_template_part( 'templates/collection-landing-page' );

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -452,7 +452,7 @@ function render_volunteer_button() {
 		return;
 	}
 	// Create the base URL for the volunteer form
-	$base_url = home_url('/volunteer-form/');
+	$base_url = home_url('/material-contribution/volunteer-signup/');
 
 	$button_url = esc_url(
 		add_query_arg(
@@ -508,29 +508,34 @@ function goonj_redirect_after_individual_creation() {
 	) {
 		return;
 	}
-
-	$individual = \Civi\Api4\Contact::get( false )
-		->addSelect( 'source', 'Individual_fields.Creation_Flow', 'email.email', 'phone.phone', 'Individual_fields.Source_Processing_Center' )
-		->addJoin( 'Email AS email', 'LEFT' )
-		->addJoin( 'Phone AS phone', 'LEFT' )
-		->addWhere( 'email.is_primary', '=', true )
-		->addWhere( 'phone.is_primary', '=', true )
-		->addWhere( 'id', '=', absint( $_GET['individualId'] ) )
-		->setLimit( 1 )
+	\Civi::log()->info('checking');
+	\Civi::log()->info('checking');
+	$individual = \Civi\Api4\Contact::get(false)
+		->addSelect('source', 'Individual_fields.Creation_Flow', 'email.email', 'phone.phone', 'Individual_fields.Source_Processing_Center')
+		->addJoin('Email AS email', 'LEFT')
+		->addJoin('Phone AS phone', 'LEFT')
+		->addWhere('phone.is_primary', '=', true) // Keep the phone condition
+		->addWhere('id', '=', absint($_GET['individualId'])) // Ensure individual ID is valid
+		->setLimit(1)
 		->execute()->single();
 
+	\Civi::log()->info('checking2', ['individual'=>$individual]);
+	
+
+	
 	$creationFlow = $individual['Individual_fields.Creation_Flow'];
 	$source = $individual['source'];
 	$sourceProcessingCenter = $individual['Individual_fields.Source_Processing_Center'];
+	\Civi::log()->info('checking3');
 
-	if ( ! $source ) {
-		return;
-	}
-
+	\Civi::log()->info('checking4',['creationFlow'=>$creationFlow]);
 	$redirectPath = '';
 
 	switch ( $creationFlow ) {
 		case 'material-contribution':
+			if ( ! $source ) {
+				return;
+			}
 			// If the individual was created while in the process of material contribution,
 			// then we need to find out from WHERE was she trying to contribute.
 

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -455,14 +455,11 @@ function render_volunteer_button() {
 	$base_url = home_url('/material-contribution/volunteer-signup/');
 
 	$button_url = esc_url(
-		add_query_arg(
-			array(
-				'Individual1' => $individualId,
-				'message' => 'individual-user'
-			),
-			$base_url
-		)
-	);	
+		$base_url . '#?' . http_build_query(array(
+			'Individual1' => $individualId,
+			'message' => 'individual-user'
+		))
+	);
 
 	// Return the button HTML
 	return '

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -505,8 +505,7 @@ function goonj_redirect_after_individual_creation() {
 	) {
 		return;
 	}
-	\Civi::log()->info('checking');
-	\Civi::log()->info('checking');
+
 	$individual = \Civi\Api4\Contact::get(false)
 		->addSelect('source', 'Individual_fields.Creation_Flow', 'email.email', 'phone.phone', 'Individual_fields.Source_Processing_Center')
 		->addJoin('Email AS email', 'LEFT')
@@ -516,16 +515,10 @@ function goonj_redirect_after_individual_creation() {
 		->setLimit(1)
 		->execute()->single();
 
-	\Civi::log()->info('checking2', ['individual'=>$individual]);
-	
-
-	
 	$creationFlow = $individual['Individual_fields.Creation_Flow'];
 	$source = $individual['source'];
 	$sourceProcessingCenter = $individual['Individual_fields.Source_Processing_Center'];
-	\Civi::log()->info('checking3');
 
-	\Civi::log()->info('checking4',['creationFlow'=>$creationFlow]);
 	$redirectPath = '';
 
 	switch ( $creationFlow ) {


### PR DESCRIPTION
- Added shortcode to display `Wish To vounteer` on contribution success page  if contact subtype is not volunteer 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new shortcodes for dynamic button creation, custom messages, and collection camp landing pages.
	- Added functionality for volunteer registration buttons based on user status.
	- Implemented an API for updating scheduled job times within the Goonjcustom extension.
- **Improvements**
	- Enhanced user identification processes for a smoother volunteer registration experience.
	- Improved redirection logic for logged-in users and after individual creation to ensure correct navigation.
	- Added a new query variable for better URL handling.
	- Updated volunteer name formatting to use display names instead of first names.
	- Adjusted handling of authorization emails to streamline processes.
	- Removed the 'activities' tab from the collection camp interface. 
	- Added CC email address for material contribution notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->