### PR TITLE
Add Dynamic Button for PU Activities using shortcode: Proceed to Office Visit or Material Contribution

### DIFF
--- a/wp-content/themes/goonj-crm/engine/helpers.php
+++ b/wp-content/themes/goonj-crm/engine/helpers.php
@@ -1,0 +1,55 @@
+<?php
+
+// Function to determine Goonj Office ID based on activity type
+function goonj_get_goonj_office_id( $activity ) {
+	$activityTypeName = $activity['activity_type_id:name'];
+	$officeMapping = array(
+		'Material Contribution' => 'Material_Contribution.Goonj_Office',
+		'Office visit' => 'Office_Visit.Goonj_Processing_Center',
+	);
+	$officeCustomFieldName = $officeMapping[$activityTypeName];
+
+	return $activity[$officeCustomFieldName];
+	// return array_key_exists( $activityTypeName, $officeMapping ) ? $activity[ $officeMapping[ $activityTypeName ] ] ?? null : null;
+}
+
+// Function to generate the redirect URL and button for the next pending activity
+function goonj_generate_activity_button( $activity, $office_id, $individual_id ) {
+	// Define all activity types to check pending activities
+	$activityTypes = array( 'Office visit', 'Material Contribution' );
+
+	// Activity type that contact has already completed
+	$completedActivityType = $activity['activity_type_id:name'];
+
+	// Calculate the pending activities by comparing with $activityTypes
+	$pendingActivities = array_diff( $activityTypes, array( $completedActivityType ) );
+
+	// Define the mapping for each activity to the corresponding button and redirect info
+	$activityMap = array(
+		'Office visit' => array(
+			'redirectPath' => '/processing-center/office-visit/details/',
+			'buttonText' => __( 'Proceed to Office Visit', 'goonj-crm' ),
+			'queryParam' => 'Office_Visit.Goonj_Processing_Center',
+		),
+		'Material Contribution' => array(
+			'redirectPath' => '/processing-center/material-contribution/details/',
+			'buttonText' => __( 'Proceed to Material Contribution', 'goonj-crm' ),
+			'queryParam' => 'Material_Contribution.Goonj_Office',
+		),
+	);
+
+	// Get the next pending activity
+	$nextActivity = reset( $pendingActivities );
+	$details = $activityMap[ $nextActivity ];
+
+	// Prepare the URL with query params
+	$redirectParams = array(
+		'source_contact_id' => $individual_id,
+		$details['queryParam'] => $office_id,
+	);
+
+	$redirectPathWithParams = $details['redirectPath'] . '#?' . http_build_query( $redirectParams );
+
+	// Generate and return the button HTML
+	return goonj_generate_button_html( $redirectPathWithParams, $details['buttonText'] );
+}

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -1,0 +1,133 @@
+<?php
+
+add_shortcode( 'goonj_check_user_form', 'goonj_check_user_action' );
+add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
+add_shortcode( 'goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button' );
+add_shortcode( 'goonj_pu_activity_button', 'goonj_pu_activity_button' );
+add_shortcode( 'goonj_collection_landing_page', 'goonj_collection_camp_landing_page' );
+add_shortcode( 'goonj_collection_camp_past', 'goonj_collection_camp_past_data' );
+
+function goonj_check_user_action( $atts ) {
+	get_template_part( 'templates/form', 'check-user', array( 'purpose' => $atts['purpose'] ) );
+	return ob_get_clean();
+}
+
+function goonj_generate_button_html( $button_url, $button_text ) {
+	ob_start();
+	get_template_part(
+		'templates/primary-button',
+		null,
+		array(
+			'button_url' => $button_url,
+			'button_text' => $button_text,
+		)
+	);
+
+	return ob_get_clean();
+}
+
+function goonj_contribution_volunteer_signup_button() {
+	$activity_id = isset( $_GET['activityId'] ) ? intval( $_GET['activityId'] ) : 0;
+
+	if ( empty( $activity_id ) ) {
+		\Civi::log()->warning( 'Activity ID is missing' );
+		return;
+	}
+
+	try {
+		$activities = \Civi\Api4\Activity::get( false )
+			->addSelect( 'source_contact_id' )
+			->addJoin( 'ActivityContact AS activity_contact', 'LEFT' )
+			->addWhere( 'id', '=', $activity_id )
+			->addWhere( 'activity_type_id:label', '=', 'Material Contribution' )
+			->execute();
+
+		if ( $activities->count() === 0 ) {
+			\Civi::log()->info( 'No activities found for Activity ID:', array( 'activityId' => $activity_id ) );
+			return;
+		}
+
+		$activity = $activities->first();
+		$individual_id = $activity['source_contact_id'];
+
+		$contact = \Civi\Api4\Contact::get( false )
+			->addSelect( 'contact_sub_type' )
+			->addWhere( 'id', '=', $individual_id )
+			->execute()
+			->first();
+
+		if ( empty( $contact ) ) {
+			\Civi::log()->info( 'Contact not found', array( 'contact' => $contact['id'] ) );
+			return;
+		}
+
+		$contactSubTypes = $contact['contact_sub_type'] ?? array();
+
+		// If the individual is already a volunteer, don't show the button
+		if ( in_array( 'Volunteer', $contactSubTypes ) ) {
+			return;
+		}
+
+		$redirectPath = '/volunteer-registration/form-with-details/';
+		$redirectPathWithParams = $redirectPath . '#?' . http_build_query(
+			array(
+				'Individual1' => $individual_id,
+				'message' => 'individual-user',
+			)
+		);
+		$buttonText = __( 'Wish to Volunteer?', 'goonj-crm' );
+
+		return goonj_generate_button_html( $redirectPathWithParams, $buttonText );
+	} catch ( \Exception $e ) {
+		\Civi::log()->error( 'Error in goonj_contribution_volunteer_signup_button: ' . $e->getMessage() );
+		return;
+	}
+}
+
+function goonj_pu_activity_button() {
+	if ( ! isset( $_GET['activityId'] ) ) {
+		return;
+	}
+
+	$activity_id = absint( $_GET['activityId'] );
+
+	try {
+		$activity = \Civi\Api4\Activity::get(false)
+			->addSelect('source_contact_id', 'Office_Visit.Goonj_Processing_Center', 'Material_Contribution.Goonj_Office', 'activity_type_id:name')
+			->addWhere('id', '=', $activity_id)
+			->execute()
+			->first();
+		
+		if (!$activity) {
+			\Civi::log()->info('No activity found', ['activityId' => $activityId]);
+			return;
+		}
+
+		$individual_id = $activity['source_contact_id'];
+
+		$office_id = goonj_get_goonj_office_id( $activity );
+
+		if ( ! $office_id ) {
+			\Civi::log()->info( 'Goonj Office ID is null for Activity ID:', array( 'activityId' => $activity_id ) );
+			return;
+		}
+
+		return goonj_generate_activity_button( $activity, $office_id, $individual_id );
+
+	} catch ( \Exception $e ) {
+		\Civi::log()->error( 'Error in goonj_pu_activity_button: ' . $e->getMessage() );
+		return;
+	}
+}
+
+function goonj_collection_camp_landing_page() {
+	ob_start();
+	get_template_part( 'templates/collection-landing-page' );
+	return ob_get_clean();
+}
+
+function goonj_collection_camp_past_data() {
+	ob_start();
+	get_template_part( 'templates/collection-camp-data' );
+	return ob_get_clean();
+}

