### PR TITLE
Add Validation to Prevent Selection of Past Dates in Dropping Center Form

### DIFF
--- a/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
+++ b/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
@@ -48,7 +48,6 @@
       this.loadData = function(selectedEntity, selectedIndex, selectedId, selectedField) {
         let toLoad = true;
         const params = {name: ctrl.getFormMeta().name, args: {}};
-        console.log(params,"params")
         // Load single entity
         if (selectedEntity) {
           toLoad = !!selectedId;

--- a/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
+++ b/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
@@ -318,7 +318,7 @@
             if (selectedDate < today) {
               isValid = false;
               
-              alert(`The selected date (${dateField}) cannot be in the past.\n`);
+              alert(`The dropping center selected date (${dateField}) cannot be in the past.\n`);
             }
           }
         }

--- a/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
+++ b/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
@@ -318,7 +318,7 @@
             if (selectedDate < today) {
               isValid = false;
               
-              alert(`The dropping center selected date (${dateField}) cannot be in the past.\n`);
+              alert(`The selected dropping center date (${dateField}) cannot be in the past.\n`);
             }
           }
         }

--- a/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
+++ b/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
@@ -48,6 +48,7 @@
       this.loadData = function(selectedEntity, selectedIndex, selectedId, selectedField) {
         let toLoad = true;
         const params = {name: ctrl.getFormMeta().name, args: {}};
+        console.log(params,"params")
         // Load single entity
         if (selectedEntity) {
           toLoad = !!selectedId;
@@ -302,6 +303,25 @@
                     isValid = false;
                 }
             }
+        }
+        
+        // Date validation for the Open Dropping Center form to ensure the selected date is not in the past.
+        if (ctrl.getFormMeta().name === 'afformDroppingCenterDetailForm') {
+          var dateField = $element.find("input.crm-form-date").val().trim(); 
+          
+          if (dateField !== "") {
+            var today = new Date();
+            today.setHours(0, 0, 0, 0);
+            var dateParts = dateField.split('/');
+            var selectedDate = new Date(dateParts[2], dateParts[1] - 1, dateParts[0]);
+            
+            // Check if the selected date is in the past
+            if (selectedDate < today) {
+              isValid = false;
+              
+              alert(`The selected date (${dateField}) cannot be in the past.\n`);
+            }
+          }
         }
 
     // Collection camp start date and end date validation


### PR DESCRIPTION
### Description:

This PR implements a validation check in the Dropping Center Detail intent Form to ensure that users cannot select past dates. If a user attempts to select a date prior to the current date, an alert message will be displayed, informing them that the selected date is invalid.

### Changes Made:
- Added a date validation check in the form to compare the selected date against the current date.
- Included an alert message for users when they select a past date, enhancing user experience and preventing erroneous submissions.

<img width="607" alt="image" src="https://github.com/user-attachments/assets/5c9295de-b337-4894-941c-76c2b0dab469">


