### PR TITLE
Fix City Value in E-Receipt for Material Contribution in PU

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -69,17 +69,8 @@ class MaterialContributionService extends AutoSubscriber {
     $contribution = $activities->first();
 
     $goonjOfficeId = $contribution['Material_Contribution.Goonj_Office'] ?? null;
-    $city = '';
 
-    if ($goonjOfficeId) {
-
-      $organization = Organization::get(FALSE)
-          ->addSelect('address_primary.city')
-          ->addWhere('id', '=', $goonjOfficeId)
-          ->execute()->single();
-
-      $city = $organization['address_primary.city'];
-    }
+    $city = self::getCityFromGoonjOfficeId($goonjOfficeId);
 
     $contactData = civicrm_api4('Contact', 'get', [
       'select' => [
@@ -134,6 +125,22 @@ class MaterialContributionService extends AutoSubscriber {
     $fileName = 'material_contribution_' . $contribution['id'] . '.pdf';
     $params['attachments'][] = \CRM_Utils_Mail::appendPDF($fileName, $html);
     $params['cc'] = 'crm@goonj.org';
+  }
+
+  private static function getCityFromGoonjOfficeId($goonjOfficeId) {
+    $city = '';
+    if ($goonjOfficeId) {
+        $organization = Organization::get(FALSE)
+            ->addSelect('address_primary.city')
+            ->addWhere('id', '=', $goonjOfficeId)
+            ->execute()->single();
+
+        // Check if organization is found and if 'address_primary.city' exists
+        if ($organization && isset($organization['address_primary.city'])) {
+            $city = $organization['address_primary.city'];
+        }
+    }
+    return $city;
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -135,7 +135,6 @@ class MaterialContributionService extends AutoSubscriber {
             ->addWhere('id', '=', $goonjOfficeId)
             ->execute()->single();
 
-        // Check if organization is found and if 'address_primary.city' exists
         if ($organization && isset($organization['address_primary.city'])) {
             $city = $organization['address_primary.city'];
         }

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -109,9 +109,9 @@ class MaterialContributionService extends AutoSubscriber {
 
     $locationAreaOfCamp = $collectionCamp['Collection_Camp_Intent_Details.Location_Area_of_camp'] ?? 'N/A';
 
-    if (!empty($city)) {
+    if (empty($locationAreaOfCamp) && !empty($city)) {
       $locationAreaOfCamp = $city;
-    }
+    } 
 
     $contactDataArray = $contactData[0] ?? [];
     $email = $contactDataArray['email_primary.email'] ?? 'N/A';

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -4,6 +4,7 @@ namespace Civi;
 
 use Civi\Api4\ActionSchedule;
 use Civi\Api4\Activity;
+use Civi\Api4\Organization;
 use Civi\Core\Service\AutoSubscriber;
 
 /**
@@ -72,12 +73,12 @@ class MaterialContributionService extends AutoSubscriber {
 
     if ($goonjOfficeId) {
 
-      $organization = \Civi\Api4\Organization::get(FALSE)
+      $organization = Organization::get(FALSE)
           ->addSelect('address_primary.city')
           ->addWhere('id', '=', $goonjOfficeId)
           ->execute()->single();
 
-      $city = $organizations['address_primary.city'];
+      $city = $organization['address_primary.city'];
     }
 
     $contactData = civicrm_api4('Contact', 'get', [
@@ -117,7 +118,7 @@ class MaterialContributionService extends AutoSubscriber {
 
     $locationAreaOfCamp = $collectionCamp['Collection_Camp_Intent_Details.Location_Area_of_camp'] ?? 'N/A';
 
-    if ($city !== null) {
+    if (!empty($city)) {
       $locationAreaOfCamp = $city;
     }
 


### PR DESCRIPTION
Issue: When a material contribution is completed in PU, the city value in the e-receipt email is displayed as "N/A" instead of the correct city of PU.

**Root Cause**: The city in the receipt PDF is added via the `locationAreaOfCamp` variable, which is fetched from the collection camp. However, this value was not being correctly set for material contributions, leading to the display of "N/A".

**Solution Implemented**:
- Added the `Material_Contribution.Goonj_Office` field to retrieve the office ID and fetch the correct city for the receipt PDF.
- Implemented the function `getCityFromGoonjOfficeId` to retrieve the office ID and city.
- After fetching the city, I included a check: if both the city and `locationAreaOfCamp` are not null, `locationAreaOfCamp` is assigned the city value.

- Added fix to set city when contribution done in PU 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced email attachments for material contributions to include the Goonj office city information, providing better context in communications.

- **Bug Fixes**
	- Improved handling of location data in contribution receipts to ensure accurate representation of the Goonj office location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->