### PR TITLE
Add Event Coordinato tab for dropping center

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -172,11 +172,6 @@ class CollectionBaseService extends AutoSubscriber {
     }
 
     $tabConfigs = [
-      'eventVolunteers' => [
-        'title' => ts('Event Volunteers'),
-        'module' => 'afsearchEventVolunteer',
-        'directive' => 'afsearch-event-volunteer',
-      ],
       'vehicleDispatch' => [
         'title' => ts('Dispatch'),
         'module' => 'afsearchCampVehicleDispatchData',

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -85,6 +85,12 @@ class CollectionCampService extends AutoSubscriber {
       //   'directive' => 'afsearch-collection-camp-activity',
       //   'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       // ],
+      'eventVolunteers' => [
+        'title' => ts('Event Volunteers'),
+        'module' => 'afsearchEventVolunteer',
+        'directive' => 'afsearch-event-volunteer',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
       'materialContribution' => [
         'title' => ts('Material Contribution'),
         'module' => 'afsearchCollectionCampMaterialContributions',

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -461,7 +461,7 @@ class DroppingCenterService extends AutoSubscriber {
     }
     $tabConfigs = [
       'eventCoordinators' => [
-        'title' => ts('event coordinators'),
+        'title' => ts('Event Coordinators'),
         'module' => 'afsearchCoordinator',
         'directive' => 'afsearch-coordinator',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -460,6 +460,12 @@ class DroppingCenterService extends AutoSubscriber {
       return;
     }
     $tabConfigs = [
+      'eventCoordinators' => [
+        'title' => ts('event coordinators'),
+        'module' => 'afsearchCoordinator',
+        'directive' => 'afsearch-coordinator',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],    
       'materialContribution' => [
         'title' => ts('Material Contribution'),
         'module' => 'afsearchDroppingCenterMaterialContributions',


### PR DESCRIPTION
I removed the "Event Volunteer" from the base and updated it in the Collection Camp section. Additionally, I created a new "Event Coordinator" tab for the Dropping Center. The reason for this change is that, according to CiviCRM rules, an email is automatically sent when an activity contact is created based on the activity type. However, the system was sending the same Collection Camp email for Dropping Center activities as well. To resolve this, we needed to create a new activity type specifically for the Dropping Center, allowing us to create a distinct message template that would be triggered based on the new activity type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new "Event Volunteers" tab in the collection camp interface for better organization of volunteer information.
	- Introduced a new tab for "Event Coordinators" in the dropping center interface to manage coordinators effectively.
	- Implemented a method to associate addresses with event volunteers during submissions.

- **Improvements**
	- Enhanced error handling for poster generation and email authorization processes, providing clearer feedback and logging.
	- Updated camp status management to reflect accurate planning and completion statuses.

- **Bug Fixes**
	- Improved robustness in email handling and queuing processes to prevent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->