### PR TITLE
Add CC recipient to contribution receipt email

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -115,6 +115,7 @@ class MaterialContributionService extends AutoSubscriber {
     $html = self::generateContributionReceiptHtml($contribution, $email, $phone, $locationAreaOfCamp);
     $fileName = 'material_contribution_' . $contribution['id'] . '.pdf';
     $params['attachments'][] = \CRM_Utils_Mail::appendPDF($fileName, $html);
+    $params['cc'] = 'crm@goonj.org';
   }
 
   /**


### PR DESCRIPTION
Add CC to contribution receipt email

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/ac819077-49dd-4b8e-a3ba-ed330d6f1e1e">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a CC email address to contribution receipt emails for improved communication.
  
- **Bug Fixes**
	- Ensured that the contribution receipt PDF is properly attached to the email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->