### PR TITLE
Refactor date and address handling logic for collection camps and dropping centers 

### DIFF
--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -30,6 +30,14 @@ $material_contribution_link = sprintf(
 	$action_target['Collection_Camp_Intent_Details.City'],
 );
 
+$dropping_center_material_contribution_link = sprintf(
+    '/dropping-center-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
+    $action_target['title'],
+    $action_target['id'],
+	$action_target['Dropping_Centre.State'],
+	$action_target['Dropping_Centre.District_City'],
+);
+
 $pu_visit_check_link = sprintf(
 	'/processing-center/office-visit/?target_id=%s',
 	$action_target['id']
@@ -40,10 +48,30 @@ $pu_material_contribution_check_link = sprintf(
 	$action_target['id']
 );
 
+
+
+$target_data = [
+	'dropping-center' => [
+	  'start_time' => 'Dropping_Centre.Start_Time',
+	  'end_time' => 'Dropping_Centre.End_Time',
+	  'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+	  'contribution_link' => $dropping_center_material_contribution_link,
+	],
+	'collection-camp' => [
+	  'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
+	  'end_time' => 'Collection_Camp_Intent_Details.End_Date',
+	  'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+	  'contribution_link' => $material_contribution_link,
+	],
+  ];
+
 if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
-	$start_date = new DateTime( $action_target['Collection_Camp_Intent_Details.Start_Date'] );
-	$end_date   = new DateTime( $action_target['Collection_Camp_Intent_Details.End_Date'] );
-	$address = $action_target['Collection_Camp_Intent_Details.Location_Area_of_camp'];
+    $target_info = $target_data[$target];
+    
+    $start_date = new DateTime($action_target[$target_info['start_time']]);
+    $end_date = new DateTime($action_target[$target_info['end_time']]);
+    $address = $action_target[$target_info['address']];
+    $contribution_link = $target_info['contribution_link'];
 
 	?>
 	<div class="wp-block-gb-heading-wrapper">
@@ -73,7 +101,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
 		<a href="<?php echo esc_url( $register_link ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Volunteer with Goonj', 'goonj-blocks' ); ?>
 		</a>
-		<a href="<?php echo esc_url( $material_contribution_link ); ?>" class="wp-block-gb-action-button">
+		<a href="<?php echo esc_url( $contribution_link ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Record your Material Contribution', 'goonj-blocks' ); ?>
 		</a>
 	</div>

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -55,12 +55,14 @@ $target_data = [
     'start_time' => 'Dropping_Centre.Start_Time',
     'end_time' => 'Dropping_Centre.End_Time',
     'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+    'address_label' => 'Area of the dropping center',
     'contribution_link' => $dropping_center_material_contribution_link,
   ],
   'collection-camp' => [
     'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
     'end_time' => 'Collection_Camp_Intent_Details.End_Date',
     'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+    'address_label' => 'Address of the camp',
     'contribution_link' => $material_contribution_link,
   ],
 ];
@@ -80,7 +82,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
 
   $address = $action_target[$target_info['address']];
   $contribution_link = $target_info['contribution_link'];
-  $address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
+  $address_label = $target_info['address_label'];
 
   ?>
     <div class="wp-block-gb-heading-wrapper">

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -1,87 +1,91 @@
 <?php
