### PR TITLE
Fix(*): City Value in E-Receipt for Material Contribution in P

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -110,9 +110,10 @@ class MaterialContributionService extends AutoSubscriber {
 
     $locationAreaOfCamp = $collectionCamp['Collection_Camp_Intent_Details.Location_Area_of_camp'] ?? 'N/A';
 
-    if (empty($locationAreaOfCamp) && !empty($city)) {
+    // If locationAreaOfCamp is 'N/A' and city is not empty, assign the value of city to locationAreaOfCamp
+    if ($locationAreaOfCamp === 'N/A' && !empty($city)) {
       $locationAreaOfCamp = $city;
-    } 
+    }
 
     $contactDataArray = $contactData[0] ?? [];
     $email = $contactDataArray['email_primary.email'] ?? 'N/A';

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -119,9 +119,9 @@ class MaterialContributionService extends AutoSubscriber {
     }
 
     $organization = Organization::get(FALSE)
-        ->addSelect('address_primary.city')
-        ->addWhere('id', '=', $officeId)
-        ->execute()->single();
+      ->addSelect('address_primary.city')
+      ->addWhere('id', '=', $officeId)
+      ->execute()->single();
 
     return $organization['address_primary.city'] ?? '';
   }


### PR DESCRIPTION
Issue: When a material contribution is completed in PU, the city value in the e-receipt email is displayed as "N/A" instead of the correct city of PU.

**Root Cause**: The city in the receipt PDF is added via the `locationAreaOfCamp` variable, which is fetched from the collection camp. However, this value was not being correctly set for material contributions, leading to the display of "N/A".

**Solution Implemented**:
- Added the `Material_Contribution.Goonj_Office` field to retrieve the office ID and fetch the correct city for the receipt PDF.
- Implemented the function `getCityFromGoonjOfficeId` to retrieve the office ID and city.
- After fetching the city, I included a check: if both the city and `locationAreaOfCamp` are not null, `locationAreaOfCamp` is assigned the city value.

- Added fix to set city when contribution done in PU 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced email receipt functionality to include location data based on the Goonj office associated with material contributions.
	- Added retrieval of Goonj office ID and city information for improved contextual details in contribution receipts.
	- Introduced methods to streamline city retrieval based on Goonj office ID and associated collection camps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->