### PR TITLE
Fix/queue induction email

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -175,7 +175,7 @@ class InductionService extends AutoSubscriber {
   private static function sendInductionEmail($volunteerId) {
     // Check if the email was already sent.
     if (self::isEmailAlreadySent($contactId)) {
-      \Civi::log()->info('Induction email already sent for contact', ['id' => $contactId]);
+      \Civi::log()->info('Induction email already sent for contact', ['id' => $volunteerId]);
       return FALSE;
     }
 
@@ -191,7 +191,7 @@ class InductionService extends AutoSubscriber {
 
     // Prepare email parameters.
     $emailParams = [
-      'contact_id' => $contactId,
+      'contact_id' => $volunteerId,
       'template_id' => $template['id'],
       'cc' => self::$volunteerInductionAssigneeEmail,
     ];
@@ -200,7 +200,7 @@ class InductionService extends AutoSubscriber {
     $contacts = Contact::get(FALSE)
       ->addSelect('email.email')
       ->addJoin('Email AS email', 'LEFT')
-      ->addWhere('id', '=', $contactId)
+      ->addWhere('id', '=', $volunteerId)
       ->execute()->single();
 
     $email = $contacts['email.email'];

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -172,7 +172,7 @@ class InductionService extends AutoSubscriber {
   /**
    * Common logic to send an email.
    */
-  private static function sendInductionEmail($contactId) {
+  private static function sendInductionEmail($volunteerId) {
     // Check if the email was already sent.
     if (self::isEmailAlreadySent($contactId)) {
       \Civi::log()->info('Induction email already sent for contact', ['id' => $contactId]);
@@ -240,12 +240,6 @@ class InductionService extends AutoSubscriber {
         'error' => $ex->getMessage(),
       ]);
     }
-    catch (\Exception $ex) {
-      \Civi::log()->error('Unexpected error while queueing induction email', [
-        'contactId' => $params['contact_id'],
-        'error' => $ex->getMessage(),
-      ]);
-    }
   }
 
   /**
@@ -258,13 +252,13 @@ class InductionService extends AutoSubscriber {
         throw new \CRM_Core_Exception($result['error_message']);
       }
       \Civi::log()->info('Successfully sent queued induction email', [
-        'contactId' => $params['contact_id'],
+        'params' => $params,
       ]);
       return TRUE;
     }
     catch (\Exception $ex) {
       \Civi::log()->error('Failed to send queued induction email', [
-        'contactId' => $params['contact_id'],
+        'params' => $params,
         'error' => $ex->getMessage(),
       ]);
       // Rethrow the exception for the queue system to handle.

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -232,17 +232,17 @@ class InductionService extends AutoSubscriber {
           'weight' => 1,
         ]);
 
-      \Civi::log()->info('Induction email queued for contact', ['contactId' => $params['contactId']]);
+      \Civi::log()->info('Induction email queued for contact', ['contactId' => $params['contact_id']]);
     }
     catch (\CRM_Core_Exception $ex) {
       \Civi::log()->error('Failed to queue induction email due to CiviCRM error', [
-        'contactId' => $params['contactId'],
+        'contactId' => $params['contact_id'],
         'error' => $ex->getMessage(),
       ]);
     }
     catch (\Exception $ex) {
       \Civi::log()->error('Unexpected error while queueing induction email', [
-        'contactId' => $params['contactId'],
+        'contactId' => $params['contact_id'],
         'error' => $ex->getMessage(),
       ]);
     }
@@ -258,13 +258,13 @@ class InductionService extends AutoSubscriber {
         throw new \CRM_Core_Exception($result['error_message']);
       }
       \Civi::log()->info('Successfully sent queued induction email', [
-        'contactId' => $params['contactId'],
+        'contactId' => $params['contact_id'],
       ]);
       return TRUE;
     }
     catch (\Exception $ex) {
       \Civi::log()->error('Failed to send queued induction email', [
-        'contactId' => $params['contactId'],
+        'contactId' => $params['contact_id'],
         'error' => $ex->getMessage(),
       ]);
       // Rethrow the exception for the queue system to handle.

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -196,21 +196,7 @@ class InductionService extends AutoSubscriber {
       'cc' => self::$volunteerInductionAssigneeEmail,
     ];
 
-    // Fetch contact's email.
-    $contacts = Contact::get(FALSE)
-      ->addSelect('email.email')
-      ->addJoin('Email AS email', 'LEFT')
-      ->addWhere('id', '=', $volunteerId)
-      ->execute()->single();
-
-    $email = $contacts['email.email'];
-
-    if (empty($email)) {
-      self::queueInductionEmail($emailParams);
-      return TRUE;
-    }
-
-    civicrm_api3('Email', 'send', $emailParams);
+    self::queueInductionEmail($emailParams);
     return TRUE;
   }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -185,11 +185,8 @@ class InductionService extends AutoSubscriber {
       ->setLimit(1)
       ->execute()->single();
 
-    // If no template is found, queue the email task to be processed later.
     if (!$template) {
-      \Civi::log()->warning('No email template found. Queuing the induction email.', ['contactId' => $contactId]);
-      self::queueInductionEmail($contactId);
-      return TRUE;
+      return FALSE;
     }
 
     // Prepare email parameters.
@@ -235,12 +232,12 @@ class InductionService extends AutoSubscriber {
         'weight' => 1,
       ]);
 
-      \Civi::log()->info('Induction email queued for contact', ['contactId' => $contactId]);
+      \Civi::log()->info('Induction email queued for contact', ['contactId' => $params['contactId']]);
 
     }
     catch (\Exception $ex) {
       \Civi::log()->error('Failed to queue induction email', [
-        'contactId' => $contactId,
+        'contactId' => $params['contactId'],
         'error' => $ex->getMessage(),
       ]);
     }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -174,7 +174,7 @@ class InductionService extends AutoSubscriber {
    */
   private static function sendInductionEmail($volunteerId) {
 
-    if (self::isEmailAlreadySent($contactId)) {
+    if (self::isEmailAlreadySent($volunteerId)) {
       return FALSE;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -173,9 +173,8 @@ class InductionService extends AutoSubscriber {
    * Common logic to send an email.
    */
   private static function sendInductionEmail($volunteerId) {
-    // Check if the email was already sent.
+
     if (self::isEmailAlreadySent($contactId)) {
-      \Civi::log()->info('Induction email already sent for contact', ['id' => $volunteerId]);
       return FALSE;
     }
 


### PR DESCRIPTION
- Queue induction email  when contact submits volunteer form after contribution email field is not saved .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a queuing system for induction emails, enhancing email processing efficiency.
	- Added functionality to check if an induction email has already been sent to prevent duplicates.
	- Improved retrieval of the volunteer induction coordinator's email for better communication.
	- Added a method to process queued induction emails, ensuring reliable sending of notifications.

- **Bug Fixes**
	- Enhanced error handling for email sending logic to manage exceptions effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->