### PR TITLE
Dropping Center Material Contribution Workflow

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -177,11 +177,6 @@ class CollectionBaseService extends AutoSubscriber {
         'module' => 'afsearchEventVolunteer',
         'directive' => 'afsearch-event-volunteer',
       ],
-      'materialContribution' => [
-        'title' => ts('Material Contribution'),
-        'module' => 'afsearchCollectionCampMaterialContributions',
-        'directive' => 'afsearch-collection-camp-material-contributions',
-      ],
       'vehicleDispatch' => [
         'title' => ts('Dispatch'),
         'module' => 'afsearchCampVehicleDispatchData',

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -84,6 +84,12 @@ class CollectionCampService extends AutoSubscriber {
       //   'directive' => 'afsearch-collection-camp-activity',
       //   'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       // ],
+      'materialContribution' => [
+        'title' => ts('Material Contribution'),
+        'module' => 'afsearchCollectionCampMaterialContributions',
+        'directive' => 'afsearch-collection-camp-material-contributions',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
       'logistics' => [
         'title' => ts('Logistics'),
         'module' => 'afsearchCollectionCampLogistics',

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -78,6 +78,11 @@ class DroppingCenterService extends AutoSubscriber {
       return;
     }
     $tabConfigs = [
+      'materialContribution' => [
+        'title' => ts('Material Contribution'),
+        'module' => 'afsearchDroppingCenterMaterialContributions',
+        'directive' => 'afsearch-dropping-center-material-contributions',
+      ],
       'status' => [
         'title' => ts('Status'),
         'module' => 'afsearchDroppingCenterStatus',

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -231,12 +231,6 @@ class DroppingCenterService extends AutoSubscriber {
         'directive' => 'afsearch-dropping-center-material-contributions',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
-      'materialContribution' => [
-        'title' => ts('Material Contribution'),
-        'module' => 'afsearchDroppingCenterMaterialContributions',
-        'directive' => 'afsearch-dropping-center-material-contributions',
-        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      ],
       'status' => [
         'title' => ts('Status'),
         'module' => 'afsearchDroppingCenterStatus',

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -84,6 +84,12 @@ class DroppingCenterService extends AutoSubscriber {
         'directive' => 'afsearch-dropping-center-material-contributions',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
+      'materialContribution' => [
+        'title' => ts('Material Contribution'),
+        'module' => 'afsearchDroppingCenterMaterialContributions',
+        'directive' => 'afsearch-dropping-center-material-contributions',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
       'status' => [
         'title' => ts('Status'),
         'module' => 'afsearchDroppingCenterStatus',

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -82,6 +82,7 @@ class DroppingCenterService extends AutoSubscriber {
         'title' => ts('Material Contribution'),
         'module' => 'afsearchDroppingCenterMaterialContributions',
         'directive' => 'afsearch-dropping-center-material-contributions',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
       'status' => [
         'title' => ts('Status'),

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -572,7 +572,6 @@ function goonj_redirect_after_individual_creation() {
 			// First, we check if the source of Individual is Collection Camp (or Dropping Center).
 			$collectionCamp = \Civi\Api4\EckEntity::get( 'Collection_Camp', FALSE )
 				->addWhere( 'title', '=', $source )
-				->setLimit( 1 )
 				->execute()->first();
 
 			if ( ! empty( $collectionCamp['id'] ) ) {
@@ -594,7 +593,6 @@ function goonj_redirect_after_individual_creation() {
 				// First, we check if the source of Individual is Dropping Center.
 				$droppingCenter = \Civi\Api4\EckEntity::get( 'Collection_Camp', false )
 					->addWhere( 'title', '=', $source )
-					->setLimit( 1 )
 					->execute()->first();
 	
 				if ( ! empty( $droppingCenter['id'] ) ) {

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -569,8 +569,8 @@ function goonj_redirect_after_individual_creation() {
 			// If the individual was created while in the process of material contribution,
 			// then we need to find out from WHERE was she trying to contribute.
 
-			// First, we check if the source of Individual is Colllection Camp (or Dropping Center).
-			$collectionCamp = \Civi\Api4\EckEntity::get( 'Collection_Camp', false )
+			// First, we check if the source of Individual is Collection Camp (or Dropping Center).
+			$collectionCamp = \Civi\Api4\EckEntity::get( 'Collection_Camp', FALSE )
 				->addWhere( 'title', '=', $source )
 				->setLimit( 1 )
 				->execute()->first();
@@ -588,19 +588,19 @@ function goonj_redirect_after_individual_creation() {
 					\Civi::log()->warning('Source is missing for material contribution flow', ['individualId' => $_GET['individualId']]);
 					return;
 				}
-				// If the individual was created while in the process of material contribution,
-				// then we need to find out from WHERE was she trying to contribute.
+				// If the individual was created during a material contribution process,
+				// We need to determine from where they were attempting to contribute.
 	
-				// First, we check if the source of Individual is Colllection Camp (or Dropping Center).
-				$collectionCamp = \Civi\Api4\EckEntity::get( 'Collection_Camp', false )
+				// First, we check if the source of Individual is Collection Camp (or Dropping Center).
+				$droppingCenter = \Civi\Api4\EckEntity::get( 'Collection_Camp', false )
 					->addWhere( 'title', '=', $source )
 					->setLimit( 1 )
 					->execute()->first();
 	
-				if ( ! empty( $collectionCamp['id'] ) ) {
+				if ( ! empty( $droppingCenter['id'] ) ) {
 					$redirectPath = sprintf(
 						'/dropping-center/material-contribution/#?Material_Contribution.Dropping_Center=%s&source_contact_id=%s',
-						$collectionCamp['id'],
+						$droppingCenter['id'],
 						$individual['id']
 					);
 					break;

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -591,7 +591,7 @@ function goonj_redirect_after_individual_creation() {
 				// If the individual was created during a material contribution process,
 				// We need to determine from where they were attempting to contribute.
 	
-				// First, we check if the source of Individual is Collection Camp (or Dropping Center).
+				// First, we check if the source of Individual is Dropping Center.
 				$droppingCenter = \Civi\Api4\EckEntity::get( 'Collection_Camp', false )
 					->addWhere( 'title', '=', $source )
 					->setLimit( 1 )

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -279,29 +279,27 @@ function goonj_handle_user_identification_form() {
 			exit;
 		}
 
-		$allowedPurposes = ['material-contribution', 'dropping-center-contribution'];
-
-		// If we are here, then it means for sure that the contact exists.
-		if (in_array($purpose, $allowedPurposes)) {
-			if ($purpose === 'material-contribution') {
-				$form_path = sprintf(
-					'/material-contribution/#?email=%s&phone=%s&Material_Contribution.Collection_Camp=%s&source_contact_id=%s',
-					$email,
-					$phone,
-					$target_id,
-					$found_contacts['id']
-				);
-			} elseif ($purpose === 'dropping-center-contribution') {
-				$form_path = sprintf(
-					'/dropping-center/material-contribution/#?email=%s&phone=%s&Material_Contribution.Dropping_Center=%s&source_contact_id=%s',
-					$email,
-					$phone,
-					$target_id,
-					$found_contacts['id']
-				);
-			}
-			
-			wp_redirect($form_path);
+		// If we are here, then it means for sure that the contact exists.	
+		if ($purpose === 'material-contribution') {
+			$material_contribution_form_Path = sprintf(
+				'/material-contribution/#?email=%s&phone=%s&Material_Contribution.Collection_Camp=%s&source_contact_id=%s',
+				$email,
+				$phone,
+				$target_id,
+				$found_contacts['id']
+			);
+			wp_redirect( $material_contribution_form_Path );
+			exit;
+		}
+		if ($purpose === 'dropping-center-contribution') {
+			$dropping_center_form_path = sprintf(
+				'/dropping-center/material-contribution/#?email=%s&phone=%s&Material_Contribution.Dropping_Center=%s&source_contact_id=%s',
+				$email,
+				$phone,
+				$target_id,
+				$found_contacts['id']
+			);
+			wp_redirect( $dropping_center_form_path );
 			exit;
 		}
 
@@ -484,6 +482,7 @@ function goonj_redirect_after_individual_creation() {
 			// First, we check if the source of Individual is Collection Camp (or Dropping Center).
 			$collectionCamp = \Civi\Api4\EckEntity::get( 'Collection_Camp', FALSE )
 				->addWhere( 'title', '=', $source )
+				->addWhere('subtype:name', '=', 'Collection_Camp')
 				->execute()->first();
 
 			if ( ! empty( $collectionCamp['id'] ) ) {
@@ -505,6 +504,7 @@ function goonj_redirect_after_individual_creation() {
 				// First, we check if the source of Individual is Dropping Center.
 				$droppingCenter = \Civi\Api4\EckEntity::get( 'Collection_Camp', false )
 					->addWhere( 'title', '=', $source )
+					->addWhere('subtype:name', '=', 'Dropping_Center')
 					->execute()->first();
 	
 				if ( ! empty( $droppingCenter['id'] ) ) {

--- a/wp-content/themes/goonj-crm/templates/form-check-user.php
+++ b/wp-content/themes/goonj-crm/templates/form-check-user.php
@@ -9,7 +9,7 @@ $source = get_query_var('source', '');
 $state_id = get_query_var('state_province_id', '');
 $city = get_query_var('city', '');
 
-$is_purpose_requiring_email = !in_array($purpose, ['material-contribution', 'processing-center-office-visit', 'processing-center-material-contribution']);
+$is_purpose_requiring_email = !in_array($purpose, ['material-contribution', 'processing-center-office-visit', 'processing-center-material-contribution', 'dropping-center-contribution']);
 ?>
 
 <div class="text-center w-xl-520 m-auto">


### PR DESCRIPTION
### Description 

1. Created a new material contribution form for the dropping center.
2. Developed a login page for material contributions, accessible at the URL: `dropping-center-contribution`
3. If the user is not already registered in the system, the individual registration form will be displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a new tab for "Material Contribution" in the collection camp based on context.
	- Introduced a new tab for 'materialContribution' in the dropping center.
	- New link for material contributions specific to the "dropping-center" in the rendering process.

- **Improvements**
	- Enhanced user identification and redirection logic for the "dropping-center-contribution."
	- Streamlined handling of existing contacts during user redirection.
	- Improved error handling and contribution links for the "dropping-center" in the rendering process.
	- Updated logic for email input requirement in the user identification form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->