+
 /**
+ * @file
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
 require_once __DIR__ . '/functions.php';
-$target        = get_query_var( 'target' );
-$action_target = get_query_var( 'action_target' );
+$target        = get_query_var('target');
+$action_target = get_query_var('action_target');
 
-$headings = array(
-    'collection-camp' => 'Collection Camp',
-    'dropping-center' => 'Dropping Center',
-    'processing-center' => 'Processing Center',
-);
+$headings = [
+  'collection-camp' => 'Collection Camp',
+  'dropping-center' => 'Dropping Center',
+  'processing-center' => 'Processing Center',
+];
 
-$heading_text = $headings[ $target ];
+$heading_text = $headings[$target];
 
 $register_link = sprintf(
-	'/volunteer-registration/form/#?source=%s&state_province_id=%s&city=%s',
-	$action_target['title'],
-	$action_target['Collection_Camp_Intent_Details.State'],
-	$action_target['Collection_Camp_Intent_Details.City'],
+    '/volunteer-registration/form/#?source=%s&state_province_id=%s&city=%s',
+    $action_target['title'],
+    $action_target['Collection_Camp_Intent_Details.State'],
+    $action_target['Collection_Camp_Intent_Details.City'],
 );
 
 $material_contribution_link = sprintf(
-	'/collection-camp-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
-	$action_target['title'],
-	$action_target['id'],
-	$action_target['Collection_Camp_Intent_Details.State'],
-	$action_target['Collection_Camp_Intent_Details.City'],
+    '/collection-camp-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
+    $action_target['title'],
+    $action_target['id'],
+    $action_target['Collection_Camp_Intent_Details.State'],
+    $action_target['Collection_Camp_Intent_Details.City'],
 );
 
 $dropping_center_material_contribution_link = sprintf(
     '/dropping-center-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
     $action_target['title'],
     $action_target['id'],
-	$action_target['Dropping_Centre.State'],
-	$action_target['Dropping_Centre.District_City'],
+    $action_target['Dropping_Centre.State'],
+    $action_target['Dropping_Centre.District_City'],
 );
 
 $pu_visit_check_link = sprintf(
-	'/processing-center/office-visit/?target_id=%s',
-	$action_target['id']
+    '/processing-center/office-visit/?target_id=%s',
+    $action_target['id']
 );
 
 $pu_material_contribution_check_link = sprintf(
-	'/processing-center/material-contribution/?target_id=%s',
-	$action_target['id']
+    '/processing-center/material-contribution/?target_id=%s',
+    $action_target['id']
 );
 
 $target_data = [
-	'dropping-center' => [
-		'start_time' => 'Dropping_Centre.Start_Time',
-		'end_time' => 'Dropping_Centre.End_Time',
-		'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
-		'contribution_link' => $dropping_center_material_contribution_link,
-	],
-	'collection-camp' => [
-		'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
-		'end_time' => 'Collection_Camp_Intent_Details.End_Date',
-		'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
-		'contribution_link' => $material_contribution_link,
-	],
+  'dropping-center' => [
+    'start_time' => 'Dropping_Centre.Start_Time',
+    'end_time' => 'Dropping_Centre.End_Time',
+    'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+    'contribution_link' => $dropping_center_material_contribution_link,
+  ],
+  'collection-camp' => [
+    'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
+    'end_time' => 'Collection_Camp_Intent_Details.End_Date',
+    'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+    'contribution_link' => $material_contribution_link,
+  ],
 ];
 
-if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
-    $target_info = $target_data[$target];
-    
-    try {
-        $start_date = new DateTime($action_target[$target_info['start_time']]);
-        $end_date = new DateTime($action_target[$target_info['end_time']]);
-    } catch (Exception $e) {
-		Civi::log()->error("Error creating DateTime object: " . $e->getMessage());
-        $start_date = $end_date = new DateTime(); // Default to current date/time
-    }
-    
-    $address = $action_target[$target_info['address']];
-    $contribution_link = $target_info['contribution_link'];
-	$address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
+if (in_array($target, ['collection-camp', 'dropping-center'])) :
+  $target_info = $target_data[$target];
 
-	?>
-	<div class="wp-block-gb-heading-wrapper">
-		<h2 class="wp-block-gb-heading"><?php echo esc_html($heading_text); ?></h2>
-	</div>
+  try {
+    $start_date = new DateTime($action_target[$target_info['start_time']]);
+    $end_date = new DateTime($action_target[$target_info['end_time']]);
+  }
+  catch (Exception $e) {
+    Civi::log()->error("Error creating DateTime object: " . $e->getMessage());
+    // Default to current date/time.
+    $start_date = $end_date = new DateTime();
+  }
+
+  $address = $action_target[$target_info['address']];
+  $contribution_link = $target_info['contribution_link'];
+  $address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
+
+  ?>
+    <div class="wp-block-gb-heading-wrapper">
+        <h2 class="wp-block-gb-heading"><?php echo esc_html($heading_text); ?></h2>
+    </div>
     <table class="wp-block-gb-table">
         <tbody>
             <tr class="wp-block-gb-table-row">
@@ -97,34 +101,34 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
             <tr class="wp-block-gb-table-row">
-				<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
+                <td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>
             </tr>
         </tbody>
     </table>
-	<div <?php echo get_block_wrapper_attributes(); ?>>
-		<a href="<?php echo esc_url( $register_link ); ?>" class="wp-block-gb-action-button">
-			<?php esc_html_e( 'Volunteer with Goonj', 'goonj-blocks' ); ?>
-		</a>
-		<a href="<?php echo esc_url( $contribution_link ?? '#' ); ?>" class="wp-block-gb-action-button">
-			<?php esc_html_e( 'Record your Material Contribution', 'goonj-blocks' ); ?>
-		</a>
-	</div>
-	<?php elseif ( 'processing-center' === $target ) : ?>
-		<table class="wp-block-gb-table">
-			<tbody>
-				<tr class="wp-block-gb-table-row">
-					<td class="wp-block-gb-table-cell wp-block-gb-table-header">Address</td>
-					<td class="wp-block-gb-table-cell"><?php echo CRM_Utils_Address::format( $action_target['address'] ); ?></td>
-				</tr>
-			</tbody>
-		</table>
-		<div <?php echo get_block_wrapper_attributes(); ?>>
-			<a href="<?php echo esc_url( $pu_visit_check_link ); ?>" class="wp-block-gb-action-button">
-				<?php esc_html_e( 'Office Visit', 'goonj-blocks' ); ?>
-			</a>
-			<a href="<?php echo esc_url( $pu_material_contribution_check_link ); ?>" class="wp-block-gb-action-button">
-				<?php esc_html_e( 'Material Contribution', 'goonj-blocks' ); ?>
-			</a>
-		</div>
-<?php endif;
+    <div <?php echo get_block_wrapper_attributes(); ?>>
+        <a href="<?php echo esc_url($register_link); ?>" class="wp-block-gb-action-button">
+            <?php esc_html_e('Volunteer with Goonj', 'goonj-blocks'); ?>
+        </a>
+        <a href="<?php echo esc_url($contribution_link ?? '#'); ?>" class="wp-block-gb-action-button">
+            <?php esc_html_e('Record your Material Contribution', 'goonj-blocks'); ?>
+        </a>
+    </div>
+  <?php elseif ('processing-center' === $target) : ?>
+        <table class="wp-block-gb-table">
+            <tbody>
+                <tr class="wp-block-gb-table-row">
+                    <td class="wp-block-gb-table-cell wp-block-gb-table-header">Address</td>
+                    <td class="wp-block-gb-table-cell"><?php echo CRM_Utils_Address::format($action_target['address']); ?></td>
+                </tr>
+            </tbody>
+        </table>
+        <div <?php echo get_block_wrapper_attributes(); ?>>
+            <a href="<?php echo esc_url($pu_visit_check_link); ?>" class="wp-block-gb-action-button">
+                <?php esc_html_e('Office Visit', 'goonj-blocks'); ?>
+            </a>
+            <a href="<?php echo esc_url($pu_material_contribution_check_link); ?>" class="wp-block-gb-action-button">
+                <?php esc_html_e('Material Contribution', 'goonj-blocks'); ?>
+            </a>
+        </div>
+  <?php endif;

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -76,6 +76,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
     
     $address = $action_target[$target_info['address']];
     $contribution_link = $target_info['contribution_link'];
+	$address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
 
 	?>
 	<div class="wp-block-gb-heading-wrapper">
@@ -96,7 +97,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
             <tr class="wp-block-gb-table-row">
-                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Address of the camp</td>
+			<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>
             </tr>
         </tbody>

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -52,18 +52,18 @@ $pu_material_contribution_check_link = sprintf(
 
 $target_data = [
 	'dropping-center' => [
-	  'start_time' => 'Dropping_Centre.Start_Time',
-	  'end_time' => 'Dropping_Centre.End_Time',
-	  'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
-	  'contribution_link' => $dropping_center_material_contribution_link,
+		'start_time' => 'Dropping_Centre.Start_Time',
+		'end_time' => 'Dropping_Centre.End_Time',
+		'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+		'contribution_link' => $dropping_center_material_contribution_link,
 	],
 	'collection-camp' => [
-	  'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
-	  'end_time' => 'Collection_Camp_Intent_Details.End_Date',
-	  'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
-	  'contribution_link' => $material_contribution_link,
+		'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
+		'end_time' => 'Collection_Camp_Intent_Details.End_Date',
+		'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+		'contribution_link' => $material_contribution_link,
 	],
-  ];
+];
 
 if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
     $target_info = $target_data[$target];

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -48,8 +48,6 @@ $pu_material_contribution_check_link = sprintf(
 	$action_target['id']
 );
 
-
-
 $target_data = [
 	'dropping-center' => [
 		'start_time' => 'Dropping_Centre.Start_Time',

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -66,8 +66,14 @@ $target_data = [
 if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
     $target_info = $target_data[$target];
     
-    $start_date = new DateTime($action_target[$target_info['start_time']]);
-    $end_date = new DateTime($action_target[$target_info['end_time']]);
+    try {
+        $start_date = new DateTime($action_target[$target_info['start_time']]);
+        $end_date = new DateTime($action_target[$target_info['end_time']]);
+    } catch (Exception $e) {
+		Civi::log()->error("Error creating DateTime object: " . $e->getMessage());
+        $start_date = $end_date = new DateTime(); // Default to current date/time
+    }
+    
     $address = $action_target[$target_info['address']];
     $contribution_link = $target_info['contribution_link'];
 
@@ -99,7 +105,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
 		<a href="<?php echo esc_url( $register_link ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Volunteer with Goonj', 'goonj-blocks' ); ?>
 		</a>
-		<a href="<?php echo esc_url( $contribution_link ); ?>" class="wp-block-gb-action-button">
+		<a href="<?php echo esc_url( $contribution_link ?? '#' ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Record your Material Contribution', 'goonj-blocks' ); ?>
 		</a>
 	</div>

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -97,7 +97,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
             <tr class="wp-block-gb-table-row">
-			<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
+				<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>
             </tr>
         </tbody>

--- a/wp-content/plugins/goonj-blocks/goonj-blocks.php
+++ b/wp-content/plugins/goonj-blocks/goonj-blocks.php
@@ -88,6 +88,11 @@ function gb_goonj_blocks_check_action_target_exists() {
 		'Collection_Camp_Intent_Details.Location_Area_of_camp',
 		'Collection_Camp_Intent_Details.City',
 		'Collection_Camp_Intent_Details.State',
+		'Dropping_Centre.Start_Time',
+		'Dropping_Centre.End_Time',
+		'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+		'Dropping_Centre.State',
+		'Dropping_Centre.District_City',
 	);
 
 	switch ( $target ) {

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -30,6 +30,14 @@ $material_contribution_link = sprintf(
 	$action_target['Collection_Camp_Intent_Details.City'],
 );
 
+$dropping_center_material_contribution_link = sprintf(
+    '/dropping-center-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
+    $action_target['title'],
+    $action_target['id'],
+	$action_target['Dropping_Centre.State'],
+	$action_target['Dropping_Centre.District_City'],
+);
+
 $pu_visit_check_link = sprintf(
 	'/processing-center/office-visit/?target_id=%s',
 	$action_target['id']
@@ -40,10 +48,30 @@ $pu_material_contribution_check_link = sprintf(
 	$action_target['id']
 );
 
+
+
+$target_data = [
+	'dropping-center' => [
+	  'start_time' => 'Dropping_Centre.Start_Time',
+	  'end_time' => 'Dropping_Centre.End_Time',
+	  'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+	  'contribution_link' => $dropping_center_material_contribution_link,
+	],
+	'collection-camp' => [
+	  'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
+	  'end_time' => 'Collection_Camp_Intent_Details.End_Date',
+	  'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+	  'contribution_link' => $material_contribution_link,
+	],
+  ];
+
 if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
-	$start_date = new DateTime( $action_target['Collection_Camp_Intent_Details.Start_Date'] );
-	$end_date   = new DateTime( $action_target['Collection_Camp_Intent_Details.End_Date'] );
-	$address = $action_target['Collection_Camp_Intent_Details.Location_Area_of_camp'];
+    $target_info = $target_data[$target];
+    
+    $start_date = new DateTime($action_target[$target_info['start_time']]);
+    $end_date = new DateTime($action_target[$target_info['end_time']]);
+    $address = $action_target[$target_info['address']];
+    $contribution_link = $target_info['contribution_link'];
 
 	?>
 	<div class="wp-block-gb-heading-wrapper">
@@ -73,7 +101,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
 		<a href="<?php echo esc_url( $register_link ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Volunteer with Goonj', 'goonj-blocks' ); ?>
 		</a>
-		<a href="<?php echo esc_url( $material_contribution_link ); ?>" class="wp-block-gb-action-button">
+		<a href="<?php echo esc_url( $contribution_link ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Record your Material Contribution', 'goonj-blocks' ); ?>
 		</a>
 	</div>

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -55,12 +55,14 @@ $target_data = [
     'start_time' => 'Dropping_Centre.Start_Time',
     'end_time' => 'Dropping_Centre.End_Time',
     'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+    'address_label' => 'Area of the dropping center',
     'contribution_link' => $dropping_center_material_contribution_link,
   ],
   'collection-camp' => [
     'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
     'end_time' => 'Collection_Camp_Intent_Details.End_Date',
     'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+    'address_label' => 'Address of the camp',
     'contribution_link' => $material_contribution_link,
   ],
 ];
@@ -80,7 +82,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
 
   $address = $action_target[$target_info['address']];
   $contribution_link = $target_info['contribution_link'];
-  $address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
+  $address_label = $target_info['address_label'];
 
   ?>
     <div class="wp-block-gb-heading-wrapper">

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -1,87 +1,91 @@
 <?php
+
 /**
+ * @file
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
 require_once __DIR__ . '/functions.php';
-$target        = get_query_var( 'target' );
-$action_target = get_query_var( 'action_target' );
+$target        = get_query_var('target');
+$action_target = get_query_var('action_target');
 
-$headings = array(
-    'collection-camp' => 'Collection Camp',
-    'dropping-center' => 'Dropping Center',
-    'processing-center' => 'Processing Center',
-);
+$headings = [
+  'collection-camp' => 'Collection Camp',
+  'dropping-center' => 'Dropping Center',
+  'processing-center' => 'Processing Center',
+];
 
-$heading_text = $headings[ $target ];
+$heading_text = $headings[$target];
 
 $register_link = sprintf(
-	'/volunteer-registration/form/#?source=%s&state_province_id=%s&city=%s',
-	$action_target['title'],
-	$action_target['Collection_Camp_Intent_Details.State'],
-	$action_target['Collection_Camp_Intent_Details.City'],
+    '/volunteer-registration/form/#?source=%s&state_province_id=%s&city=%s',
+    $action_target['title'],
+    $action_target['Collection_Camp_Intent_Details.State'],
+    $action_target['Collection_Camp_Intent_Details.City'],
 );
 
 $material_contribution_link = sprintf(
-	'/collection-camp-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
-	$action_target['title'],
-	$action_target['id'],
-	$action_target['Collection_Camp_Intent_Details.State'],
-	$action_target['Collection_Camp_Intent_Details.City'],
+    '/collection-camp-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
+    $action_target['title'],
+    $action_target['id'],
+    $action_target['Collection_Camp_Intent_Details.State'],
+    $action_target['Collection_Camp_Intent_Details.City'],
 );
 
 $dropping_center_material_contribution_link = sprintf(
     '/dropping-center-contribution?source=%s&target_id=%s&state_province_id=%s&city=%s',
     $action_target['title'],
     $action_target['id'],
-	$action_target['Dropping_Centre.State'],
-	$action_target['Dropping_Centre.District_City'],
+    $action_target['Dropping_Centre.State'],
+    $action_target['Dropping_Centre.District_City'],
 );
 
 $pu_visit_check_link = sprintf(
-	'/processing-center/office-visit/?target_id=%s',
-	$action_target['id']
+    '/processing-center/office-visit/?target_id=%s',
+    $action_target['id']
 );
 
 $pu_material_contribution_check_link = sprintf(
-	'/processing-center/material-contribution/?target_id=%s',
-	$action_target['id']
+    '/processing-center/material-contribution/?target_id=%s',
+    $action_target['id']
 );
 
 $target_data = [
-	'dropping-center' => [
-		'start_time' => 'Dropping_Centre.Start_Time',
-		'end_time' => 'Dropping_Centre.End_Time',
-		'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
-		'contribution_link' => $dropping_center_material_contribution_link,
-	],
-	'collection-camp' => [
-		'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
-		'end_time' => 'Collection_Camp_Intent_Details.End_Date',
-		'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
-		'contribution_link' => $material_contribution_link,
-	],
+  'dropping-center' => [
+    'start_time' => 'Dropping_Centre.Start_Time',
+    'end_time' => 'Dropping_Centre.End_Time',
+    'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+    'contribution_link' => $dropping_center_material_contribution_link,
+  ],
+  'collection-camp' => [
+    'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
+    'end_time' => 'Collection_Camp_Intent_Details.End_Date',
+    'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+    'contribution_link' => $material_contribution_link,
+  ],
 ];
 
-if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
-    $target_info = $target_data[$target];
-    
-    try {
-        $start_date = new DateTime($action_target[$target_info['start_time']]);
-        $end_date = new DateTime($action_target[$target_info['end_time']]);
-    } catch (Exception $e) {
-		Civi::log()->error("Error creating DateTime object: " . $e->getMessage());
-        $start_date = $end_date = new DateTime(); // Default to current date/time
-    }
-    
-    $address = $action_target[$target_info['address']];
-    $contribution_link = $target_info['contribution_link'];
-	$address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
+if (in_array($target, ['collection-camp', 'dropping-center'])) :
+  $target_info = $target_data[$target];
 
-	?>
-	<div class="wp-block-gb-heading-wrapper">
-		<h2 class="wp-block-gb-heading"><?php echo esc_html($heading_text); ?></h2>
-	</div>
+  try {
+    $start_date = new DateTime($action_target[$target_info['start_time']]);
+    $end_date = new DateTime($action_target[$target_info['end_time']]);
+  }
+  catch (Exception $e) {
+    Civi::log()->error("Error creating DateTime object: " . $e->getMessage());
+    // Default to current date/time.
+    $start_date = $end_date = new DateTime();
+  }
+
+  $address = $action_target[$target_info['address']];
+  $contribution_link = $target_info['contribution_link'];
+  $address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
+
+  ?>
+    <div class="wp-block-gb-heading-wrapper">
+        <h2 class="wp-block-gb-heading"><?php echo esc_html($heading_text); ?></h2>
+    </div>
     <table class="wp-block-gb-table">
         <tbody>
             <tr class="wp-block-gb-table-row">
@@ -97,34 +101,34 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
             <tr class="wp-block-gb-table-row">
-				<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
+                <td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>
             </tr>
         </tbody>
     </table>
-	<div <?php echo get_block_wrapper_attributes(); ?>>
-		<a href="<?php echo esc_url( $register_link ); ?>" class="wp-block-gb-action-button">
-			<?php esc_html_e( 'Volunteer with Goonj', 'goonj-blocks' ); ?>
-		</a>
-		<a href="<?php echo esc_url( $contribution_link ?? '#' ); ?>" class="wp-block-gb-action-button">
-			<?php esc_html_e( 'Record your Material Contribution', 'goonj-blocks' ); ?>
-		</a>
-	</div>
-	<?php elseif ( 'processing-center' === $target ) : ?>
-		<table class="wp-block-gb-table">
-			<tbody>
-				<tr class="wp-block-gb-table-row">
-					<td class="wp-block-gb-table-cell wp-block-gb-table-header">Address</td>
-					<td class="wp-block-gb-table-cell"><?php echo CRM_Utils_Address::format( $action_target['address'] ); ?></td>
-				</tr>
-			</tbody>
-		</table>
-		<div <?php echo get_block_wrapper_attributes(); ?>>
-			<a href="<?php echo esc_url( $pu_visit_check_link ); ?>" class="wp-block-gb-action-button">
-				<?php esc_html_e( 'Office Visit', 'goonj-blocks' ); ?>
-			</a>
-			<a href="<?php echo esc_url( $pu_material_contribution_check_link ); ?>" class="wp-block-gb-action-button">
-				<?php esc_html_e( 'Material Contribution', 'goonj-blocks' ); ?>
-			</a>
-		</div>
-<?php endif;
+    <div <?php echo get_block_wrapper_attributes(); ?>>
+        <a href="<?php echo esc_url($register_link); ?>" class="wp-block-gb-action-button">
+            <?php esc_html_e('Volunteer with Goonj', 'goonj-blocks'); ?>
+        </a>
+        <a href="<?php echo esc_url($contribution_link ?? '#'); ?>" class="wp-block-gb-action-button">
+            <?php esc_html_e('Record your Material Contribution', 'goonj-blocks'); ?>
+        </a>
+    </div>
+  <?php elseif ('processing-center' === $target) : ?>
+        <table class="wp-block-gb-table">
+            <tbody>
+                <tr class="wp-block-gb-table-row">
+                    <td class="wp-block-gb-table-cell wp-block-gb-table-header">Address</td>
+                    <td class="wp-block-gb-table-cell"><?php echo CRM_Utils_Address::format($action_target['address']); ?></td>
+                </tr>
+            </tbody>
+        </table>
+        <div <?php echo get_block_wrapper_attributes(); ?>>
+            <a href="<?php echo esc_url($pu_visit_check_link); ?>" class="wp-block-gb-action-button">
+                <?php esc_html_e('Office Visit', 'goonj-blocks'); ?>
+            </a>
+            <a href="<?php echo esc_url($pu_material_contribution_check_link); ?>" class="wp-block-gb-action-button">
+                <?php esc_html_e('Material Contribution', 'goonj-blocks'); ?>
+            </a>
+        </div>
+  <?php endif;

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -76,6 +76,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
     
     $address = $action_target[$target_info['address']];
     $contribution_link = $target_info['contribution_link'];
+	$address_label = ($target === 'dropping-center') ? 'Area of the dropping center' : 'Address of the camp';
 
 	?>
 	<div class="wp-block-gb-heading-wrapper">
@@ -96,7 +97,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
             <tr class="wp-block-gb-table-row">
-                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Address of the camp</td>
+			<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>
             </tr>
         </tbody>

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -52,18 +52,18 @@ $pu_material_contribution_check_link = sprintf(
 
 $target_data = [
 	'dropping-center' => [
-	  'start_time' => 'Dropping_Centre.Start_Time',
-	  'end_time' => 'Dropping_Centre.End_Time',
-	  'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
-	  'contribution_link' => $dropping_center_material_contribution_link,
+		'start_time' => 'Dropping_Centre.Start_Time',
+		'end_time' => 'Dropping_Centre.End_Time',
+		'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
+		'contribution_link' => $dropping_center_material_contribution_link,
 	],
 	'collection-camp' => [
-	  'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
-	  'end_time' => 'Collection_Camp_Intent_Details.End_Date',
-	  'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
-	  'contribution_link' => $material_contribution_link,
+		'start_time' => 'Collection_Camp_Intent_Details.Start_Date',
+		'end_time' => 'Collection_Camp_Intent_Details.End_Date',
+		'address' => 'Collection_Camp_Intent_Details.Location_Area_of_camp',
+		'contribution_link' => $material_contribution_link,
 	],
-  ];
+];
 
 if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
     $target_info = $target_data[$target];

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -48,8 +48,6 @@ $pu_material_contribution_check_link = sprintf(
 	$action_target['id']
 );
 
-
-
 $target_data = [
 	'dropping-center' => [
 		'start_time' => 'Dropping_Centre.Start_Time',

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -66,8 +66,14 @@ $target_data = [
 if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
     $target_info = $target_data[$target];
     
-    $start_date = new DateTime($action_target[$target_info['start_time']]);
-    $end_date = new DateTime($action_target[$target_info['end_time']]);
+    try {
+        $start_date = new DateTime($action_target[$target_info['start_time']]);
+        $end_date = new DateTime($action_target[$target_info['end_time']]);
+    } catch (Exception $e) {
+		Civi::log()->error("Error creating DateTime object: " . $e->getMessage());
+        $start_date = $end_date = new DateTime(); // Default to current date/time
+    }
+    
     $address = $action_target[$target_info['address']];
     $contribution_link = $target_info['contribution_link'];
 
@@ -99,7 +105,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
 		<a href="<?php echo esc_url( $register_link ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Volunteer with Goonj', 'goonj-blocks' ); ?>
 		</a>
-		<a href="<?php echo esc_url( $contribution_link ); ?>" class="wp-block-gb-action-button">
+		<a href="<?php echo esc_url( $contribution_link ?? '#' ); ?>" class="wp-block-gb-action-button">
 			<?php esc_html_e( 'Record your Material Contribution', 'goonj-blocks' ); ?>
 		</a>
 	</div>

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -97,7 +97,7 @@ if ( in_array( $target, array( 'collection-camp', 'dropping-center' ) ) ) :
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
             <tr class="wp-block-gb-table-row">
-			<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
+				<td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>
             </tr>
         </tbody>


### PR DESCRIPTION
This PR updates how we manage the start date, end date, and address fields for both collection camps and dropping centers.

1. We added a configuration array to select the right fields based on the type of target (either collection camp or dropping center).

<img width="599" alt="image" src="https://github.com/user-attachments/assets/fccb55d9-4672-4392-85ab-a8418722eba9">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new link for material contributions related to the "dropping-center."
	- Added new fields for 'Dropping Centre' to enhance data retrieval in the plugin.

- **Improvements**
	- Streamlined handling of material contributions with a new associative array for better data organization.
	- Updated contribution links in the volunteer section for dynamic URL generation based on selected targets.
	- Enhanced error handling for date-related operations to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->