### PR TITLE
Fix the condition for Camp outcome reminder

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampOutcomeService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampOutcomeService.php
@@ -40,7 +40,7 @@ class CollectionCampOutcomeService {
     }
 
     // Return if 24 hours have not passed since the last reminder.
-    if ($hoursSinceLastReminder < 24) {
+    if ($lastReminderSent !== NULL && $hoursSinceLastReminder < 24) {
       return FALSE;
     }
     self::sendOutcomeReminderEmail($campAttendedById, $from, $campCode, $campAddress, $collectionCampId, $endDateString);


### PR DESCRIPTION
Fix the condition for outcome reminder

 added a new check $lastReminderSent !== NULL:
 ```
 if ($lastReminderSent !== NULL && $hoursSinceLastReminder < 24) {
    return FALSE;
}
 ```
 This check is necessary because, without it, the function would never run correctly. Previously, the condition `$hoursSinceLastReminder < 24` would always return TRUE on the first run since hoursSinceLastReminder is NULL (treated as 0 on the first execution). As a result, the function would exit early. By adding the $lastReminderSent !== NULL check, we ensure that this condition only evaluates when a reminder has already been sent. This prevents the function from exiting prematurely on the first run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced reminder email logic to prevent errors when no previous reminder has been sent.
	- Added a new parameter for specifying the sender's email address in the reminder email function.

- **Bug Fixes**
	- Improved conditions for sending reminder emails to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->