### PR TITLE
Fix poster file naming format to improve clarity

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -108,9 +108,7 @@ class CollectionBaseService extends AutoSubscriber {
       'collectionSourceCustomData' => self::$generatePosterRequest['customData'],
     ],
     );
-
-    $baseFileName = "poster_{$collectionSourceId}.png";
-    $fileName = \CRM_Utils_File::makeFileName($baseFileName);
+    $baseFileName = "CollectionCampPoster_{$collectionSourceId}.png";
     $tempFilePath = \CRM_Utils_File::tempnam($baseFileName);
 
     $posterGenerated = self::html2image($rendered['html'], $tempFilePath);
@@ -137,7 +135,7 @@ class CollectionBaseService extends AutoSubscriber {
     // Save the poster image as an attachment linked to the collection camp.
     $params = [
       'entity_id' => $collectionSourceId,
-      'name' => $fileName,
+      'name' => $baseFileName,
       'mime_type' => 'image/png',
       'field_name' => $posterFieldId,
       'options' => [


### PR DESCRIPTION
### Description 

1. Changed the Poster file name format : 
The new format will be `CollectionCampPoster_{collectionSourceId}.png`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved poster filename clarity for collection camp posters.
	- Enhanced attachment naming conventions for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->