### PR TITLE
Update Dropping Center Outcome Details via Daily Cron Job

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -46,7 +46,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
 
     // Calculate footfall.
     $activities = civicrm_api4('Activity', 'get', [
-      'select' => ['subject'],
+      'select' => ['id'],
       'where' => [
         ['activity_type_id:name', '=', 'Material Contribution'],
         ['Material_Contribution.Dropping_Center', '=', $trackingId],

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -13,11 +13,11 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   $droppingCenters = civicrm_api4('Eck_Collection_Camp', 'get', [
     'select' => [
       'Donation_Box_Register_Tracking.Cash_Contribution',
-      'Dropping_Centre.Donation_Tracking_Id',
+      'Dropping_Centre.Dropping_Center_Tracking_Id',
       'Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_',
     ],
     'where' => [
-        ['Dropping_Centre.Donation_Tracking_Id', 'IS NOT NULL'],
+        ['Dropping_Centre.Dropping_Center_Tracking_Id', 'IS NOT NULL'],
     ],
     'checkPermissions' => FALSE,
   ]);
@@ -29,7 +29,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   $bagsReceivedByTrackingId = [];
 
   foreach ($droppingCenters as $center) {
-    $trackingId = $center['Dropping_Centre.Donation_Tracking_Id'];
+    $trackingId = $center['Dropping_Centre.Dropping_Center_Tracking_Id'];
 
     if (!isset($cashContributionByTrackingId[$trackingId])) {
       $cashContributionByTrackingId[$trackingId] = 0;
@@ -39,52 +39,83 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
     }
 
     // Calculate cash contibution.
-    $cashContributionByTrackingId[$trackingId] += (int) ($center['Donation_Box_Register_Tracking.Cash_Contribution'] ?? 0);
+    $cashContributionByTrackingId[$trackingId] += (float) ($center['Donation_Box_Register_Tracking.Cash_Contribution'] ?? 0);
 
     // Calculate product sale amounts.
     $productSaleAmountByTrackingId[$trackingId] += (float) ($center['Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_'] ?? 0);
 
-    // Calculate footfall.
-    $activities = civicrm_api4('Activity', 'get', [
-      'select' => ['id'],
-      'where' => [
-        ['activity_type_id:name', '=', 'Material Contribution'],
-        ['Material_Contribution.Dropping_Center', '=', $trackingId],
-      ],
-      'checkPermissions' => FALSE,
-    ]);
-    $footfallByTrackingId[$trackingId] = count($activities);
+  }
 
-    // Calculate vehicle dispatch count.
-    $collectionSourceVehicleDispatches = civicrm_api4('Eck_Collection_Source_Vehicle_Dispatch', 'get', [
-      'select' => ['Camp_Vehicle_Dispatch.Collection_Camp'],
-      'where' => [['Camp_Vehicle_Dispatch.Collection_Camp', '=', $trackingId]],
-      'checkPermissions' => FALSE,
-    ]);
-    $vehicleDispatchesByTrackingId[$trackingId] = count($collectionSourceVehicleDispatches);
+  // Calculate vehicle dispatch count.
+  $collectionSourceVehicleDispatches = civicrm_api4('Eck_Collection_Source_Vehicle_Dispatch', 'get', [
+    'select' => ['Camp_Vehicle_Dispatch.Collection_Camp'],
+    'where' => [['Camp_Vehicle_Dispatch.Collection_Camp', 'IS NOT NULL']],
+    'checkPermissions' => FALSE,
+  ]);
 
-    // Calculate number of bags received.
-    $bagData = civicrm_api4('Eck_Collection_Source_Vehicle_Dispatch', 'get', [
-      'select' => [
-        'Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office',
-        'Camp_Vehicle_Dispatch.Collection_Camp',
-      ],
-      'where' => [
-        ['Camp_Vehicle_Dispatch.Collection_Camp', '=', $trackingId],
-      ],
-      'checkPermissions' => FALSE,
-    ]);
+  $vehicleDispatchCount = [];
+  foreach ($collectionSourceVehicleDispatches as $dispatch) {
+    $dispatchId = $dispatch['Camp_Vehicle_Dispatch.Collection_Camp'];
 
-    $totalBags = 0;
-
-    foreach ($bagData as $record) {
-      if (!empty($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'])) {
-        $totalBags += (int) $record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'];
-      }
+    if (!isset($vehicleDispatchCount[$dispatchId])) {
+      $vehicleDispatchCount[$dispatchId] = 0;
     }
+    $vehicleDispatchCount[$dispatchId] += 1;
+  }
 
-    // Store the totalBags count into $bagsReceivedByTrackingId for further use.
-    $bagsReceivedByTrackingId[$trackingId] = $totalBags;
+  foreach ($vehicleDispatchCount as $dispatchId => $count) {
+    $vehicleDispatchesByTrackingId[$dispatchId] = $count;
+  }
+
+  // Calculate the number of bags received.
+  $bagData = civicrm_api4('Eck_Collection_Source_Vehicle_Dispatch', 'get', [
+    'select' => [
+      'Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office',
+      'Camp_Vehicle_Dispatch.Collection_Camp',
+    ],
+    'where' => [
+      ['Camp_Vehicle_Dispatch.Collection_Camp', 'IS NOT NULL'],
+    ],
+    'checkPermissions' => FALSE,
+  ]);
+
+  $bagsReceivedByTrackingId = [];
+
+  foreach ($bagData as $record) {
+    $dispatchId = $record['Camp_Vehicle_Dispatch.Collection_Camp'];
+    // Default to 0 if empty.
+    $bagsReceived = (int) ($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'] ?? 0);
+
+    if (!isset($bagsReceivedByTrackingId[$dispatchId])) {
+      $bagsReceivedByTrackingId[$dispatchId] = 0;
+    }
+    $bagsReceivedByTrackingId[$dispatchId] += $bagsReceived;
+  }
+
+  // Calculate footfall.
+  $activities = civicrm_api4('Activity', 'get', [
+    'select' => ['id', 'Material_Contribution.Dropping_Center'],
+    'where' => [
+      ['activity_type_id:name', '=', 'Material Contribution'],
+      ['Material_Contribution.Dropping_Center', 'IS NOT NULL'],
+    ],
+    'checkPermissions' => FALSE,
+  ]);
+
+  $totalFootfall = [];
+
+  foreach ($activities as $activity) {
+    $droppingCenterId = $activity['Material_Contribution.Dropping_Center'];
+    if (!empty($droppingCenterId)) {
+      if (!isset($totalFootfall[$droppingCenterId])) {
+        $totalFootfall[$droppingCenterId] = 0;
+      }
+      $totalFootfall[$droppingCenterId] += 1;
+    }
+  }
+
+  foreach ($totalFootfall as $droppingCenterId => $footfallCount) {
+    $footfallByTrackingId[$droppingCenterId] = $footfallCount;
   }
 
   // Update Cash Contributions.

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ *
+ */
+function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
+  $returnValues = [];
+
+  $droppingCenters = civicrm_api4('Eck_Collection_Camp', 'get', [
+    'select' => [
+      'Donation_Box_Register_Tracking.Cash_Contribution',
+      'Dropping_Centre.Donation_Tracking_Id',
+      'Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_',
+    ],
+    'where' => [
+        ['Dropping_Centre.Donation_Tracking_Id', 'IS NOT NULL'],
+    ],
+    'checkPermissions' => FALSE,
+  ]);
+
+  $cashContributionByTrackingId = [];
+  $productSaleAmountByTrackingId = [];
+  $footfallByTrackingId = [];
+  $vehicleDispatchesByTrackingId = [];
+  $bagsReceivedByTrackingId = [];
+
+  foreach ($droppingCenters as $center) {
+    $trackingId = $center['Dropping_Centre.Donation_Tracking_Id'];
+
+    if (!isset($cashContributionByTrackingId[$trackingId])) {
+      $cashContributionByTrackingId[$trackingId] = 0;
+    }
+    if (!isset($productSaleAmountByTrackingId[$trackingId])) {
+      $productSaleAmountByTrackingId[$trackingId] = 0;
+    }
+
+    // Calculate cash contibution.
+    $cashContributionByTrackingId[$trackingId] += (int) ($center['Donation_Box_Register_Tracking.Cash_Contribution'] ?? 0);
+
+    // Calculate product sale amounts.
+    $productSaleAmountByTrackingId[$trackingId] += (float) ($center['Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_'] ?? 0);
+
+    // Calculate footfall.
+    $activities = civicrm_api4('Activity', 'get', [
+      'select' => ['subject'],
+      'where' => [
+        ['activity_type_id:name', '=', 'Material Contribution'],
+        ['Material_Contribution.Dropping_Center', '=', $trackingId],
+      ],
+      'checkPermissions' => TRUE,
+    ]);
+    $footfallByTrackingId[$trackingId] = count($activities);
+
+    // Calculate vehicle dispatch count.
+    $collectionSourceVehicleDispatches = civicrm_api4('Eck_Collection_Source_Vehicle_Dispatch', 'get', [
+      'select' => ['Camp_Vehicle_Dispatch.Collection_Camp'],
+      'where' => [['Camp_Vehicle_Dispatch.Collection_Camp', '=', $trackingId]],
+      'checkPermissions' => TRUE,
+    ]);
+    $vehicleDispatchesByTrackingId[$trackingId] = count($collectionSourceVehicleDispatches);
+
+    // Calculate number of bags received.
+    $bagData = civicrm_api4('Eck_Collection_Source_Vehicle_Dispatch', 'get', [
+      'select' => [
+        'Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office',
+        'Camp_Vehicle_Dispatch.Collection_Camp',
+      ],
+      'where' => [
+        ['Camp_Vehicle_Dispatch.Collection_Camp', '=', $trackingId],
+      ],
+      'checkPermissions' => TRUE,
+    ]);
+
+    $totalBags = 0;
+
+    foreach ($bagData as $record) {
+      if (!empty($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'])) {
+        $totalBags += (int) $record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'];
+      }
+    }
+
+    // Store the totalBags count into $bagsReceivedByTrackingId for further use.
+    $bagsReceivedByTrackingId[$trackingId] = $totalBags;
+  }
+
+  // Update Cash Contributions.
+  foreach ($cashContributionByTrackingId as $trackingId => $cashContributionSum) {
+    civicrm_api4('Eck_Collection_Camp', 'update', [
+      'values' => ['Dropping_Center_Outcome.Cash_Contribution' => max($cashContributionSum, 0)],
+      'where' => [['id', '=', $trackingId]],
+      'checkPermissions' => FALSE,
+    ]);
+  }
+
+  // Update Product Sale Amount.
+  foreach ($productSaleAmountByTrackingId as $trackingId => $productSaleSum) {
+    civicrm_api4('Eck_Collection_Camp', 'update', [
+      'values' => ['Dropping_Center_Outcome.Product_Sale_Amount_GBG_' => max($productSaleSum, 0)],
+      'where' => [['id', '=', $trackingId]],
+      'checkPermissions' => FALSE,
+    ]);
+  }
+
+  // Update Footfall Count based on Material Contribution activities.
+  foreach ($footfallByTrackingId as $trackingId => $footfallCount) {
+    civicrm_api4('Eck_Collection_Camp', 'update', [
+      'values' => ['Dropping_Center_Outcome.Footfall_at_the_center' => max($footfallCount, 0)],
+      'where' => [['id', '=', $trackingId]],
+      'checkPermissions' => TRUE,
+    ]);
+  }
+
+  // Update Vehicle Count based on dispatches.
+  foreach ($vehicleDispatchesByTrackingId as $trackingId => $vehicleCount) {
+    civicrm_api4('Eck_Collection_Camp', 'update', [
+      'values' => ['Dropping_Center_Outcome.Total_no_of_vehicle_material_collected' => max($vehicleCount, 0)],
+      'where' => [['id', '=', $trackingId]],
+      'checkPermissions' => TRUE,
+    ]);
+  }
+
+  // Update Bags Received.
+  foreach ($bagsReceivedByTrackingId as $trackingId => $bagsReceived) {
+    civicrm_api4('Eck_Collection_Camp', 'update', [
+      'values' => ['Dropping_Center_Outcome.Total_no_of_bags_received_from_center' => max($bagsReceived, 0)],
+      'where' => [['id', '=', $trackingId]],
+      'checkPermissions' => TRUE,
+    ]);
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'dropping_center_outcome_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -8,79 +8,53 @@ use Civi\Api4\Activity;
 use Civi\Api4\EckEntity;
 
 /**
- *
+ * Cron job to update Dropping Center outcomes.
  */
 function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   $returnValues = [];
 
-  $droppingCenters = EckEntity::get('Collection_Camp', TRUE)
-    ->addSelect('Donation_Box_Register_Tracking.Cash_Contribution', 'Dropping_Centre.Tracking_Id', 'Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_')
-    ->addWhere('Dropping_Centre.Tracking_Id', 'IS NOT NULL')
+  $cashContributionById = [];
+  $productSaleAmountById = [];
+
+  $droppingCenterMetas = EckEntity::get('Dropping_Center_Meta', TRUE)
+    ->addSelect('Donation.Cash_Contribution', 'Donation.Product_Sale_Amount_GBG_', 'Dropping_Center_Meta.Dropping_Center')
+    ->addClause('OR', ['Donation.Cash_Contribution', 'IS NOT EMPTY'], ['Donation.Product_Sale_Amount_GBG_', 'IS NOT EMPTY'])
     ->execute();
 
-  $cashContributionByTrackingId = [];
-  $productSaleAmountByTrackingId = [];
-  $footfallByTrackingId = [];
-  $vehicleDispatchesByTrackingId = [];
-  $bagsReceivedByTrackingId = [];
+  foreach ($droppingCenterMetas as $center) {
+    $id = $center['Dropping_Center_Meta.Dropping_Center'];
 
-  foreach ($droppingCenters as $center) {
-    $trackingId = $center['Dropping_Centre.Tracking_Id'];
-
-    if (!isset($cashContributionByTrackingId[$trackingId])) {
-      $cashContributionByTrackingId[$trackingId] = 0;
+    if (!isset($cashContributionById[$id])) {
+      $cashContributionById[$id] = 0;
     }
-    if (!isset($productSaleAmountByTrackingId[$trackingId])) {
-      $productSaleAmountByTrackingId[$trackingId] = 0;
+    if (!isset($productSaleAmountById[$id])) {
+      $productSaleAmountById[$id] = 0;
     }
 
-    // Calculate cash contibution.
-    $cashContributionByTrackingId[$trackingId] += (float) ($center['Donation_Box_Register_Tracking.Cash_Contribution'] ?? 0);
+    // Sum the Cash Contribution.
+    $cashContributionById[$id] += (float) ($center['Donation.Cash_Contribution'] ?? 0);
 
-    // Calculate product sale amounts.
-    $productSaleAmountByTrackingId[$trackingId] += (float) ($center['Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_'] ?? 0);
-
+    // Sum the Product Sale Amount.
+    $productSaleAmountById[$id] += (float) ($center['Donation.Product_Sale_Amount_GBG_'] ?? 0);
   }
 
-  // Calculate vehicle dispatch count.
   $vehicleDispatches = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
     ->addSelect('Camp_Vehicle_Dispatch.Collection_Camp')
     ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp', 'IS NOT NULL')
     ->execute();
 
   $vehicleDispatchCount = [];
+
   foreach ($vehicleDispatches as $dispatch) {
     $dispatchId = $dispatch['Camp_Vehicle_Dispatch.Collection_Camp'];
 
     if (!isset($vehicleDispatchCount[$dispatchId])) {
       $vehicleDispatchCount[$dispatchId] = 0;
     }
+
     $vehicleDispatchCount[$dispatchId] += 1;
   }
 
-  foreach ($vehicleDispatchCount as $dispatchId => $count) {
-    $vehicleDispatchesByTrackingId[$dispatchId] = $count;
-  }
-
-  // Calculate the number of bags received.
-  $bagData = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
-    ->addSelect('Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office', 'Camp_Vehicle_Dispatch.Collection_Camp')
-    ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp', 'IS NOT NULL')
-    ->execute();
-
-  $bagsReceivedByTrackingId = [];
-
-  foreach ($bagData as $record) {
-    $dispatchId = $record['Camp_Vehicle_Dispatch.Collection_Camp'];
-    $bagsReceived = (int) ($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'] ?? 0);
-
-    if (!isset($bagsReceivedByTrackingId[$dispatchId])) {
-      $bagsReceivedByTrackingId[$dispatchId] = 0;
-    }
-    $bagsReceivedByTrackingId[$dispatchId] += $bagsReceived;
-  }
-
-  // Calculate footfall.
   $activities = Activity::get(TRUE)
     ->addSelect('id', 'Material_Contribution.Dropping_Center')
     ->addWhere('activity_type_id:name', '=', 'Material Contribution')
@@ -91,57 +65,71 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
 
   foreach ($activities as $activity) {
     $droppingCenterId = $activity['Material_Contribution.Dropping_Center'];
-    if (!empty($droppingCenterId)) {
-      if (!isset($totalFootfall[$droppingCenterId])) {
-        $totalFootfall[$droppingCenterId] = 0;
-      }
-      $totalFootfall[$droppingCenterId] += 1;
+
+    if (!isset($totalFootfall[$droppingCenterId])) {
+      $totalFootfall[$droppingCenterId] = 0;
     }
+
+    $totalFootfall[$droppingCenterId] += 1;
   }
 
-  foreach ($totalFootfall as $droppingCenterId => $footfallCount) {
-    $footfallByTrackingId[$droppingCenterId] = $footfallCount;
+  $bagData = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
+    ->addSelect('Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office', 'Camp_Vehicle_Dispatch.Collection_Camp')
+    ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp', 'IS NOT NULL')
+    ->execute();
+
+  $bagsReceivedCount = [];
+
+  foreach ($bagData as $record) {
+    $dispatchId = $record['Camp_Vehicle_Dispatch.Collection_Camp'];
+    $bagsReceived = (int) ($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'] ?? 0);
+
+    if (!isset($bagsReceivedCount[$dispatchId])) {
+      $bagsReceivedCount[$dispatchId] = 0;
+    }
+    $bagsReceivedCount[$dispatchId] += $bagsReceived;
   }
 
   // Update Cash Contributions.
-  foreach ($cashContributionByTrackingId as $trackingId => $cashContributionSum) {
+  foreach ($cashContributionById as $id => $cashContributionSum) {
     EckEntity::update('Collection_Camp', TRUE)
       ->addValue('Dropping_Center_Outcome.Cash_Contribution', max($cashContributionSum, 0))
-      ->addWhere('id', '=', $trackingId)
+      ->addWhere('id', '=', $id)
       ->execute();
   }
 
   // Update Product Sale Amount.
-  foreach ($productSaleAmountByTrackingId as $trackingId => $productSaleSum) {
+  foreach ($productSaleAmountById as $id => $productSaleSum) {
     EckEntity::update('Collection_Camp', TRUE)
       ->addValue('Dropping_Center_Outcome.Product_Sale_Amount_GBG_', max($productSaleSum, 0))
-      ->addWhere('id', '=', $trackingId)
-      ->execute();
-  }
-
-  // Update Footfall Count based on Material Contribution activities.
-  foreach ($footfallByTrackingId as $trackingId => $footfallCount) {
-    EckEntity::update('Collection_Camp', TRUE)
-      ->addValue('Dropping_Center_Outcome.Footfall_at_the_center', max($footfallCount, 0))
-      ->addWhere('id', '=', $trackingId)
+      ->addWhere('id', '=', $id)
       ->execute();
   }
 
   // Update Vehicle Count based on dispatches.
-  foreach ($vehicleDispatchesByTrackingId as $trackingId => $vehicleCount) {
+  foreach ($vehicleDispatchCount as $id => $vehicleCount) {
     EckEntity::update('Collection_Camp', TRUE)
       ->addValue('Dropping_Center_Outcome.Total_no_of_vehicle_material_collected', max($vehicleCount, 0))
-      ->addWhere('id', '=', $trackingId)
+      ->addWhere('id', '=', $id)
+      ->execute();
+  }
+
+  // Update Footfall Count based on Material Contribution activities.
+  foreach ($totalFootfall as $id => $footfallCount) {
+    EckEntity::update('Collection_Camp', TRUE)
+      ->addValue('Dropping_Center_Outcome.Footfall_at_the_center', max($footfallCount, 0))
+      ->addWhere('id', '=', $id)
       ->execute();
   }
 
   // Update Bags Received.
-  foreach ($bagsReceivedByTrackingId as $trackingId => $bagsReceived) {
+  foreach ($bagsReceivedCount as $id => $bagsReceived) {
     EckEntity::update('Collection_Camp', TRUE)
       ->addValue('Dropping_Center_Outcome.Total_no_of_bags_received_from_center', max($bagsReceived, 0))
-      ->addWhere('id', '=', $trackingId)
+      ->addWhere('id', '=', $id)
       ->execute();
   }
 
+  // Return success response.
   return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'dropping_center_outcome_cron');
 }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -51,7 +51,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
         ['activity_type_id:name', '=', 'Material Contribution'],
         ['Material_Contribution.Dropping_Center', '=', $trackingId],
       ],
-      'checkPermissions' => TRUE,
+      'checkPermissions' => FALSE,
     ]);
     $footfallByTrackingId[$trackingId] = count($activities);
 
@@ -59,7 +59,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
     $collectionSourceVehicleDispatches = civicrm_api4('Eck_Collection_Source_Vehicle_Dispatch', 'get', [
       'select' => ['Camp_Vehicle_Dispatch.Collection_Camp'],
       'where' => [['Camp_Vehicle_Dispatch.Collection_Camp', '=', $trackingId]],
-      'checkPermissions' => TRUE,
+      'checkPermissions' => FALSE,
     ]);
     $vehicleDispatchesByTrackingId[$trackingId] = count($collectionSourceVehicleDispatches);
 
@@ -72,7 +72,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
       'where' => [
         ['Camp_Vehicle_Dispatch.Collection_Camp', '=', $trackingId],
       ],
-      'checkPermissions' => TRUE,
+      'checkPermissions' => FALSE,
     ]);
 
     $totalBags = 0;
@@ -110,7 +110,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
     civicrm_api4('Eck_Collection_Camp', 'update', [
       'values' => ['Dropping_Center_Outcome.Footfall_at_the_center' => max($footfallCount, 0)],
       'where' => [['id', '=', $trackingId]],
-      'checkPermissions' => TRUE,
+      'checkPermissions' => FALSE,
     ]);
   }
 
@@ -119,7 +119,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
     civicrm_api4('Eck_Collection_Camp', 'update', [
       'values' => ['Dropping_Center_Outcome.Total_no_of_vehicle_material_collected' => max($vehicleCount, 0)],
       'where' => [['id', '=', $trackingId]],
-      'checkPermissions' => TRUE,
+      'checkPermissions' => FALSE,
     ]);
   }
 
@@ -128,7 +128,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
     civicrm_api4('Eck_Collection_Camp', 'update', [
       'values' => ['Dropping_Center_Outcome.Total_no_of_bags_received_from_center' => max($bagsReceived, 0)],
       'where' => [['id', '=', $trackingId]],
-      'checkPermissions' => TRUE,
+      'checkPermissions' => FALSE,
     ]);
   }
 

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -43,13 +43,13 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   }
 
   // Calculate vehicle dispatch count.
-  $collectionSourceVehicleDispatches = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
+  $vehicleDispatches = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
     ->addSelect('Camp_Vehicle_Dispatch.Collection_Camp')
     ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp', 'IS NOT NULL')
     ->execute();
 
   $vehicleDispatchCount = [];
-  foreach ($collectionSourceVehicleDispatches as $dispatch) {
+  foreach ($vehicleDispatches as $dispatch) {
     $dispatchId = $dispatch['Camp_Vehicle_Dispatch.Collection_Camp'];
 
     if (!isset($vehicleDispatchCount[$dispatchId])) {

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -13,11 +13,11 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   $droppingCenters = civicrm_api4('Eck_Collection_Camp', 'get', [
     'select' => [
       'Donation_Box_Register_Tracking.Cash_Contribution',
-      'Dropping_Centre.Dropping_Center_Tracking_Id',
+      'Dropping_Centre.Tracking_Id',
       'Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_',
     ],
     'where' => [
-        ['Dropping_Centre.Dropping_Center_Tracking_Id', 'IS NOT NULL'],
+        ['Dropping_Centre.Tracking_Id', 'IS NOT NULL'],
     ],
     'checkPermissions' => FALSE,
   ]);
@@ -29,7 +29,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   $bagsReceivedByTrackingId = [];
 
   foreach ($droppingCenters as $center) {
-    $trackingId = $center['Dropping_Centre.Dropping_Center_Tracking_Id'];
+    $trackingId = $center['Dropping_Centre.Tracking_Id'];
 
     if (!isset($cashContributionByTrackingId[$trackingId])) {
       $cashContributionByTrackingId[$trackingId] = 0;

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -83,7 +83,6 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
 
   foreach ($bagData as $record) {
     $dispatchId = $record['Camp_Vehicle_Dispatch.Collection_Camp'];
-    // Default to 0 if empty.
     $bagsReceived = (int) ($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'] ?? 0);
 
     if (!isset($bagsReceivedByTrackingId[$dispatchId])) {

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -23,19 +23,8 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
 
   foreach ($droppingCenterMetas as $center) {
     $id = $center['Dropping_Center_Meta.Dropping_Center'];
-
-    if (!isset($cashContributionById[$id])) {
-      $cashContributionById[$id] = 0;
-    }
-    if (!isset($productSaleAmountById[$id])) {
-      $productSaleAmountById[$id] = 0;
-    }
-
-    // Sum the Cash Contribution.
-    $cashContributionById[$id] += (float) ($center['Donation.Cash_Contribution'] ?? 0);
-
-    // Sum the Product Sale Amount.
-    $productSaleAmountById[$id] += (float) ($center['Donation.Product_Sale_Amount_GBG_'] ?? 0);
+    $cashContributionById[$id] = ($cashContributionById[$id] ?? 0) + (float) ($center['Donation.Cash_Contribution'] ?? 0);
+    $productSaleAmountById[$id] = ($productSaleAmountById[$id] ?? 0) + (float) ($center['Donation.Product_Sale_Amount_GBG_'] ?? 0);
   }
 
   $vehicleDispatches = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
@@ -43,35 +32,19 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
     ->addWhere('Camp_Vehicle_Dispatch.Collection_Camp', 'IS NOT NULL')
     ->execute();
 
-  $vehicleDispatchCount = [];
+  $vehicleDispatchArray = $vehicleDispatches->getIterator()->getArrayCopy();
 
-  foreach ($vehicleDispatches as $dispatch) {
-    $dispatchId = $dispatch['Camp_Vehicle_Dispatch.Collection_Camp'];
-
-    if (!isset($vehicleDispatchCount[$dispatchId])) {
-      $vehicleDispatchCount[$dispatchId] = 0;
-    }
-
-    $vehicleDispatchCount[$dispatchId] += 1;
-  }
+  $vehicleDispatchCount = array_count_values(array_column($vehicleDispatchArray, 'Camp_Vehicle_Dispatch.Collection_Camp'));
 
   $activities = Activity::get(TRUE)
-    ->addSelect('id', 'Material_Contribution.Dropping_Center')
+    ->addSelect('Material_Contribution.Dropping_Center')
     ->addWhere('activity_type_id:name', '=', 'Material Contribution')
     ->addWhere('Material_Contribution.Dropping_Center', 'IS NOT NULL')
     ->execute();
 
-  $totalFootfall = [];
+  $activitiesArray = $activities->getIterator()->getArrayCopy();
 
-  foreach ($activities as $activity) {
-    $droppingCenterId = $activity['Material_Contribution.Dropping_Center'];
-
-    if (!isset($totalFootfall[$droppingCenterId])) {
-      $totalFootfall[$droppingCenterId] = 0;
-    }
-
-    $totalFootfall[$droppingCenterId] += 1;
-  }
+  $totalFootfall = array_count_values(array_column($activitiesArray, 'Material_Contribution.Dropping_Center'));
 
   $bagData = EckEntity::get('Collection_Source_Vehicle_Dispatch', TRUE)
     ->addSelect('Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office', 'Camp_Vehicle_Dispatch.Collection_Camp')
@@ -79,57 +52,28 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
     ->execute();
 
   $bagsReceivedCount = [];
-
   foreach ($bagData as $record) {
     $dispatchId = $record['Camp_Vehicle_Dispatch.Collection_Camp'];
-    $bagsReceived = (int) ($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'] ?? 0);
+    $bagsReceivedCount[$dispatchId] = ($bagsReceivedCount[$dispatchId] ?? 0) + (int) ($record['Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office'] ?? 0);
+  }
 
-    if (!isset($bagsReceivedCount[$dispatchId])) {
-      $bagsReceivedCount[$dispatchId] = 0;
+  /**
+   *
+   */
+  function updateDroppingCenterMetric($metricName, $data) {
+    foreach ($data as $id => $value) {
+      EckEntity::update('Collection_Camp', TRUE)
+        ->addValue("Dropping_Center_Outcome.$metricName", max($value, 0))
+        ->addWhere('id', '=', $id)
+        ->execute();
     }
-    $bagsReceivedCount[$dispatchId] += $bagsReceived;
   }
 
-  // Update Cash Contributions.
-  foreach ($cashContributionById as $id => $cashContributionSum) {
-    EckEntity::update('Collection_Camp', TRUE)
-      ->addValue('Dropping_Center_Outcome.Cash_Contribution', max($cashContributionSum, 0))
-      ->addWhere('id', '=', $id)
-      ->execute();
-  }
+  updateDroppingCenterMetric('Cash_Contribution', $cashContributionById);
+  updateDroppingCenterMetric('Product_Sale_Amount_GBG_', $productSaleAmountById);
+  updateDroppingCenterMetric('Total_no_of_vehicle_material_collected', $vehicleDispatchCount);
+  updateDroppingCenterMetric('Footfall_at_the_center', $totalFootfall);
+  updateDroppingCenterMetric('Total_no_of_bags_received_from_center', $bagsReceivedCount);
 
-  // Update Product Sale Amount.
-  foreach ($productSaleAmountById as $id => $productSaleSum) {
-    EckEntity::update('Collection_Camp', TRUE)
-      ->addValue('Dropping_Center_Outcome.Product_Sale_Amount_GBG_', max($productSaleSum, 0))
-      ->addWhere('id', '=', $id)
-      ->execute();
-  }
-
-  // Update Vehicle Count based on dispatches.
-  foreach ($vehicleDispatchCount as $id => $vehicleCount) {
-    EckEntity::update('Collection_Camp', TRUE)
-      ->addValue('Dropping_Center_Outcome.Total_no_of_vehicle_material_collected', max($vehicleCount, 0))
-      ->addWhere('id', '=', $id)
-      ->execute();
-  }
-
-  // Update Footfall Count based on Material Contribution activities.
-  foreach ($totalFootfall as $id => $footfallCount) {
-    EckEntity::update('Collection_Camp', TRUE)
-      ->addValue('Dropping_Center_Outcome.Footfall_at_the_center', max($footfallCount, 0))
-      ->addWhere('id', '=', $id)
-      ->execute();
-  }
-
-  // Update Bags Received.
-  foreach ($bagsReceivedCount as $id => $bagsReceived) {
-    EckEntity::update('Collection_Camp', TRUE)
-      ->addValue('Dropping_Center_Outcome.Total_no_of_bags_received_from_center', max($bagsReceived, 0))
-      ->addWhere('id', '=', $id)
-      ->execute();
-  }
-
-  // Return success response.
   return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'dropping_center_outcome_cron');
 }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/DroppingCenterOutcomeCron.php
@@ -14,8 +14,8 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   $returnValues = [];
 
   $droppingCenters = EckEntity::get('Collection_Camp', TRUE)
-    ->addSelect('Donation_Box_Register_Tracking.Cash_Contribution', 'Dropping_Centre.Dropping_Center_Tracking_Id', 'Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_')
-    ->addWhere('Dropping_Centre.Dropping_Center_Tracking_Id', 'IS NOT NULL')
+    ->addSelect('Donation_Box_Register_Tracking.Cash_Contribution', 'Dropping_Centre.Tracking_Id', 'Donation_Box_Register_Tracking.Product_Sale_Amount_GBG_')
+    ->addWhere('Dropping_Centre.Tracking_Id', 'IS NOT NULL')
     ->execute();
 
   $cashContributionByTrackingId = [];
@@ -25,7 +25,7 @@ function civicrm_api3_goonjcustom_dropping_center_outcome_cron($params) {
   $bagsReceivedByTrackingId = [];
 
   foreach ($droppingCenters as $center) {
-    $trackingId = $center['Dropping_Centre.Dropping_Center_Tracking_Id'];
+    $trackingId = $center['Dropping_Centre.Tracking_Id'];
 
     if (!isset($cashContributionByTrackingId[$trackingId])) {
       $cashContributionByTrackingId[$trackingId] = 0;


### PR DESCRIPTION
## Description

A daily cron job executes to update the outcome Fields.

Updating Record :
1. Cash Contributions: Updates the cash contribution totals.
2. Product Sale Amounts: Updates the total product sale amounts.
3. Footfall Counts: Updates the count of visitors based on material contribution activities.
4. Vehicle Dispatch Counts: Updates the count of vehicles that dispatched materials.
5. Bags Received: Updates the total number of bags received from the center.

<img width="713" alt="image" src="https://github.com/user-attachments/assets/69fb2cec-7019-43a4-bd8f-15a9fe67d63b">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to aggregate and update metrics related to dropping centers in CiviCRM, enhancing data tracking and reporting capabilities.
	- Added methods for sending email notifications to the Material Management Team and processing dispatch events, improving communication and operational efficiency.
	- Defined a new constant for relationship type in the Material Management Team.
- **Bug Fixes**
	- Enhanced error handling in email notification processes for better traceability.
- **Refactor**
	- Improved conditional logic and code formatting for clarity and adherence to coding standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->