### PR TITLE
Volunteer camp feedback reminder

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -78,7 +78,7 @@ class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
       'from' => $from,
       'toEmail' => $volunteerEmailId,
       'replyTo' => $from,
-      'html' => self::getVolunteerFeedbackReminderEmailHtml($volunteerName, $collectionCampId, $volunteerEmailId),
+      'html' => self::getVolunteerFeedbackReminderEmailHtml($volunteerName, $collectionCampId),
     ];
 
     $emailSendResult = \CRM_Utils_Mail::send($mailParams);
@@ -97,18 +97,17 @@ class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
    *
    * @param string $volunteerName
    * @param int $collectionCampId
-   * @param int $volunteerEmailId
    *
    * @return string
    */
-  public static function getVolunteerFeedbackReminderEmailHtml($volunteerName, $collectionCampId, $volunteerEmailId) {
+  public static function getVolunteerFeedbackReminderEmailHtml($volunteerName, $collectionCampId) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
     $feedbackFormUrl = $homeUrl . 'volunteer-camp-feedback/#?Eck_Collection_Camp1=' . $collectionCampId;
 
     $html = "
       <p>Dear $volunteerName,</p>
       <p>Greetings from Goonj!</p>
-      <p>Kindly reminding you to share your valuable feedback on the recent collection camp. Your insights are important for us to continue improving future in future camps.</p>
+      <p>Kindly reminding you to share your valuable feedback on the recent collection camp. Your insights are important for us to continue improving in future camps.</p>
       <p>If you haven’t had the chance yet, please take a few minutes to fill out the feedback form here:</p>
       <p><a href=\"$feedbackFormUrl\">Volunteer Feedback Form</a></p>
       <p>We look forward to working with you again!</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Civi;
+
+use Civi\Core\Service\AutoSubscriber;
+
+/**
+ * Collection Camp Outcome Service.
+ */
+class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
+
+  /**
+   * Define subscribed events.
+   */
+  public static function getSubscribedEvents() {
+    return [];
+  }
+
+  /**
+   * Send the feedback reminder email to the volunteer.
+   *
+   * @param int $volunteerEmailId
+   * @param string $from
+   * @param string $campAddress
+   * @param int $collectionCampId
+   * @param \DateTime $endDate
+   */
+  public static function sendVolunteerFeedbackReminderEmail($volunteerEmailId, $from, $campAddress, $collectionCampId, $endDate, $volunteerName) {
+    $mailParams = [
+      'subject' => 'Reminder to fill the camp feedback form for ' . $campAddress . ' on ' . $endDate->format('Y-m-d'),
+      'from' => $from,
+      'toEmail' => $volunteerEmailId,
+      'replyTo' => $from,
+      'html' => self::getVolunteerFeedbackReminderEmailHtml($volunteerName, $collectionCampId, $volunteerEmailId),
+    ];
+
+    $emailSendResult = \CRM_Utils_Mail::send($mailParams);
+
+    if (!$emailSendResult) {
+      \Civi::log()->error('Failed to send feedback reminder email', [
+        'volunteerEmailId' => $volunteerEmailId,
+        'volunteerEmail' => $volunteerEmail,
+      ]);
+      throw new \CRM_Core_Exception('Failed to send feedback reminder email');
+    }
+  }
+
+  /**
+   * Generates HTML content for the volunteer feedback reminder email.
+   *
+   * @param string $volunteerName
+   * @param int $collectionCampId
+   * @param int $volunteerEmailId
+   *
+   * @return string
+   */
+  public static function getVolunteerFeedbackReminderEmailHtml($volunteerName, $collectionCampId, $volunteerEmailId) {
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+    $feedbackFormUrl = $homeUrl . 'volunteer-camp-feedback/#?Eck_Collection_Camp1=' . $collectionCampId;
+
+    $html = "
+      <p>Dear $volunteerName,</p>
+      <p>Greetings from Goonj!</p>
+      <p>We are kindly reminding you to share your valuable feedback on the recent collection camp you attended. Your insights are essential for us to continue improving our future camps and make them even better.</p>
+      <p>If you haven’t had the chance yet, please take a few minutes to fill out the feedback form here:</p>
+      <p><a href=\"$feedbackFormUrl\">Volunteer Feedback Form</a></p>
+      <p>We look forward to working with you again!</p>
+      <p>Warm regards,<br>Team Goonj</p>";
+
+    return $html;
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -44,7 +44,7 @@ class CollectionCampVolunteerFeedbackService {
     $hoursSinceCampEnd = abs($now->getTimestamp() - $endDate->getTimestamp()) / 3600;
 
     // Check if feedback form is not filled and 24 hours have passed since camp end.
-    if ($hoursSinceCampEnd >= 24 && ($lastReminderSent === NULL)) {
+    if ($hoursSinceCampEnd >= 24 && !$lastReminderSent) {
       // Send the first reminder email to the volunteer.
       self::sendVolunteerFeedbackReminderEmail($initiatorEmail, $from, $campAddress, $collectionCampId, $endDate, $initiatorName);
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -43,7 +43,6 @@ class CollectionCampVolunteerFeedbackService {
     // Calculate hours since camp ended.
     $hoursSinceCampEnd = abs($today->getTimestamp() - $endDate->getTimestamp()) / 3600;
 
-
     // Check if feedback form is not filled and 24 hours have passed since camp end.
     if ($hoursSinceCampEnd >= 24 && ($lastReminderSent === NULL)) {
       // Send the first reminder email to the volunteer.

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -4,7 +4,6 @@ namespace Civi;
 
 use Civi\Api4\Contact;
 use Civi\Api4\EckEntity;
-use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Collection Camp Outcome Service.
@@ -21,8 +20,7 @@ class CollectionCampVolunteerFeedbackService {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function processVolunteerFeedbackReminder($camp, $now) {
-    $from = self::getDefaultFromEmail();
+  public static function processVolunteerFeedbackReminder($camp, $now, $from) {
     $initiatorId = $camp['Collection_Camp_Core_Details.Contact_Id'];
     $initiator = Contact::get(TRUE)
       ->addSelect('email.email', 'display_name')

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -27,7 +27,7 @@ class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
    */
   public static function sendVolunteerFeedbackReminderEmail($volunteerEmailId, $from, $campAddress, $collectionCampId, $endDate, $volunteerName) {
     $mailParams = [
-      'subject' => 'Reminder to fill the camp feedback form for ' . $campAddress . ' on ' . $endDate->format('Y-m-d'),
+      'subject' => 'Reminder to share your feedback for ' . $campAddress . ' on ' . $endDate->format('Y-m-d'),
       'from' => $from,
       'toEmail' => $volunteerEmailId,
       'replyTo' => $from,
@@ -61,7 +61,7 @@ class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
     $html = "
       <p>Dear $volunteerName,</p>
       <p>Greetings from Goonj!</p>
-      <p>We are kindly reminding you to share your valuable feedback on the recent collection camp you attended. Your insights are essential for us to continue improving our future camps and make them even better.</p>
+      <p>Kindly reminding you to share your valuable feedback on the recent collection camp. Your insights are important for us to continue improving future in future camps.</p>
       <p>If you haven’t had the chance yet, please take a few minutes to fill out the feedback form here:</p>
       <p><a href=\"$feedbackFormUrl\">Volunteer Feedback Form</a></p>
       <p>We look forward to working with you again!</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -41,7 +41,8 @@ class CollectionCampVolunteerFeedbackService {
     $lastReminderSent = $camp['Volunteer_Camp_Feedback.Last_Reminder_Sent'] ? new \DateTime($camp['Volunteer_Camp_Feedback.Last_Reminder_Sent']) : NULL;
 
     // Calculate hours since camp ended.
-    $hoursSinceCampEnd = $today->diff($endDate)->h + ($today->diff($endDate)->days * 24);
+    $hoursSinceCampEnd = abs($today->getTimestamp() - $endDate->getTimestamp()) / 3600;
+
 
     // Check if feedback form is not filled and 24 hours have passed since camp end.
     if ($hoursSinceCampEnd >= 24 && ($lastReminderSent === NULL)) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -9,14 +9,7 @@ use Civi\Core\Service\AutoSubscriber;
 /**
  * Collection Camp Outcome Service.
  */
-class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
-
-  /**
-   * Define subscribed events.
-   */
-  public static function getSubscribedEvents() {
-    return [];
-  }
+class CollectionCampVolunteerFeedbackService {
 
   /**
    * Process the feedback reminder for a volunteer.

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -16,12 +16,12 @@ class CollectionCampVolunteerFeedbackService {
    *
    * @param array $camp
    *   The camp data.
-   * @param \DateTimeImmutable $today
+   * @param \DateTimeImmutable $now
    *   The current date.
    *
    * @throws \CRM_Core_Exception
    */
-  public static function processVolunteerFeedbackReminder($camp, $today) {
+  public static function processVolunteerFeedbackReminder($camp, $now) {
     $from = self::getDefaultFromEmail();
     $initiatorId = $camp['Collection_Camp_Core_Details.Contact_Id'];
     $initiator = Contact::get(TRUE)
@@ -41,7 +41,7 @@ class CollectionCampVolunteerFeedbackService {
     $lastReminderSent = $camp['Volunteer_Camp_Feedback.Last_Reminder_Sent'] ? new \DateTime($camp['Volunteer_Camp_Feedback.Last_Reminder_Sent']) : NULL;
 
     // Calculate hours since camp ended.
-    $hoursSinceCampEnd = abs($today->getTimestamp() - $endDate->getTimestamp()) / 3600;
+    $hoursSinceCampEnd = abs($now->getTimestamp() - $endDate->getTimestamp()) / 3600;
 
     // Check if feedback form is not filled and 24 hours have passed since camp end.
     if ($hoursSinceCampEnd >= 24 && ($lastReminderSent === NULL)) {
@@ -51,7 +51,7 @@ class CollectionCampVolunteerFeedbackService {
       // Update the Last_Reminder_Sent field in the database.
       EckEntity::update('Collection_Camp', TRUE)
         ->addWhere('id', '=', $collectionCampId)
-        ->addValue('Volunteer_Camp_Feedback.Last_Reminder_Sent', $today->format('Y-m-d H:i:s'))
+        ->addValue('Volunteer_Camp_Feedback.Last_Reminder_Sent', $now->format('Y-m-d H:i:s'))
         ->execute();
     }
   }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -29,10 +29,7 @@ class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
    * @throws \CRM_Core_Exception
    */
   public static function processVolunteerFeedbackReminder($camp, $today) {
-    // Get the default 'from' email.
-    [$defaultFromName, $defaultFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail();
-    $from = "\"$defaultFromName\" <$defaultFromEmail>";
-
+    $from = self::getDefaultFromEmail();
     $volunteerContactId = $camp['Collection_Camp_Core_Details.Contact_Id'];
     $campAttendedBy = Contact::get(TRUE)
       ->addSelect('email.email', 'display_name')
@@ -118,6 +115,14 @@ class CollectionCampVolunteerFeedbackService extends AutoSubscriber {
       <p>Warm regards,<br>Team Goonj</p>";
 
     return $html;
+  }
+
+  /**
+   * Get default from email.
+   */
+  public static function getDefaultFromEmail() {
+    [$defaultFromName, $defaultFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail();
+    return "\"$defaultFromName\" <$defaultFromEmail>";
   }
 
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -107,12 +107,4 @@ class CollectionCampVolunteerFeedbackService {
     return $html;
   }
 
-  /**
-   * Get default from email.
-   */
-  public static function getDefaultFromEmail() {
-    [$defaultFromName, $defaultFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail();
-    return "\"$defaultFromName\" <$defaultFromEmail>";
-  }
-
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/HelperService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/HelperService.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Civi;
+
+/**
+ * Collection Camp Outcome Service.
+ */
+class HelperService {
+
+  /**
+   * Get default from email.
+   */
+  public static function getDefaultFromEmail() {
+    [$defaultFromName, $defaultFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail();
+    return "\"$defaultFromName\" <$defaultFromEmail>";
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -42,7 +42,7 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
   // Fetch camps that have completed and volunteers have not filled the feedback form.
-  $volunteerCamps = EckEntity::get('Collection_Camp', TRUE)
+  $campsNeedReminder = EckEntity::get('Collection_Camp', TRUE)
     ->addSelect('Volunteer_Camp_Feedback.Last_Reminder_Sent', 'Collection_Camp_Intent_Details.Location_Area_of_camp', 'Collection_Camp_Intent_Details.End_Date', 'Collection_Camp_Core_Details.Contact_Id')
     ->addWhere('Volunteer_Camp_Feedback.Give_Rating_to_your_camp', 'IS NULL')
     ->addWhere('Logistics_Coordination.Feedback_Email_Sent', '=', 1)
@@ -50,7 +50,7 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
     ->addWhere('Collection_Camp_Intent_Details.End_Date', '<=', $endOfDay)
     ->execute();
 
-  foreach ($volunteerCamps as $camp) {
+  foreach ($campsNeedReminder as $camp) {
     try {
       CollectionCampVolunteerFeedbackService::processVolunteerFeedbackReminder($camp, $today);
     }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -38,8 +38,8 @@ function _civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron_spec(&$spec)
  */
 function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
   $returnValues = [];
-  $today = new DateTimeImmutable();
-  $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+  $now = new DateTimeImmutable();
+  $endOfDay = $now->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
   // Fetch camps that have completed and volunteers have not filled the feedback form.
   $campsNeedReminder = EckEntity::get('Collection_Camp', TRUE)
@@ -52,7 +52,7 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
 
   foreach ($campsNeedReminder as $camp) {
     try {
-      CollectionCampVolunteerFeedbackService::processVolunteerFeedbackReminder($camp, $today);
+      CollectionCampVolunteerFeedbackService::processVolunteerFeedbackReminder($camp, $now);
     }
     catch (\Exception $e) {
       \Civi::log()->error('Error processing volunteer feedback reminder', [

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -4,6 +4,10 @@
  * @file
  */
 
+use Civi\Api4\EckEntity;
+use Civi\CollectionCampVolunteerFeedbackService;
+use Civi\Api4\Contact;
+
 /**
  * Goonjcustom.VolunteerFeedbackReminderCron API specification (optional)
  * This is used for documentation and validation.
@@ -61,7 +65,7 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
         ->execute()->single();
 
       $volunteerEmailId = $campAttendedBy['email.email'];
-      $organizingContactName = $campAttendedBy['display_name'];
+      $volunteerName = $campAttendedBy['display_name'];
 
       $endDate = new \DateTime($camp['Collection_Camp_Intent_Details.End_Date']);
       $collectionCampId = $camp['id'];
@@ -75,7 +79,7 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
       // Check if feedback form is not filled and 24 hours have passed since camp end.
       if ($hoursSinceCampEnd >= 24 && ($lastReminderSent === NULL)) {
         // Send the first reminder email to the volunteer.
-        CollectionCampOutcomeService::sendVolunteerFeedbackReminderEmail($volunteerEmailId, $from, $campAddress, $collectionCampId, $endDate);
+        CollectionCampVolunteerFeedbackService::sendVolunteerFeedbackReminderEmail($volunteerEmailId, $from, $campAddress, $collectionCampId, $endDate, $volunteerName);
 
         // Update the Last_Reminder_Sent field in the database to avoid duplicate reminders.
         EckEntity::update('Collection_Camp', TRUE)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -29,7 +29,6 @@ function _civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron_spec(&$spec)
  *
  * @throws \CRM_Core_Exception
  */
-< ? php
 
 /**
  * Cron job to send reminder emails to volunteers who haven't filled the feedback form.

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -41,6 +41,9 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
   $now = new DateTimeImmutable();
   $endOfDay = $now->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
+  // Get the default "from" email.
+  $from = CollectionCampVolunteerFeedbackService::getDefaultFromEmail();
+
   // Fetch camps that have completed and volunteers have not filled the feedback form.
   $campsNeedReminder = EckEntity::get('Collection_Camp', TRUE)
     ->addSelect('Volunteer_Camp_Feedback.Last_Reminder_Sent', 'Collection_Camp_Intent_Details.Location_Area_of_camp', 'Collection_Camp_Intent_Details.End_Date', 'Collection_Camp_Core_Details.Contact_Id')
@@ -52,7 +55,7 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
 
   foreach ($campsNeedReminder as $camp) {
     try {
-      CollectionCampVolunteerFeedbackService::processVolunteerFeedbackReminder($camp, $now);
+      CollectionCampVolunteerFeedbackService::processVolunteerFeedbackReminder($camp, $now, $from);
     }
     catch (\Exception $e) {
       \Civi::log()->error('Error processing volunteer feedback reminder', [

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -5,6 +5,7 @@
  */
 
 use Civi\Api4\EckEntity;
+use Civi\HelperService;
 use Civi\CollectionCampVolunteerFeedbackService;
 
 /**
@@ -42,7 +43,7 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
   $endOfDay = $now->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
   // Get the default "from" email.
-  $from = CollectionCampVolunteerFeedbackService::getDefaultFromEmail();
+  $from = HelperService::getDefaultFromEmail();
 
   // Fetch camps that have completed and volunteers have not filled the feedback form.
   $campsNeedReminder = EckEntity::get('Collection_Camp', TRUE)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ * Goonjcustom.VolunteerFeedbackReminderCron API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron_spec(&$spec) {
+  // No parameters required for the Goonjcustom volunteer feedback reminder cron.
+}
+
+/**
+ * Goonjcustom.VolunteerFeedbackReminderCron API.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+< ? php
+
+/**
+ * Cron job to send reminder emails to volunteers who haven't filled the feedback form.
+ */
+function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
+  $returnValues = [];
+  $today = new DateTimeImmutable();
+  $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+
+  // Fetch camps that have completed and volunteers have not filled the feedback form.
+  $volunteerCamps = EckEntity::get('Collection_Camp', TRUE)
+    ->addSelect('Volunteer_Camp_Feedback.Last_Reminder_Sent', 'Collection_Camp_Intent_Details.Location_Area_of_camp', 'Collection_Camp_Intent_Details.End_Date', 'Collection_Camp_Core_Details.Contact_Id')
+    ->addWhere('Volunteer_Camp_Feedback.Give_Rating_to_your_camp', 'IS NULL')
+    ->addWhere('Logistics_Coordination.Feedback_Email_Sent', '=', 1)
+    ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
+    ->addWhere('Collection_Camp_Intent_Details.End_Date', '<=', $endOfDay)
+    ->execute();
+
+  [$defaultFromName, $defaultFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail();
+  $from = "\"$defaultFromName\" <$defaultFromEmail>";
+
+  foreach ($volunteerCamps as $camp) {
+    try {
+      $volunteerContactId = $camp['Collection_Camp_Core_Details.Contact_Id'];
+      // Get recipient email and name.
+      $campAttendedBy = Contact::get(TRUE)
+        ->addSelect('email.email', 'display_name')
+        ->addJoin('Email AS email', 'LEFT')
+        ->addWhere('id', '=', $volunteerContactId)
+        ->execute()->single();
+
+      $volunteerEmailId = $campAttendedBy['email.email'];
+      $organizingContactName = $campAttendedBy['display_name'];
+
+      $endDate = new \DateTime($camp['Collection_Camp_Intent_Details.End_Date']);
+      $collectionCampId = $camp['id'];
+      $campAddress = $camp['Collection_Camp_Intent_Details.Location_Area_of_camp'];
+
+      $lastReminderSent = $camp['Volunteer_Camp_Feedback.Last_Reminder_Sent'] ? new \DateTime($camp['Volunteer_Camp_Feedback.Last_Reminder_Sent']) : NULL;
+
+      // Calculate hours since camp ended.
+      $hoursSinceCampEnd = $today->diff($endDate)->h + ($today->diff($endDate)->days * 24);
+
+      // Check if feedback form is not filled and 24 hours have passed since camp end.
+      if ($hoursSinceCampEnd >= 24 && ($lastReminderSent === NULL)) {
+        // Send the first reminder email to the volunteer.
+        CollectionCampOutcomeService::sendVolunteerFeedbackReminderEmail($volunteerEmailId, $from, $campAddress, $collectionCampId, $endDate);
+
+        // Update the Last_Reminder_Sent field in the database to avoid duplicate reminders.
+        EckEntity::update('Collection_Camp', TRUE)
+          ->addWhere('id', '=', $camp['id'])
+          ->addValue('Volunteer_Camp_Feedback.Last_Reminder_Sent', $today->format('Y-m-d H:i:s'))
+          ->execute();
+      }
+    }
+    catch (\Exception $e) {
+      \Civi::log()->error('Error processing volunteer feedback reminder', [
+        'id' => $camp['id'],
+        'error' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'volunteer_feedback_reminder_cron');
+}


### PR DESCRIPTION
## Requirement
If a camp volunteer doesn’t fill the feedback form , send a reminder once after 24 hours of completion of the form

## Logic to build the outcome reminder
1. Created a cron job that runs on a daily basis
2. Fetch camps that have completed and volunteers have not filled the feedback form.
3. Calculate hours since camp ended.
4. Calculate hours since the last reminder was sent (if any)
5. Check if feedback form is not filled and 24 hours have passed since camp end.
6.Send the reminder email to the volunteer.
7.  Update the Last_Reminder_Sent field in the database.

## Test the feedback reminder
1. Execute the Volunteer Feedback Reminder cron job from wp-admin by going to the `CiviCRM -> Administer -> system setting -> Scheduled Jobs`.
2. Now you need to check how many camps are there that have completed means authorized but the feedback form is not yet filled by running the API with the help of the below API
https://goonj-crm.staging.coloredcow.com/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fapi4#/explorer/Eck_Collection_Camp/get?select=%5B%22Volunteer_Camp_Feedback.Last_Reminder_Sent%22,%22Collection_Camp_Intent_Details.Location_Area_of_camp%22,%22Collection_Camp_Intent_Details.End_Date%22,%22Collection_Camp_Core_Details.Contact_Id%22,%22Logistics_Coordination.Feedback_Email_Sent%22,%22Volunteer_Camp_Feedback.Give_Rating_to_your_camp%22%5D&where=%5B%5B%22Volunteer_Camp_Feedback.Give_Rating_to_your_camp%22,%22IS%20NULL%22%5D,%5B%22Logistics_Coordination.Feedback_Email_Sent%22,%22%3D%22,%221%22%5D,%5B%22Collection_Camp_Core_Details.Status%22,%22%3D%22,%22authorized%22%5D,%5B%22Collection_Camp_Intent_Details.End_Date%22,%22%3C%3D%22,%222024-10-10%2010:33:00%22%5D%5D&debug=0&checkPermissions=0
3. From the API you'll able to see the end date of the collection camp where you will be able to see how many hours it reached if it's reached 24 hours then an reminder email should be there on maildev for the **contact** which is on the initiated by on collection camp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a cron job that sends reminder emails to volunteers who have not completed feedback forms after attending camps.
	- Added an API for managing the reminder process, ensuring timely follow-ups with volunteers.
	- Implemented a new service for sending volunteer feedback reminder emails, including customizable email content.
	- Enhanced email reminders with personalized messages and links to feedback forms.
	- Added functionality to track and manage the last reminder sent to volunteers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->