### PR TITLE
Reminder for outcome 2 emails will be sent

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampOutcomeService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampOutcomeService.php
@@ -27,7 +27,6 @@ class CollectionCampOutcomeService {
     $campAddress = $camp['Collection_Camp_Intent_Details.Location_Area_of_camp'];
 
     $lastReminderSent = $camp['Camp_Outcome.Last_Reminder_Sent'] ? new \DateTime($camp['Camp_Outcome.Last_Reminder_Sent']) : NULL;
-    $finalReminderSent = $camp['Camp_Outcome.Final_Reminder_Sent'] ? new \DateTime($camp['Camp_Outcome.Final_Reminder_Sent']) : NULL;
 
     // Calculate hours since camp ended.
     $hoursSinceCampEnd = abs($now->getTimestamp() - $endDate->getTimestamp()) / 3600;
@@ -37,10 +36,6 @@ class CollectionCampOutcomeService {
 
     // Check if the outcome form is not filled and send the first reminder after 48 hours of camp end.
     if ($hoursSinceCampEnd < 48) {
-      return FALSE;
-    }
-
-    if ($finalReminderSent !== NULL) {
       return FALSE;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampOutcomeService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampOutcomeService.php
@@ -27,6 +27,7 @@ class CollectionCampOutcomeService {
     $campAddress = $camp['Collection_Camp_Intent_Details.Location_Area_of_camp'];
 
     $lastReminderSent = $camp['Camp_Outcome.Last_Reminder_Sent'] ? new \DateTime($camp['Camp_Outcome.Last_Reminder_Sent']) : NULL;
+    $finalReminderSent = $camp['Camp_Outcome.Final_Reminder_Sent'] ? new \DateTime($camp['Camp_Outcome.Final_Reminder_Sent']) : NULL;
 
     // Calculate hours since camp ended.
     $hoursSinceCampEnd = abs($now->getTimestamp() - $endDate->getTimestamp()) / 3600;
@@ -39,15 +40,30 @@ class CollectionCampOutcomeService {
       return FALSE;
     }
 
-    // Return if 24 hours have not passed since the last reminder.
-    if ($lastReminderSent !== NULL && $hoursSinceLastReminder < 24) {
+    if ($finalReminderSent !== NULL) {
+      return FALSE;
+    }
+
+    // If no reminders have been sent yet, send the first reminder.
+    if ($lastReminderSent === NULL) {
+      EckEntity::update('Collection_Camp', TRUE)
+        ->addWhere('id', '=', $camp['id'])
+        ->addValue('Camp_Outcome.Last_Reminder_Sent', $now->format('Y-m-d H:i:s'))
+        ->execute();
+
+      self::sendOutcomeReminderEmail($campAttendedById, $from, $campCode, $campAddress, $collectionCampId, $endDateString);
+      return;
+    }
+
+    // Return if 48 hours have not passed since the last reminder was sent.
+    if ($lastReminderSent !== NULL && $hoursSinceLastReminder < 48) {
       return FALSE;
     }
     self::sendOutcomeReminderEmail($campAttendedById, $from, $campCode, $campAddress, $collectionCampId, $endDateString);
 
     EckEntity::update('Collection_Camp', TRUE)
       ->addWhere('id', '=', $camp['id'])
-      ->addValue('Camp_Outcome.Last_Reminder_Sent', $now->format('Y-m-d H:i:s'))
+      ->addValue('Camp_Outcome.Final_Reminder_Sent', $now->format('Y-m-d H:i:s'))
       ->execute();
   }
 

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampOutcomeReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampOutcomeReminderCron.php
@@ -47,6 +47,7 @@ function civicrm_api3_goonjcustom_collection_camp_outcome_reminder_cron($params)
       'Camp_Outcome.Last_Reminder_Sent',
       'title',
       'Collection_Camp_Intent_Details.Location_Area_of_camp',
+      'Camp_Outcome.Final_Reminder_Sent',
     )
     ->addWhere('Camp_Outcome.Rate_the_camp', 'IS NULL')
     ->addWhere('Logistics_Coordination.Email_Sent', '=', 1)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampOutcomeReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampOutcomeReminderCron.php
@@ -54,6 +54,7 @@ function civicrm_api3_goonjcustom_collection_camp_outcome_reminder_cron($params)
     ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
     ->addWhere('Collection_Camp_Intent_Details.End_Date', '<=', $endOfDay)
     ->addWhere('Collection_Camp_Intent_Details.Camp_Status', '!=', 'aborted')
+    ->addWhere('Camp_Outcome.Final_Reminder_Sent', 'IS NULL')
     ->execute();
 
   foreach ($collectionCamps as $camp) {


### PR DESCRIPTION
There were some changes to the requirement where we need 2 emails to be sent, once after 48 hours and if that is not filled then 48 hours after that. We don't want the emails to go after that.

Target issue: https://github.com/coloredcow-admin/goonj-crm/issues/149#issuecomment-2431109084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced reminder system for collection camps, including tracking of final reminders.
	- Additional data field for final reminders included in API responses.

- **Bug Fixes**
	- Improved logic for sending reminders, ensuring accurate tracking and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->