### PR TITLE
Added additional params to auto fill form fields

### DIFF
--- a/wp-content/themes/goonj-crm/engine/helpers.php
+++ b/wp-content/themes/goonj-crm/engine/helpers.php
@@ -28,7 +28,7 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 	$activityMap = array(
 		'Office visit' => array(
 			'redirectPath' => '/processing-center/office-visit/details/',
-			'buttonText' => __( 'Proceed to Office Visit', 'goonj-crm' ),
+			'buttonText' => __( 'Proceed to Processing Center Tour', 'goonj-crm' ),
 			'queryParam' => 'Office_Visit.Goonj_Processing_Center',
 			'additionalParams' => array(
 				'Office_Visit.Entity_Type' => $activity['Material_Contribution.Entity_Type'], //additonal params to auto fill from contribution activity

--- a/wp-content/themes/goonj-crm/engine/helpers.php
+++ b/wp-content/themes/goonj-crm/engine/helpers.php
@@ -30,6 +30,10 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 			'redirectPath' => '/processing-center/office-visit/details/',
 			'buttonText' => __( 'Proceed to Office Visit', 'goonj-crm' ),
 			'queryParam' => 'Office_Visit.Goonj_Processing_Center',
+			'additionalParams' => array(
+				'Office_Visit.Entity_Type' => $activity['Material_Contribution.Entity_Type'], //additonal params to auto fill from contribution activity
+				'Office_Visit.Entity_Name' => $activity['Material_Contribution.Entity_Name']
+			)
 		),
 		'Material Contribution' => array(
 			'redirectPath' => '/processing-center/material-contribution/details/',
@@ -47,6 +51,10 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 		'source_contact_id' => $individual_id,
 		$details['queryParam'] => $office_id,
 	);
+
+	if ( isset( $details['additionalParams'] ) ) {
+		$redirectParams = array_merge( $redirectParams, $details['additionalParams'] );
+	}
 
 	$redirectPathWithParams = $details['redirectPath'] . '#?' . http_build_query( $redirectParams );
 

--- a/wp-content/themes/goonj-crm/engine/helpers.php
+++ b/wp-content/themes/goonj-crm/engine/helpers.php
@@ -31,7 +31,7 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 			'buttonText' => __( 'Proceed to Processing Center Tour', 'goonj-crm' ),
 			'queryParam' => 'Office_Visit.Goonj_Processing_Center',
 			'additionalParams' => array(
-				'Office_Visit.Entity_Type' => $activity['Material_Contribution.Entity_Type'], //additonal params to auto fill from contribution activity
+				'Office_Visit.Entity_Type' => $activity['Material_Contribution.Entity_Type'], // Additional params from contribution activity
 				'Office_Visit.Entity_Name' => $activity['Material_Contribution.Entity_Name']
 			)
 		),
@@ -52,8 +52,9 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 		$details['queryParam'] => $office_id,
 	);
 
-	if ( isset( $details['additionalParams'] ) ) {
-		$redirectParams = array_merge( $redirectParams, $details['additionalParams'] );
+	// Merge additional params if they exist
+	if ( !empty( $details['additionalParams'] ) ) {
+		$redirectParams += $details['additionalParams'];
 	}
 
 	$redirectPathWithParams = $details['redirectPath'] . '#?' . http_build_query( $redirectParams );

--- a/wp-content/themes/goonj-crm/engine/helpers.php
+++ b/wp-content/themes/goonj-crm/engine/helpers.php
@@ -37,7 +37,7 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 			'buttonText' => __( 'Proceed to Processing Center Tour', 'goonj-crm' ),
 			'queryParam' => 'Office_Visit.Goonj_Processing_Center',
 			'additionalParams' => array(
-				'Office_Visit.Entity_Type' => $activity['Material_Contribution.Entity_Type'], // Additional params from contribution activity
+				'Office_Visit.Entity_Type' => $activity['Material_Contribution.Entity_Type'],
 				'Office_Visit.Entity_Name' => $activity['Material_Contribution.Entity_Name'],
 				'Office_Visit.You_are_Visiting_as'=>$visitedAs
 			)

--- a/wp-content/themes/goonj-crm/engine/helpers.php
+++ b/wp-content/themes/goonj-crm/engine/helpers.php
@@ -24,6 +24,12 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 	// Calculate the pending activities by comparing with $activityTypes
 	$pendingActivities = array_diff( $activityTypes, array( $completedActivityType ) );
 
+	// Set the 'You are Visiting as' field to 'Group' if both 'Entity_Type' and 'Entity_Name' 
+	// are provided in the Material Contribution form; otherwise, set it to 'Individual'.
+	$visitedAs = (!empty($activity['Material_Contribution.Entity_Type']) && !empty($activity['Material_Contribution.Entity_Name']))
+	? 'Group'
+	: 'Individual';
+
 	// Define the mapping for each activity to the corresponding button and redirect info
 	$activityMap = array(
 		'Office visit' => array(
@@ -32,7 +38,8 @@ function goonj_generate_activity_button( $activity, $office_id, $individual_id )
 			'queryParam' => 'Office_Visit.Goonj_Processing_Center',
 			'additionalParams' => array(
 				'Office_Visit.Entity_Type' => $activity['Material_Contribution.Entity_Type'], // Additional params from contribution activity
-				'Office_Visit.Entity_Name' => $activity['Material_Contribution.Entity_Name']
+				'Office_Visit.Entity_Name' => $activity['Material_Contribution.Entity_Name'],
+				'Office_Visit.You_are_Visiting_as'=>$visitedAs
 			)
 		),
 		'Material Contribution' => array(

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -92,7 +92,7 @@ function goonj_pu_activity_button() {
 
 	try {
 		$activity = \Civi\Api4\Activity::get(false)
-			->addSelect('source_contact_id', 'Office_Visit.Goonj_Processing_Center', 'Material_Contribution.Goonj_Office', 'activity_type_id:name')
+			->addSelect('custom.*', 'source_contact_id', 'Office_Visit.Goonj_Processing_Center', 'Material_Contribution.Goonj_Office', 'activity_type_id:name')
 			->addWhere('id', '=', $activity_id)
 			->execute()
 			->first();


### PR DESCRIPTION
- Issue - [144](https://github.com/coloredcow-admin/goonj-crm/issues/144) please refer [point no 6](https://github.com/coloredcow-admin/goonj-crm/issues/144#issue-2591626524)
- In the PU activity flow, after completing the Material Contribution form, the success page will display a "Proceed to Processing Center Tour" button. When the user clicks this button, they will be redirected to the Office Visit form, where the previously entered details for Entity Type and Entity Name from the Material Contribution form will be automatically filled in the Office Visit form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced activity handling within the Goonj CRM theme.
	- Updated button text for 'Office visit' activity to improve clarity.
	- Introduced auto-filling of parameters for the 'Office visit' activity based on 'Material Contribution'.

- **Improvements**
	- Improved selection of fields from the Activity API, allowing retrieval of all custom fields associated with activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->