### PR TITLE
Fix(*) disable permission check

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -98,6 +98,7 @@ class MaterialContributionService extends AutoSubscriber {
               ['id', '=', $activity['Material_Contribution.Collection_Camp']],
       ],
       'limit' => 1,
+      'checkPermissions' => FALSE,
     ]);
 
     $collectionCamp = $collectionCampData[0] ?? [];

--- a/wp-content/civi-extensions/goonjcustom/Civi/Traits/CollectionSource.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/Traits/CollectionSource.php
@@ -37,6 +37,7 @@ trait CollectionSource {
       'where' => [
               ['id', '=', $entityID],
       ],
+      'checkPermissions' => FALSE,
     ]);
 
     $entityData = $getSubtypeName[0] ?? [];


### PR DESCRIPTION
- Disabled permission check when retrieving the subtype name of a Collection_Camp entity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for fetching and attaching material contribution receipts to emails, allowing broader access to collection camp details.
	- Updated method for retrieving entity subtype names, bypassing permission checks.

- **Bug Fixes**
	- Preserved existing error handling for fetching reminder IDs, ensuring consistent logging of errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->