### PR TITLE
Removed Pin Code From Poster

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/CollectionCamp.php
@@ -197,7 +197,7 @@ class CRM_Goonjcustom_Token_CollectionCamp extends AbstractTokenSubscriber {
       $collectionSource['Collection_Camp_Intent_Details.District'],
       $collectionSource['Collection_Camp_Intent_Details.City'],
       // CRM_Core_PseudoConstant::stateProvince($collectionSource['Collection_Camp_Intent_Details.State']),.
-      $collectionSource['Collection_Camp_Intent_Details.Pin_Code'],
+      // $collectionSource['Collection_Camp_Intent_Details.Pin_Code'],
     ];
 
     return join(', ', array_filter($addressParts));


### PR DESCRIPTION
## Description

- updates the `formatVenue` method in the `CRM_Goonjcustom_Token_CollectionCamp` class to exclude the pin code from the venue address formatting.