### PR TITLE
Dropping Center Poster Implmentation

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
@@ -41,7 +41,7 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
   ) {
 
     if (empty($row->context['collectionSourceId'])) {
-      \Civi::log()->debug(__CLASS__ . '::' . __METHOD__ . ' There is no collectionSourceId in the context, you can\'t use collection_camp tokens.');
+      \Civi::log()->debug(__CLASS__ . '::' . __METHOD__ . ' There is no collectionSourceId in the context, you can\'t use dropping_center tokens.');
       $row->format('text/plain')->tokens($entity, $field, '');
       return;
     }

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ *
+ */
+
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
+use Civi\Api4\EckEntity;
+use Civi\Api4\Phone;
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\TokenRow;
+
+/**
+ *
+ */
+class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
+
+  const ACTIVITY_TARGET_RECORD_TYPE_ID = 3;
+
+  public function __construct() {
+    parent::__construct('dropping_center', [
+      'venue' => \CRM_Goonjcustom_ExtensionUtil::ts('Venue'),
+      'date' => \CRM_Goonjcustom_ExtensionUtil::ts('Date'),
+      'time' => \CRM_Goonjcustom_ExtensionUtil::ts('Time'),
+      'volunteers' => \CRM_Goonjcustom_ExtensionUtil::ts('Volunteers'),
+      'coordinator' => \CRM_Goonjcustom_ExtensionUtil::ts('Coordinator (Goonj)'),
+      'remarks' => \CRM_Goonjcustom_ExtensionUtil::ts('Remarks'),
+      'type' => \CRM_Goonjcustom_ExtensionUtil::ts('Type (Camp/Drive)'),
+      'address_city' => \CRM_Goonjcustom_ExtensionUtil::ts('City'),
+    ]);
+  }
+
+  /**
+   *
+   */
+  public function evaluateToken(
+    TokenRow $row,
+    $entity,
+    $field,
+    $prefetch = NULL,
+  ) {
+
+    if (empty($row->context['collectionSourceId'])) {
+      \Civi::log()->debug(__CLASS__ . '::' . __METHOD__ . ' There is no collectionSourceId in the context, you can\'t use collection_camp tokens.');
+      $row->format('text/plain')->tokens($entity, $field, '');
+      return;
+    }
+
+    $newCustomData = $row->context['collectionSourceCustomData'];
+
+    $currentCustomData = EckEntity::get('Collection_Camp', FALSE)
+      ->addSelect('custom.*')
+      ->addWhere('id', '=', $row->context['collectionSourceId'])
+      ->execute()->single();
+
+    $collectionSource = array_merge($currentCustomData, $newCustomData);
+
+    switch ($field) {
+      case 'venue':
+        $value = $this->formatVenue($collectionSource);
+        break;
+
+      case 'date':
+      case 'time':
+      case 'type':
+        $start = new DateTime($collectionSource['Dropping_Centre.Start_Date']);
+        $end = new DateTime($collectionSource['Dropping_Centre.End_Date']);
+
+        if ($field === 'type') {
+          $value = $start->format('Y-m-d') === $end->format('Y-m-d') ? 'Camp' : 'Drive';
+        }
+        elseif ($field === 'date') {
+          $value = $this->formatDate($start, $end);
+        }
+        else {
+          $value = $this->formatTime($start, $end);
+        }
+        break;
+
+      case 'volunteers':
+        $value = $this->formatVolunteers($collectionSource);
+        break;
+
+      case 'remarks':
+        $value = $collectionSource['Collection_Camp_Core_Details.Remarks'];
+        break;
+
+      case 'coordinator':
+        $value = $this->formatCoordinator($collectionSource);
+        break;
+
+      case 'address_city':
+        $value = $collectionSource['Dropping_Centre.District_City'];
+        break;
+
+      default:
+        $value = '';
+        break;
+
+    }
+
+    $row->format('text/html')->tokens($entity, $field, $value);
+    $row->format('text/plain')->tokens($entity, $field, $value);
+    return;
+
+  }
+
+  /**
+   *
+   */
+  private function formatDate($start, $end) {
+
+    $startFormatted = $start->format('M jS, Y (l)');
+    $endFormatted = $end->format('M jS, Y (l)');
+
+    if ($start->format('Y-m-d') === $end->format('Y-m-d')) {
+      return $startFormatted;
+    }
+
+    return "$startFormatted - $endFormatted";
+  }
+
+  /**
+   *
+   */
+  private function formatTime($start, $end) {
+
+    $startTime = $start->format('h:i A');
+    $endTime = $end->format('h:i A');
+
+    return "$startTime to $endTime";
+  }
+
+  /**
+   *
+   */
+  private function formatVolunteers($collectionSource) {
+    $initiatorId = $collectionSource['Collection_Camp_Core_Details.Contact_Id'];
+
+    $volunteeringActivities = Activity::get(FALSE)
+      ->addSelect('activity_contact.contact_id')
+      ->addJoin('ActivityContact AS activity_contact', 'LEFT')
+      ->addWhere('activity_type_id:name', '=', 'Volunteering')
+      ->addWhere('Volunteering_Activity.Collection_Camp', '=', $collectionSource['id'])
+      ->addWhere('activity_contact.record_type_id', '=', self::ACTIVITY_TARGET_RECORD_TYPE_ID)
+      ->execute();
+
+    $volunteerIds = array_merge([$initiatorId], $volunteeringActivities->column('activity_contact.contact_id'));
+
+    $volunteers = Contact::get(FALSE)
+      ->addSelect('phone.phone', 'phone.is_primary', 'display_name')
+      ->addJoin('Phone AS phone', 'LEFT')
+      ->addWhere('id', 'IN', $volunteerIds)
+      ->addOrderBy('created_date', 'ASC')
+      ->execute();
+
+    $volunteersArray = $volunteers->jsonSerialize();
+    $volunteersDetails = [];
+
+    foreach ($volunteerIds as $volunteerId) {
+      $primaryVolunteers = array_filter($volunteersArray, function ($volunteer) use ($volunteerId) {
+        return $volunteer['id'] == $volunteerId && $volunteer['phone.is_primary'];
+      });
+
+      if (!empty($primaryVolunteer)) {
+        $volunteersDetails[] = reset($primaryVolunteers);
+      }
+      else {
+        $volunteer = array_filter($volunteersArray, function ($volunteer) use ($volunteerId) {
+          return $volunteer['id'] == $volunteerId;
+        });
+
+        if (!empty($volunteer)) {
+          $volunteersDetails[] = reset($volunteer);
+        }
+      }
+
+    }
+
+    $volunteersWithPhone = array_map(
+      fn($volunteer) => isset($volunteer['phone.phone']) && !empty($volunteer['phone.phone'])
+          ? sprintf('%1$s (%2$s)', $volunteer['display_name'], $volunteer['phone.phone'])
+          : $volunteer['display_name'],
+      $volunteersDetails
+    );
+
+    return join(', ', $volunteersWithPhone);
+  }
+
+  /**
+   *
+   */
+  private function formatVenue($collectionSource) {
+    $addressParts = [
+        $collectionSource['Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_'] ?? '',
+        $collectionSource['Dropping_Centre.District_City'] ?? '',
+        // Uncomment if needed
+        // CRM_Core_PseudoConstant::stateProvince($collectionSource['Dropping_Centre.State']) ?? '',
+        // $collectionSource['Dropping_Centre.Postal_Code'] ?? '',
+    ];
+
+    return join(', ', array_filter($addressParts));
+
+  }
+
+  /**
+   *
+   */
+  private function formatCoordinator($collectionSource) {
+    $officeId = $collectionSource['Dropping_Centre.Goonj_Office'];
+
+    $officePhones = Phone::get(FALSE)
+      ->addSelect('phone')
+      ->addWhere('contact_id', '=', $officeId)
+      ->execute();
+
+    $phoneNumbers = $officePhones->column('phone');
+
+    return sprintf('%1$s (%2$s)', \CRM_Goonjcustom_ExtensionUtil::ts('Team Goonj'), join(', ', $phoneNumbers));
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
@@ -22,11 +22,10 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
     parent::__construct('dropping_center', [
       'venue' => \CRM_Goonjcustom_ExtensionUtil::ts('Venue'),
       'date' => \CRM_Goonjcustom_ExtensionUtil::ts('Date'),
-      'time' => \CRM_Goonjcustom_ExtensionUtil::ts('Time'),
+      'time' => \CRM_Goonjcustom_ExtensionUtil::ts('Timing'),
       'volunteers' => \CRM_Goonjcustom_ExtensionUtil::ts('Volunteers'),
       'coordinator' => \CRM_Goonjcustom_ExtensionUtil::ts('Coordinator (Goonj)'),
       'remarks' => \CRM_Goonjcustom_ExtensionUtil::ts('Remarks'),
-      'type' => \CRM_Goonjcustom_ExtensionUtil::ts('Type (Camp/Drive)'),
       'address_city' => \CRM_Goonjcustom_ExtensionUtil::ts('City'),
     ]);
   }
@@ -62,21 +61,10 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
         break;
 
       case 'date':
-      case 'time':
-      case 'type':
-        $start = new DateTime($collectionSource['Dropping_Centre.Start_Date']);
-        $end = new DateTime($collectionSource['Dropping_Centre.End_Date']);
 
-        if ($field === 'type') {
-          $value = $start->format('Y-m-d') === $end->format('Y-m-d') ? 'Camp' : 'Drive';
-        }
-        elseif ($field === 'date') {
-          $value = $this->formatDate($start, $end);
-        }
-        else {
-          $value = $this->formatTime($start, $end);
-        }
-        break;
+      // @todo Update the data timing field for the poster.
+      // Need to adjust and implement the logic for formatting the start and end time.
+      case 'time':
 
       case 'volunteers':
         $value = $this->formatVolunteers($collectionSource);
@@ -193,11 +181,11 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
    */
   private function formatVenue($collectionSource) {
     $addressParts = [
-        $collectionSource['Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_'] ?? '',
-        $collectionSource['Dropping_Centre.District_City'] ?? '',
+      $collectionSource['Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_'] ?? '',
+      $collectionSource['Dropping_Centre.District_City'] ?? '',
         // Uncomment if needed
         // CRM_Core_PseudoConstant::stateProvince($collectionSource['Dropping_Centre.State']) ?? '',
-        // $collectionSource['Dropping_Centre.Postal_Code'] ?? '',
+        // $collectionSource['Dropping_Centre.Postal_Code'] ?? '',.
     ];
 
     return join(', ', array_filter($addressParts));

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
@@ -62,9 +62,9 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
 
       case 'date':
 
-      // @todo Update the data timing field for the poster.
-      // Need to adjust and implement the logic for formatting the start and end time.
       case 'time':
+        $value = $collectionSource['Dropping_Centre.Timing'];
+        break;
 
       case 'volunteers':
         $value = $this->formatVolunteers($collectionSource);

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -11,11 +11,13 @@ use Civi\Api4\GroupContact;
 use Civi\Api4\MessageTemplate;
 use Civi\Api4\OptionValue;
 use Civi\Core\Service\AutoSubscriber;
+use Civi\Traits\CollectionSource;
 
 /**
  *
  */
 class CollectionBaseService extends AutoSubscriber {
+  use CollectionSource;
 
   const ENTITY_NAME = 'Collection_Camp';
   const INTENT_CUSTOM_GROUP_NAME = 'Collection_Camp_Intent_Details';
@@ -65,6 +67,22 @@ class CollectionBaseService extends AutoSubscriber {
   /**
    *
    */
+  private static function generateBaseFileName($collectionSourceId) {
+    if (self::getEntitySubtypeName($collectionSourceId) == self::ENTITY_NAME) {
+      $baseFileName = "collection_camp_{$collectionSourceId}.png";
+      error_log("collebaseFileName: " . print_r($baseFileName, TRUE));
+    }
+    else {
+      $baseFileName = "dropping_center_{$collectionSourceId}.png";
+      error_log("dropbaseFileName: " . print_r($baseFileName, TRUE));
+    }
+
+    return $baseFileName;
+  }
+
+  /**
+   *
+   */
   public static function maybeGeneratePoster(string $op, string $objectName, int $objectId, &$objectRef) {
     if (!self::$generatePosterRequest || $objectName !== 'Eck_Collection_Camp' || $op !== 'edit') {
       return;
@@ -97,8 +115,8 @@ class CollectionBaseService extends AutoSubscriber {
       'collectionSourceCustomData' => self::$generatePosterRequest['customData'],
     ],
     );
+    $baseFileName = self::generateBaseFileName($collectionSourceId);
 
-    $baseFileName = "collection_camp_{$collectionSourceId}.png";
     $fileName = \CRM_Utils_File::makeFileName($baseFileName);
     $tempFilePath = \CRM_Utils_File::tempnam($baseFileName);
 
@@ -475,7 +493,7 @@ class CollectionBaseService extends AutoSubscriber {
         $emailParams['attachments'][] = [
           'fullPath' => $filePath,
           'mime_type' => $file['mime_type'],
-          'cleanName' => "collection_camp_{$collectionSourceId}.png",
+          'cleanName' => self::generateBaseFileName($collectionSourceId),
         ];
       }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -70,11 +70,9 @@ class CollectionBaseService extends AutoSubscriber {
   private static function generateBaseFileName($collectionSourceId) {
     if (self::getEntitySubtypeName($collectionSourceId) == self::ENTITY_NAME) {
       $baseFileName = "collection_camp_{$collectionSourceId}.png";
-      error_log("collebaseFileName: " . print_r($baseFileName, TRUE));
     }
     else {
       $baseFileName = "dropping_center_{$collectionSourceId}.png";
-      error_log("dropbaseFileName: " . print_r($baseFileName, TRUE));
     }
 
     return $baseFileName;

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -22,6 +22,7 @@ function goonjcustom_civicrm_config(&$config): void {
   _goonjcustom_civix_civicrm_config($config);
 
   \Civi::dispatcher()->addSubscriber(new CRM_Goonjcustom_Token_CollectionCamp());
+  \Civi::dispatcher()->addSubscriber(new CRM_Goonjcustom_Token_DroppingCenter());
 }
 
 /**


### PR DESCRIPTION
### Description

1. Created new tokens for the Dropping Center, including venue, date, time, volunteers, coordinator, remarks and city.
2. Update the Poster name based on collection camp and dropping center subtype.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new token evaluation class for handling "dropping center" contexts in CiviCRM.
	- Enhanced event handling capabilities by registering the new token subscriber.
	- Improved functionality for generating base file names dynamically based on collection source IDs.

- **Bug Fixes**
	- Improved token evaluation logic for better data retrieval and formatting related to volunteers and events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->