### PR TITLE
Volunteer Induction reminder

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -468,7 +468,7 @@ class InductionService extends AutoSubscriber {
     error_log("hoursSinceRegistration: " . print_r($hoursSinceRegistration, TRUE));
 
     // Calculate hours since last reminder was sent (if any)
-    $hoursSinceLastReminder = $lastReminderSent ? ($today->diff($lastReminderSent)->h + ($today->diff($lastReminderSent)->days * 24)) : NULL;
+    $hoursSinceLastReminder = $lastReminderSent ? (($today->getTimestamp() - $lastReminderSent->getTimestamp()) / 3600) : NULL;
     error_log("hoursSinceLastReminder: " . print_r($hoursSinceLastReminder, TRUE));
 
     // Send the first reminder if one week (7 days = 168 hours) has passed since registration.

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -464,7 +464,7 @@ class InductionService extends AutoSubscriber {
     $lastReminderSent = $volunteer['Volunteer_fields.Last_Reminder_Sent'] ? new \DateTime($volunteer['Volunteer_fields.Last_Reminder_Sent']) : NULL;
 
     // Calculate hours since registration.
-    $hoursSinceRegistration = $today->diff($registrationDate)->h + ($today->diff($registrationDate)->days * 24);
+    $hoursSinceRegistration = ($today->getTimestamp() - $registrationDate->getTimestamp()) / 3600;
     error_log("hoursSinceRegistration: " . print_r($hoursSinceRegistration, TRUE));
 
     // Calculate hours since last reminder was sent (if any)

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -455,8 +455,7 @@ class InductionService extends AutoSubscriber {
    *
    * @throws \Exception
    */
-  public static function processInductionReminder($volunteer, $today) {
-    $from = self::getDefaultFromEmail();
+  public static function processInductionReminder($volunteer, $today, $from) {
     $volunteerId = $volunteer['id'];
     $volunteerName = $volunteer['display_name'];
     $volunteerEmail = $volunteer['email_primary.email'];
@@ -534,14 +533,6 @@ class InductionService extends AutoSubscriber {
     <p>Warm regards,<br>Team Goonj</p>";
 
     return $html;
-  }
-
-  /**
-   * Get default from email.
-   */
-  public static function getDefaultFromEmail() {
-    [$defaultFromName, $defaultFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail();
-    return "\"$defaultFromName\" <$defaultFromEmail>";
   }
 
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -5,6 +5,7 @@ namespace Civi;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
+use Civi\Api4\Individual;
 use Civi\Api4\MessageTemplate;
 use Civi\Api4\Relationship;
 use Civi\Core\Service\AutoSubscriber;
@@ -460,7 +461,7 @@ class InductionService extends AutoSubscriber {
     $volunteerName = $volunteer['display_name'];
     $volunteerEmail = $volunteer['email_primary.email'];
     $registrationDate = new \DateTime($volunteer['created_date']);
-    $lastReminderSent = $volunteer['Volunteer_fields.Last_Reminder_Sent'] ? new \DateTime($volunteer['Volunteer_fields.Last_Reminder_Sent']) : NULL;
+    $lastReminderSent = $volunteer['Individual_fields.Last_Reminder_Sent'] ? new \DateTime($volunteer['Individual_fields.Last_Reminder_Sent']) : NULL;
 
     error_log("volunteerId: " . print_r($volunteerId, TRUE));
 
@@ -472,11 +473,12 @@ class InductionService extends AutoSubscriber {
     if ($hoursSinceRegistration >= 168 && $lastReminderSent === NULL) {
       // Send the reminder email.
       self::sendInductionReminderEmail($volunteerId, $from, $volunteerName, $volunteerEmail);
+      error_log("working");
 
       // Update the Last_Reminder_Sent field in the database.
-      EckEntity::update('Volunteer_Induction', TRUE)
+      Individual::update(FALSE)
+        ->addValue('Individual_fields.Last_Reminder_Sent', $today->format('Y-m-d H:i:s'))
         ->addWhere('id', '=', $volunteerId)
-        ->addValue('Volunteer_fields.Last_Reminder_Sent', $today->format('Y-m-d H:i:s'))
         ->execute();
 
       error_log("Reminder sent to volunteerId: " . print_r($volunteerId, TRUE));

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -462,6 +462,8 @@ class InductionService extends AutoSubscriber {
     $registrationDate = new \DateTime($volunteer['created_date']);
     $lastReminderSent = $volunteer['Volunteer_fields.Last_Reminder_Sent'] ? new \DateTime($volunteer['Volunteer_fields.Last_Reminder_Sent']) : NULL;
 
+    error_log("volunteerId: " . print_r($volunteerId, TRUE));
+
     // Calculate hours since registration.
     $hoursSinceRegistration = ($today->getTimestamp() - $registrationDate->getTimestamp()) / 3600;
     error_log("hoursSinceRegistration: " . print_r($hoursSinceRegistration, TRUE));
@@ -477,11 +479,11 @@ class InductionService extends AutoSubscriber {
         // Send the reminder email.
         self::sendInductionReminderEmail($volunteerId, $from, $volunteerName, $volunteerEmail);
 
-        // Update the Last_Reminder_Sent field in the database.
-        EckEntity::update('Volunteer_Induction', TRUE)
-          ->addWhere('id', '=', $volunteer['id'])
-          ->addValue('Volunteer_fields.Last_Reminder_Sent', $today->format('Y-m-d H:i:s'))
-          ->execute();
+        // // Update the Last_Reminder_Sent field in the database.
+        // EckEntity::update('Volunteer_Induction', TRUE)
+        //   ->addWhere('id', '=', $volunteer['id'])
+        //   ->addValue('Volunteer_fields.Last_Reminder_Sent', $today->format('Y-m-d H:i:s'))
+        //   ->execute();
       }
     }
   }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
@@ -41,11 +41,12 @@ function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
   while (TRUE) {
     // Fetch volunteers who have registered but not scheduled an induction.
     $volunteers = Individual::get(TRUE)
-      ->addSelect('created_date', 'display_name', 'email_primary.email', 'Volunteer_fields.Last_Reminder_Sent')
+      ->addSelect('created_date', 'display_name', 'email_primary.email', 'Individual_fields.Last_Reminder_Sent')
       ->addJoin('Activity AS activity', 'LEFT')
       ->addWhere('activity.activity_type_id', '=', 57)
       ->addWhere('activity.status_id', '=', 9)
       ->addWhere('contact_sub_type', '=', 'Volunteer')
+      ->addWhere('Individual_fields.Last_Reminder_Sent', 'IS NULL')
       ->addWhere('created_date', '<=', (new DateTime())->format('Y-m-d H:i:s'))
       ->setLimit($batchSize)
       ->setOffset($offset)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
@@ -40,7 +40,6 @@ function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
   $from = HelperService::getDefaultFromEmail();
 
   while (TRUE) {
-    // Fetch volunteers who have registered but not scheduled an induction.
     $activityTypeOptionValue = OptionValue::get(TRUE)
       ->addWhere('option_group_id:name', '=', 'activity_type')
       ->addWhere('name', '=', 'Induction')
@@ -55,6 +54,7 @@ function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
 
     $activityStatus = $activityStatusOptionValue['value'];
 
+    // Fetch volunteers who have registered but not scheduled an induction.
     $volunteers = Individual::get(TRUE)
       ->addSelect('created_date', 'display_name', 'email_primary.email', 'Individual_fields.Last_Reminder_Sent', 'address_primary.state_province_id')
       ->addJoin('Activity AS activity', 'LEFT')

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
@@ -30,7 +30,7 @@ function _civicrm_api3_goonjcustom_volunteer_induction_reminder_cron_spec(&$spec
 function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
   $returnValues = [];
   $today = new DateTimeImmutable();
-  $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+
   // Limit the number of emails per batch.
   $batchSize = 20;
   // Start from the first offset.

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
@@ -5,8 +5,8 @@
  */
 
 use Civi\Api4\Individual;
-use Civi\InductionService;
 use Civi\HelperService;
+use Civi\InductionService;
 
 /**
  * Custom.VolunteerInductionReminderCron API specification.
@@ -30,31 +30,48 @@ function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
   $returnValues = [];
   $today = new DateTimeImmutable();
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+  // Limit the number of emails per batch.
+  $batchSize = 20;
+  // Start from the first offset.
+  $offset = 0;
 
   // Get the default "from" email.
   $from = HelperService::getDefaultFromEmail();
 
-  // Fetch volunteers who have registered but not scheduled an induction.
-  $volunteers = Individual::get(TRUE)
-    ->addSelect('created_date', 'display_name', 'email_primary.email', 'Volunteer_fields.Last_Reminder_Sent')
-    ->addJoin('Activity AS activity', 'LEFT')
-    ->addWhere('activity.activity_type_id', '=', 57)
-    ->addWhere('activity.status_id', '=', 9)
-    ->addWhere('contact_sub_type', '=', 'Volunteer')
-    ->addWhere('created_date', '<=', (new DateTime())->format('Y-m-d H:i:s'))
-    ->execute();
+  while (TRUE) {
+    // Fetch volunteers who have registered but not scheduled an induction.
+    $volunteers = Individual::get(TRUE)
+      ->addSelect('created_date', 'display_name', 'email_primary.email', 'Volunteer_fields.Last_Reminder_Sent')
+      ->addJoin('Activity AS activity', 'LEFT')
+      ->addWhere('activity.activity_type_id', '=', 57)
+      ->addWhere('activity.status_id', '=', 9)
+      ->addWhere('contact_sub_type', '=', 'Volunteer')
+      ->addWhere('created_date', '<=', (new DateTime())->format('Y-m-d H:i:s'))
+      ->setLimit($batchSize)
+      ->setOffset($offset)
+      ->execute();
 
-  foreach ($volunteers as $volunteer) {
-    error_log("volunteer: " . print_r($volunteer, TRUE));
-    try {
-      InductionService::processInductionReminder($volunteer, $today, $from);
+    // If there are no more volunteers to process, break the loop.
+    if (empty($volunteers)) {
+      break;
     }
-    catch (\Exception $e) {
-      \Civi::log()->error('Error processing volunteer induction reminder', [
-        'id' => $volunteer['id'],
-        'error' => $e->getMessage(),
-      ]);
+
+    // Process each volunteer in the fetched batch.
+    foreach ($volunteers as $volunteer) {
+      error_log("volunteer: " . print_r($volunteer, TRUE));
+      try {
+        InductionService::processInductionReminder($volunteer, $today, $from);
+      }
+      catch (\Exception $e) {
+        \Civi::log()->error('Error processing volunteer induction reminder', [
+          'id' => $volunteer['id'],
+          'error' => $e->getMessage(),
+        ]);
+      }
     }
+
+    // Increment the offset for the next batch.
+    $offset += $batchSize;
   }
 
   return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'volunteer_induction_reminder_cron');

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
@@ -5,6 +5,7 @@
  */
 
 use Civi\Api4\Individual;
+use Civi\Api4\OptionValue;
 use Civi\HelperService;
 use Civi\InductionService;
 
@@ -40,11 +41,25 @@ function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
 
   while (TRUE) {
     // Fetch volunteers who have registered but not scheduled an induction.
+    $activityTypeOptionValue = OptionValue::get(TRUE)
+      ->addWhere('option_group_id:name', '=', 'activity_type')
+      ->addWhere('name', '=', 'Induction')
+      ->execute()->single();
+
+    $activityTypeId = $activityTypeOptionValue['value'];
+
+    $activityStatusOptionValue = OptionValue::get(TRUE)
+      ->addWhere('option_group_id:name', '=', 'activity_status')
+      ->addWhere('name', '=', 'To be scheduled')
+      ->execute()->single();
+
+    $activityStatus = $activityStatusOptionValue['value'];
+
     $volunteers = Individual::get(TRUE)
       ->addSelect('created_date', 'display_name', 'email_primary.email', 'Individual_fields.Last_Reminder_Sent')
       ->addJoin('Activity AS activity', 'LEFT')
-      ->addWhere('activity.activity_type_id', '=', 57)
-      ->addWhere('activity.status_id', '=', 9)
+      ->addWhere('activity.activity_type_id', '=', $activityTypeId)
+      ->addWhere('activity.status_id', '=', $activityStatus)
       ->addWhere('contact_sub_type', '=', 'Volunteer')
       ->addWhere('Individual_fields.Last_Reminder_Sent', 'IS NULL')
       ->addWhere('created_date', '<=', (new DateTime())->format('Y-m-d H:i:s'))

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerInductionReminderCron.php
@@ -56,7 +56,7 @@ function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
     $activityStatus = $activityStatusOptionValue['value'];
 
     $volunteers = Individual::get(TRUE)
-      ->addSelect('created_date', 'display_name', 'email_primary.email', 'Individual_fields.Last_Reminder_Sent')
+      ->addSelect('created_date', 'display_name', 'email_primary.email', 'Individual_fields.Last_Reminder_Sent', 'address_primary.state_province_id')
       ->addJoin('Activity AS activity', 'LEFT')
       ->addWhere('activity.activity_type_id', '=', $activityTypeId)
       ->addWhere('activity.status_id', '=', $activityStatus)
@@ -74,7 +74,6 @@ function civicrm_api3_goonjcustom_volunteer_induction_reminder_cron($params) {
 
     // Process each volunteer in the fetched batch.
     foreach ($volunteers as $volunteer) {
-      error_log("volunteer: " . print_r($volunteer, TRUE));
       try {
         InductionService::processInductionReminder($volunteer, $today, $from);
       }


### PR DESCRIPTION
Volunteer Induction reminder

Target Issue - https://github.com/coloredcow-admin/goonj-crm/issues/121

First, we need to send the **bulk email through the CRM.** 

After that, we will deploy the code to production to identify contacts who have registered as volunteers but haven't scheduled their induction. We'll also check the database for volunteers that have completed 7 days and send them a reminder. Going forward, this check will be automated daily, and any contact who reaches the 7-day mark will receive an email reminder.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced induction process for volunteers with automated reminder emails.
	- Introduced a custom API endpoint for managing volunteer induction reminders.
	- Added functionality to calculate and send induction reminders based on registration and last reminder dates.
	- New methods for sending reminder emails and generating email content.
	- Improved logging of volunteer information during reminder processing.

- **Bug Fixes**
	- Enhanced error logging for reminder processing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->