### PR TITLE
UI Improvement: Display Volunteer Name for Dropping Center, Remove Time Info

### DIFF
--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -52,8 +52,7 @@ $pu_material_contribution_check_link = sprintf(
 
 $target_data = [
   'dropping-center' => [
-    'start_time' => 'Dropping_Centre.Start_Time',
-    'end_time' => 'Dropping_Centre.End_Time',
+    'volunteer_name' => 'Collection_Camp_Core_Details.Contact_Id.display_name',
     'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
     'address_label' => 'Area of the dropping center',
     'contribution_link' => $dropping_center_material_contribution_link,
@@ -83,6 +82,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
   $address = $action_target[$target_info['address']];
   $contribution_link = $target_info['contribution_link'];
   $address_label = $target_info['address_label'];
+  $volunteer_name = $action_target[$target_info['volunteer_name']];
 
   ?>
     <div class="wp-block-gb-heading-wrapper">
@@ -90,6 +90,14 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
     </div>
     <table class="wp-block-gb-table">
         <tbody>
+            <?php if ($target === 'dropping-center') : ?>
+            <tr class="wp-block-gb-table-row">
+                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Goonj volunteer run dropping center (Address)</td>
+                <td class="wp-block-gb-table-cell"><?php echo esc_html($volunteer_name); ?></td>
+            </tr>
+            <?php endif; ?>
+
+            <?php if ($target === 'collection-camp') : ?>
             <tr class="wp-block-gb-table-row">
                 <td class="wp-block-gb-table-cell wp-block-gb-table-header">From</td>
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_date($start_date); ?></td>
@@ -102,6 +110,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
                 <td class="wp-block-gb-table-cell wp-block-gb-table-header">Time</td>
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
+            <?php endif; ?>
             <tr class="wp-block-gb-table-row">
                 <td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -54,7 +54,7 @@ $target_data = [
   'dropping-center' => [
     'volunteer_name' => 'Collection_Camp_Core_Details.Contact_Id.display_name',
     'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
-    'address_label' => 'Area of the dropping center',
+    'address_label' => 'Goonj volunteer run dropping center (Address)',
     'contribution_link' => $dropping_center_material_contribution_link,
   ],
   'collection-camp' => [
@@ -92,7 +92,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
         <tbody>
             <?php if ($target === 'dropping-center') : ?>
             <tr class="wp-block-gb-table-row">
-                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Goonj volunteer run dropping center (Address)</td>
+                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Volunteer name</td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($volunteer_name); ?></td>
             </tr>
             <?php endif; ?>

--- a/wp-content/plugins/goonj-blocks/goonj-blocks.php
+++ b/wp-content/plugins/goonj-blocks/goonj-blocks.php
@@ -88,8 +88,6 @@ function gb_goonj_blocks_check_action_target_exists() {
 		'Collection_Camp_Intent_Details.Location_Area_of_camp',
 		'Collection_Camp_Intent_Details.City',
 		'Collection_Camp_Intent_Details.State',
-		'Dropping_Centre.Start_Time',
-		'Dropping_Centre.End_Time',
 		'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
 		'Dropping_Centre.State',
 		'Dropping_Centre.District_City',

--- a/wp-content/plugins/goonj-blocks/goonj-blocks.php
+++ b/wp-content/plugins/goonj-blocks/goonj-blocks.php
@@ -93,6 +93,7 @@ function gb_goonj_blocks_check_action_target_exists() {
 		'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
 		'Dropping_Centre.State',
 		'Dropping_Centre.District_City',
+		'Collection_Camp_Core_Details.Contact_Id.display_name',
 	);
 
 	switch ( $target ) {

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -52,8 +52,7 @@ $pu_material_contribution_check_link = sprintf(
 
 $target_data = [
   'dropping-center' => [
-    'start_time' => 'Dropping_Centre.Start_Time',
-    'end_time' => 'Dropping_Centre.End_Time',
+    'volunteer_name' => 'Collection_Camp_Core_Details.Contact_Id.display_name',
     'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
     'address_label' => 'Area of the dropping center',
     'contribution_link' => $dropping_center_material_contribution_link,
@@ -83,6 +82,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
   $address = $action_target[$target_info['address']];
   $contribution_link = $target_info['contribution_link'];
   $address_label = $target_info['address_label'];
+  $volunteer_name = $action_target[$target_info['volunteer_name']];
 
   ?>
     <div class="wp-block-gb-heading-wrapper">
@@ -90,6 +90,14 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
     </div>
     <table class="wp-block-gb-table">
         <tbody>
+            <?php if ($target === 'dropping-center') : ?>
+            <tr class="wp-block-gb-table-row">
+                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Goonj volunteer run dropping center (Address)</td>
+                <td class="wp-block-gb-table-cell"><?php echo esc_html($volunteer_name); ?></td>
+            </tr>
+            <?php endif; ?>
+
+            <?php if ($target === 'collection-camp') : ?>
             <tr class="wp-block-gb-table-row">
                 <td class="wp-block-gb-table-cell wp-block-gb-table-header">From</td>
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_date($start_date); ?></td>
@@ -102,6 +110,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
                 <td class="wp-block-gb-table-cell wp-block-gb-table-header">Time</td>
                 <td class="wp-block-gb-table-cell"><?php echo gb_format_time_range($start_date, $end_date); ?></td>
             </tr>
+            <?php endif; ?>
             <tr class="wp-block-gb-table-row">
                 <td class="wp-block-gb-table-cell wp-block-gb-table-header"><?php echo esc_html($address_label); ?></td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($address); ?></td>

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -54,7 +54,7 @@ $target_data = [
   'dropping-center' => [
     'volunteer_name' => 'Collection_Camp_Core_Details.Contact_Id.display_name',
     'address' => 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_',
-    'address_label' => 'Area of the dropping center',
+    'address_label' => 'Goonj volunteer run dropping center (Address)',
     'contribution_link' => $dropping_center_material_contribution_link,
   ],
   'collection-camp' => [
@@ -92,7 +92,7 @@ if (in_array($target, ['collection-camp', 'dropping-center'])) :
         <tbody>
             <?php if ($target === 'dropping-center') : ?>
             <tr class="wp-block-gb-table-row">
-                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Goonj volunteer run dropping center (Address)</td>
+                <td class="wp-block-gb-table-cell wp-block-gb-table-header">Volunteer name</td>
                 <td class="wp-block-gb-table-cell"><?php echo esc_html($volunteer_name); ?></td>
             </tr>
             <?php endif; ?>


### PR DESCRIPTION
### Description

**Changes Made:**
1. Volunteer Name Display: Added functionality to display the volunteer name for the Dropping Center case.
2. Time Information Removal: Removed the "From" and "To" date/time rows from the UI when displaying details for the Dropping Center.

<img width="722" alt="image" src="https://github.com/user-attachments/assets/a0ba26da-ae90-45d2-af77-a51ed29559f4">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added display of volunteer names for the "dropping-center" target.
	- Enhanced data retrieval for collection camp and dropping center entities.

- **Bug Fixes**
	- Removed outdated fields (`start_time` and `end_time`) from the dropping center data structure. 

These updates improve the information presented to users regarding volunteer involvement at dropping centers while maintaining existing functionalities for other targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->