--- a/wp-content/themes/goonj-crm/templates/primary-button.php
+++ b/wp-content/themes/goonj-crm/templates/primary-button.php
@@ -1,0 +1,5 @@
+<div class="volunteer-button-container">
+	<a href="<?php echo esc_url( $args['button_url'] ); ?>" class="wp-block-button__link has-white-color has-vivid-red-background-color has-text-color has-background has-link-color wp-element-button volunteer-button-link">
+		<?php echo esc_html( $args['button_text'] ); ?>
+	</a>
+</div>


### PR DESCRIPTION
Target Issue: [#78](https://github.com/coloredcow-admin/goonj-crm/issues/78#issuecomment-2407219632)

This PR introduces a shortcode, goonj_pu_activity_button, which dynamically displays the appropriate button, either `Proceed to Office Visit` or `Proceed to Material Contribution` based on individual activity. If both activities (Office Visit and Material Contribution) have already been completed for the day, no button will be displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new shortcodes for enhanced user interactions related to volunteer activities and collection camps.
	- Added functions to retrieve office IDs and generate activity buttons.
	- Implemented a new styled button for volunteer actions.

- **Bug Fixes**
	- Removed outdated shortcodes to streamline user identification processes. 

- **Refactor**
	- Improved modularity of code by reorganizing functions and shortcodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->