### PR TITLE
Add Logistics Tab Search Kit

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -83,9 +83,9 @@ class CollectionCampService extends AutoSubscriber {
       // ],
       'logistics' => [
         'title' => ts('Logistics'),
-        'module' => 'afformLogisticsCoordination',
-        'directive' => 'afform-logistics-coordination',
-        'template' => 'CRM/Goonjcustom/Tabs/CollectionCampService.tpl',
+        'module' => 'afsearchCollectionCampLogistics',
+        'directive' => 'afsearch-collection-camp-logistics',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
       'campOutcome' => [
         'title' => ts('Camp Outcome'),


### PR DESCRIPTION
Clicking on the Logistics tab will open a search kit and Once this Pr merged will update the `aff.html` file to add a Logistics button, which will load a form and pass the option.ccid parameter.