### PR TITLE
Fix the status feedbacks

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1211,7 +1211,7 @@ class CollectionCampService extends AutoSubscriber {
 
     }
     catch (\Exception $e) {
-      error_log("Exception occurred while updating camp status for campId: $collectionCampId");
+      \Civi::log()->error("Exception occurred while updating camp status for campId: $collectionCampId. Error: " . $e->getMessage());
     }
   }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -37,6 +37,7 @@ class CollectionCampService extends AutoSubscriber {
   private static $individualId = NULL;
   private static $collectionCampAddress = NULL;
   private static $fromAddress = NULL;
+  private static $processedCampIds = [];
 
   /**
    *
@@ -1187,7 +1188,7 @@ class CollectionCampService extends AutoSubscriber {
    *   The reference to the object.
    */
   public static function updateCampStatusOnOutcomeFilled(string $op, string $objectName, int $objectId, &$objectRef) {
-    if ($objectName !== 'Eck_Collection_Camp' || !$objectRef->id) {
+    if ($objectName !== 'Eck_Collection_Camp' || !$objectRef->id || $objectRef->afform_name !== 'afformCampOutcomeForm') {
       return;
     }
 
@@ -1196,12 +1197,13 @@ class CollectionCampService extends AutoSubscriber {
     $collectionCampId = $objectRef->id;
 
     // If the camp ID has already been processed, return to avoid repeated execution.
-    if ($collectionCampId === $processedCampId) {
+    if (in_array($collectionCampId, self::$processedCampIds)) {
       return;
     }
 
     // Mark this camp ID as processed to prevent future executions for the same ID.
-    $processedCampId = $collectionCampId;
+    self::$processedCampIds[] = $collectionCampId;
+    error_log("collectionCampId: " . print_r($collectionCampId, TRUE));
 
     try {
       EckEntity::update('Collection_Camp', FALSE)

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1171,9 +1171,11 @@ class CollectionCampService extends AutoSubscriber {
           ->addValue('Collection_Camp_Intent_Details.Camp_Status', 'planned')
           ->addWhere('id', '=', $campId)
           ->execute();
+          error_log("results: " . print_r($results, TRUE));
       }
     }
   }
+
 
   /**
    * This hook is called after a db write on entities.

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1188,7 +1188,15 @@ class CollectionCampService extends AutoSubscriber {
    *   The reference to the object.
    */
   public static function updateCampStatusOnOutcomeFilled(string $op, string $objectName, int $objectId, &$objectRef) {
-    if ($objectName !== 'Eck_Collection_Camp' || !$objectRef->id || $objectRef->afform_name !== 'afformCampOutcomeForm') {
+    if ($objectRef instanceof CRM_Afform_BAO_AfformSubmission) {
+      $afformName = $objectRef->afform_name;
+
+      if ($afformName !== 'afformCampOutcomeForm') {
+        return;
+      }
+    }
+
+    if ($objectName !== 'Eck_Collection_Camp' || !$objectRef->id) {
       return;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1161,11 +1161,6 @@ class CollectionCampService extends AutoSubscriber {
 
     if ($currentStatus !== $newStatus) {
       if ($newStatus === 'authorized') {
-        $subtypeId = $objectRef['subtype'] ?? NULL;
-        if ($subtypeId === NULL) {
-          return;
-        }
-
         $campId = $objectRef['id'] ?? NULL;
         if ($campId === NULL) {
           return;

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1170,7 +1170,6 @@ class CollectionCampService extends AutoSubscriber {
           ->addValue('Collection_Camp_Intent_Details.Camp_Status', 'planned')
           ->addWhere('id', '=', $campId)
           ->execute();
-        error_log("results: " . print_r($results, TRUE));
       }
     }
   }


### PR DESCRIPTION
Move the logic to post-type and change the status from anything to completed when the outcome form is submitted and added the check on based of form so that it wont run on other triggers

The second point from the below feedback PR
https://github.com/coloredcow-admin/goonj-crm/issues/146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event handling to automatically update the status of collection camps when outcomes are filled.
  
- **Bug Fixes**
  - Improved error handling to ensure robust updates for camp statuses, enhancing overall reliability.

- **Documentation**
  - Updated documentation comments for better clarity on method parameters and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->