### PR TITLE
Remove activity type check to use shortcode for other activites

### DIFF
--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -39,7 +39,6 @@ function goonj_contribution_volunteer_signup_button() {
 			->addSelect( 'source_contact_id' )
 			->addJoin( 'ActivityContact AS activity_contact', 'LEFT' )
 			->addWhere( 'id', '=', $activity_id )
-			->addWhere( 'activity_type_id:label', '=', 'Material Contribution' )
 			->execute();
 
 		if ( $activities->count() === 0 ) {


### PR DESCRIPTION
Issue - [144](https://github.com/coloredcow-admin/goonj-crm/issues/144) Please refer to [Point No. 3](https://github.com/coloredcow-admin/goonj-crm/issues/144#issuecomment-2419160446) for further details.
- Changes are done regarding PU Activites
- Remove the activity check for adding the "Wish to Volunteer?" button on the office visit activity success page.
- Upon submitting the office visit activity, the success page will display the "Wish to Volunteer?" button, allowing users to express their interest in volunteering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded volunteer signup functionality to include all activity types, enhancing user participation options.
	- Improved data retrieval for activities by adding additional fields to the selection process.

- **Bug Fixes**
	- Updated logging for better clarity on activity retrieval and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->