### PR TITLE
Send Feedback Email When Dropping Center is Closed or sent every 6 month

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackCron.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Civi;
+
+use Civi\Api4\Contact;
+use Civi\Api4\EckEntity;
+
+/**
+ *
+ */
+class DroppingCenterFeedbackCron {
+
+  /**
+   * Send feedback email if it hasn't been sent yet.
+   *
+   * @param array $meta
+   *   Meta data for the Dropping Center.
+   * @param string $from
+   *   Email address for 'from'.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function processDroppingCenterStatus($meta, $from) {
+    $droppingCenterId = $meta['Dropping_Center_Meta.Dropping_Center'];
+    $initiatorId = $meta['Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id'];
+    $status = $meta['Status.Feedback_Email_Delivered:name'];
+
+    // Get recipient email and name.
+    $campAttendedBy = Contact::get(TRUE)
+      ->addSelect('email.email', 'display_name')
+      ->addJoin('Email AS email', 'LEFT')
+      ->addWhere('id', '=', $initiatorId)
+      ->execute()->single();
+
+    $contactEmailId = $campAttendedBy['email.email'];
+    $organizingContactName = $campAttendedBy['display_name'];
+
+    if (!$status) {
+      $mailParams = [
+        'subject' => 'Your Feedback on Managing the Goonj Dropping Center',
+        'from' => $from,
+        'toEmail' => $contactEmailId,
+        'replyTo' => $from,
+        'html' => self::sendFeedbackEmail($organizingContactName, $droppingCenterId),
+      ];
+
+      // Send the email.
+      $feedbackEmailSendResult = \CRM_Utils_Mail::send($mailParams);
+
+      // Update status if the email is sent.
+      if ($feedbackEmailSendResult) {
+        EckEntity::update('Dropping_Center_Meta', TRUE)
+          ->addValue('Status.Feedback_Email_Delivered:name', 1)
+          ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
+          ->execute();
+      }
+    }
+  }
+
+  /**
+   * Generate HTML for feedback email.
+   *
+   * @param string $organizingContactName
+   * @param int $droppingCenterId
+   *
+   * @return string HTML content for email
+   */
+  public static function sendFeedbackEmail($organizingContactName, $droppingCenterId) {
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+
+    // URL for the feedback form.
+    $volunteerFeedback = $homeUrl . 'volunteer-feedback/#?Eck_Collection_Camp1=' . $droppingCenterId;
+
+    $html = "
+      <p>Dear $organizingContactName,</p>
+    
+      <p>Thank you for being such an outstanding representative of Goonj! 
+      Your dedication, time, and passion are truly making a difference as we work to bring essential materials to remote villages across the country.</p>
+    
+      <p>As part of our commitment to constant improvement, we would greatly appreciate hearing about your experience managing the Dropping Center. 
+      If you could spare a few moments to complete our feedback form, your input would be invaluable to us!</p>
+    
+      <p><a href='$volunteerFeedback'>Click here to access the feedback form.</a></p>
+    
+      <p>We encourage you to share any highlights, suggestions, or challenges you’ve encountered. Together, we can refine and enhance this process even further.</p>
+    
+      <p>We look forward to continuing this important journey with you!</p>
+    
+      <p>Warm Regards,<br>
+      Team Goonj</p>
+    ";
+
+    return $html;
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
@@ -51,12 +51,22 @@ class DroppingCenterFeedbackService {
    * @return array|null
    *   An associative array containing the email and display name, or null if not found.
    */
-  protected static function getContactDetails($initiatorId) {
+  public static function getContactDetails($initiatorId) {
     return Contact::get(TRUE)
       ->addSelect('email.email', 'display_name')
       ->addJoin('Email AS email', 'LEFT')
       ->addWhere('id', '=', $initiatorId)
       ->execute()->single();
+  }
+
+  /**
+   *
+   */
+  public static function updateFeedbackLastSentDate($droppingCenterId) {
+    EckEntity::update('Collection_Camp', TRUE)
+      ->addWhere('id', '=', $droppingCenterId)
+      ->addValue('Dropping_Centre.last_feedback_sent_date', (new \DateTime())->format('Y-m-d'))
+      ->execute();
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
@@ -8,7 +8,7 @@ use Civi\Api4\EckEntity;
 /**
  * Class to manage sending feedback emails for Dropping Centers.
  */
-class DroppingCenterFeedbackCron {
+class DroppingCenterFeedbackService {
 
   /**
    * Send feedback email if it hasn't been sent yet.

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
@@ -24,7 +24,7 @@ class DroppingCenterFeedbackService {
 
     // Get recipient email and name.
     $contactDetails = self::getContactDetails($initiatorId);
-    
+
     if ($contactDetails) {
       $contactEmailId = $contactDetails['email.email'];
       $organizingContactName = $contactDetails['display_name'];
@@ -40,7 +40,7 @@ class DroppingCenterFeedbackService {
       }
     }
   }
-  
+
   /**
    * Get contact details for the given initiator ID.
    *

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
@@ -21,7 +21,6 @@ class DroppingCenterFeedbackService {
    * @throws \CRM_Core_Exception
    */
   public static function processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from) {
-
     // Get recipient email and name.
     $contactDetails = self::getContactDetails($initiatorId);
 
@@ -29,15 +28,17 @@ class DroppingCenterFeedbackService {
       $contactEmailId = $contactDetails['email.email'];
       $organizingContactName = $contactDetails['display_name'];
 
-      if (!$status) {
-        self::sendFeedbackEmail($organizingContactName, $droppingCenterId, $contactEmailId, $from);
-
-        // Update status if the email is sent.
-        EckEntity::update('Dropping_Center_Meta', TRUE)
-          ->addValue('Status.Feedback_Email_Delivered:name', 1)
-          ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
-          ->execute();
+      if ($status) {
+        return;
       }
+
+      self::sendFeedbackEmail($organizingContactName, $droppingCenterId, $contactEmailId, $from);
+
+      // Update status if the email is sent.
+      EckEntity::update('Dropping_Center_Meta', TRUE)
+        ->addValue('Status.Feedback_Email_Delivered:name', 1)
+        ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
+        ->execute();
     }
   }
 

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -24,7 +24,7 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
   // Set threshold date to 6 months ago.
   $thresholdDate = (new \DateTime())->modify('-6 months')->format('Y-m-d');
 
-  // and the last feedback email was either never sent or sent more than 6 months ago.
+  // And the last feedback email was either never sent or sent more than 6 months ago.
   $droppingCenters = EckEntity::get('Collection_Camp', TRUE)
     ->addSelect('Collection_Camp_Core_Details.Contact_Id', 'Dropping_Centre.last_feedback_sent_date')
     ->addWhere('Dropping_Centre.When_do_you_wish_to_open_center_Date_', '<=', $thresholdDate)
@@ -55,10 +55,7 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
       DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);
 
       // Update the last_feedback_sent_date to the current date after the email is sent.
-      EckEntity::update('Collection_Camp', TRUE)
-        ->addWhere('id', '=', $droppingCenterId)
-        ->addValue('Dropping_Centre.last_feedback_sent_date', (new \DateTime())->format('Y-m-d'))
-        ->execute();
+      DroppingCenterFeedbackService::updateFeedbackLastSentDate($droppingCenterId);
     }
   }
   catch (Exception $e) {

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -4,16 +4,15 @@
  * @file
  */
 
-use Civi\Api4\Contact;
 use Civi\Api4\EckEntity;
-use Civi\HelperService;
 use Civi\DroppingCenterFeedbackService;
+use Civi\HelperService;
 
 /**
  *
  */
 function _civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron_spec(&$spec) {
-    // There are no parameters for the Goonjcustom cron.
+  // There are no parameters for the Goonjcustom cron.
 }
 
 /**
@@ -34,8 +33,7 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
     ->addClause('OR', ['Dropping_Centre.last_feedback_sent_date', 'IS NULL'], ['Dropping_Centre.last_feedback_sent_date', '<=', $thresholdDate])
     ->execute();
 
-
-    $from = HelperService::getDefaultFromEmail();
+  $from = HelperService::getDefaultFromEmail();
 
   try {
     foreach ($droppingCenters as $center) {
@@ -43,30 +41,27 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
       $initiatorId = $center['Collection_Camp_Core_Details.Contact_Id'];
 
       $droppingCenterMeta = EckEntity::get('Dropping_Center_Meta', TRUE)
-      ->addSelect('Status.Status:name','Status.Feedback_Email_Delivered:name')
-      ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
-      ->addWhere('Status.Status:name', '=', 'Permanently_Closed')
-      ->execute();
+        ->addSelect('Status.Status:name', 'Status.Feedback_Email_Delivered:name')
+        ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
+        ->addWhere('Status.Status:name', '=', 'Permanently_Closed')
+        ->execute();
 
+      foreach ($droppingCenterMeta as $meta) {
+        $status = $meta['Status.Feedback_Email_Delivered:name'];
 
-          
-        foreach ($droppingCenterMeta as $meta) {
-          $status = $meta['Status.Feedback_Email_Delivered:name'];    
+      }
 
-        }
-          
+      // Send email only if not delivered and not permanently closed
+      // Send the feedback email.
+      DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);
 
-          // Send email only if not delivered and not permanently closed
-            // Send the feedback email.
-            DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);
-
-            // Update the last_feedback_sent_date to the current date after the email is sent.
-            EckEntity::update('Collection_Camp', TRUE)
-              ->addWhere('id', '=', $droppingCenterId)
-              ->addValue('Dropping_Centre.last_feedback_sent_date', (new \DateTime())->format('Y-m-d'))
-              ->execute();
-          }
-        }
+      // Update the last_feedback_sent_date to the current date after the email is sent.
+      EckEntity::update('Collection_Camp', TRUE)
+        ->addWhere('id', '=', $droppingCenterId)
+        ->addValue('Dropping_Centre.last_feedback_sent_date', (new \DateTime())->format('Y-m-d'))
+        ->execute();
+    }
+  }
   catch (Exception $e) {
     \CRM_Core_Error::debug_log_message('Error processing Dropping Center feedback: ' . $e->getMessage());
   }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -24,7 +24,6 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
   // Set threshold date to 6 months ago.
   $thresholdDate = (new \DateTime())->modify('-6 months')->format('Y-m-d');
 
-  // Get all dropping centers where the center's open date is older than 6 months
   // and the last feedback email was either never sent or sent more than 6 months ago.
   $droppingCenters = EckEntity::get('Collection_Camp', TRUE)
     ->addSelect('Collection_Camp_Core_Details.Contact_Id', 'Dropping_Centre.last_feedback_sent_date')

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ */
+
+use Civi\Api4\Contact;
+use Civi\Api4\EckEntity;
+use Civi\DroppingCenterFeedbackCron;
+
+/**
+ *
+ */
+function _civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron_spec(&$spec) {
+}
+
+/**
+ *
+ */
+function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params) {
+  $returnValues = [];
+
+  $thresholdDate = (new \DateTime())->modify('-6 months')->format('Y-m-d');
+
+  $droppingCenters = EckEntity::get('Collection_Camp', TRUE)
+    ->addSelect('Dropping_Centre.When_do_you_wish_to_open_center_Date_', 'id', 'Collection_Camp_Core_Details.Contact_Id')
+    ->addWhere('Dropping_Centre.When_do_you_wish_to_open_center_Date_', '<=', $thresholdDate)
+    ->execute();
+
+  [$defaultFromName, $defaultFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail();
+  $from = "\"$defaultFromName\" <$defaultFromEmail>";
+
+  try {
+    foreach ($droppingCenters as $center) {
+      $droppingCenterId = $center['id'];
+      $initiatorId = $center['Collection_Camp_Core_Details.Contact_Id'];
+
+      $campAttendedBy = Contact::get(TRUE)
+        ->addSelect('email.email', 'display_name')
+        ->addJoin('Email AS email', 'LEFT')
+        ->addWhere('id', '=', $initiatorId)
+        ->execute()->single();
+
+      if ($campAttendedBy) {
+        $contactEmailId = $campAttendedBy['email.email'];
+        $organizingContactName = $campAttendedBy['display_name'];
+
+        DroppingCenterFeedbackCron::sendFeedbackEmail($organizingContactName, $droppingCenterId, $contactEmailId, $from);
+      }
+    }
+  }
+  catch (Exception $e) {
+    \CRM_Core_Error::debug_log_message('Error processing Dropping Center feedback: ' . $e->getMessage());
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'biannual_dropping_center_feedback_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -32,6 +32,8 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
     ->addClause('OR', ['Dropping_Centre.last_feedback_sent_date', 'IS NULL'], ['Dropping_Centre.last_feedback_sent_date', '<=', $thresholdDate])
     ->execute();
 
+  error_log("droppingCenters: " . print_r($droppingCenters, TRUE));
+
   $from = HelperService::getDefaultFromEmail();
 
   try {
@@ -42,13 +44,10 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
       $droppingCenterMeta = EckEntity::get('Dropping_Center_Meta', TRUE)
         ->addSelect('Status.Status:name', 'Status.Feedback_Email_Delivered:name')
         ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
-        ->addWhere('Status.Status:name', '=', 'Permanently_Closed')
-        ->execute();
+        ->addWhere('Status.Status:name', '=', 'Parmanently_Closed')
+        ->execute()->single();
 
-      foreach ($droppingCenterMeta as $meta) {
-        $status = $meta['Status.Feedback_Email_Delivered:name'];
-
-      }
+      $status = $droppingCenterMeta['Status.Feedback_Email_Delivered:name'];
 
       // Send email only if not delivered and not permanently closed
       // Send the feedback email.

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -32,8 +32,6 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
     ->addClause('OR', ['Dropping_Centre.last_feedback_sent_date', 'IS NULL'], ['Dropping_Centre.last_feedback_sent_date', '<=', $thresholdDate])
     ->execute();
 
-  error_log("droppingCenters: " . print_r($droppingCenters, TRUE));
-
   $from = HelperService::getDefaultFromEmail();
 
   try {

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -6,12 +6,14 @@
 
 use Civi\Api4\Contact;
 use Civi\Api4\EckEntity;
+use Civi\HelperService;
 use Civi\DroppingCenterFeedbackService;
 
 /**
  *
  */
 function _civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron_spec(&$spec) {
+    // There are no parameters for the Goonjcustom cron.
 }
 
 /**
@@ -26,45 +28,37 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
   // Get all dropping centers where the center's open date is older than 6 months
   // and the last feedback email was either never sent or sent more than 6 months ago.
   $droppingCenters = EckEntity::get('Collection_Camp', TRUE)
-    ->addSelect('Dropping_Centre.When_do_you_wish_to_open_center_Date_', 'id', 'Collection_Camp_Core_Details.Contact_Id', 'Dropping_Centre.last_feedback_sent_date')
+    ->addSelect('Collection_Camp_Core_Details.Contact_Id', 'Dropping_Centre.last_feedback_sent_date')
     ->addWhere('Dropping_Centre.When_do_you_wish_to_open_center_Date_', '<=', $thresholdDate)
     ->addWhere('Collection_Camp_Core_Details.Status:name', '=', 'Authorized')
     ->addClause('OR', ['Dropping_Centre.last_feedback_sent_date', 'IS NULL'], ['Dropping_Centre.last_feedback_sent_date', '<=', $thresholdDate])
     ->execute();
 
-  [$defaultFromName, $defaultFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail();
-  $from = "\"$defaultFromName\" <$defaultFromEmail>";
+
+    $from = HelperService::getDefaultFromEmail();
 
   try {
     foreach ($droppingCenters as $center) {
       $droppingCenterId = $center['id'];
       $initiatorId = $center['Collection_Camp_Core_Details.Contact_Id'];
 
-      // Fetch the email and name of the initiator.
-      $campAttendedBy = Contact::get(TRUE)
-        ->addSelect('email.email', 'display_name')
-        ->addJoin('Email AS email', 'LEFT')
-        ->addWhere('id', '=', $initiatorId)
-        ->execute()->single();
+      $droppingCenterMeta = EckEntity::get('Dropping_Center_Meta', TRUE)
+      ->addSelect('Status.Status:name','Status.Feedback_Email_Delivered:name')
+      ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
+      ->addWhere('Status.Status:name', '=', 'Permanently_Closed')
+      ->execute();
 
-      if ($campAttendedBy) {
-        $contactEmailId = $campAttendedBy['email.email'];
-        $organizingContactName = $campAttendedBy['display_name'];
 
-        // Check the status of the dropping center
-        $droppingCenterMeta = EckEntity::get('Dropping_Center_Meta', TRUE)
-          ->addSelect('Status.Status:name','Status.Feedback_Email_Delivered:name')
-          ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
-          ->addWhere('Status.Status:name', '=', 'Parmanently_Closed')
-          ->execute();
           
         foreach ($droppingCenterMeta as $meta) {
-          $status = $meta['Status.Feedback_Email_Delivered'];          
+          $status = $meta['Status.Feedback_Email_Delivered:name'];    
+
+        }
+          
 
           // Send email only if not delivered and not permanently closed
-          if (!$status) {
             // Send the feedback email.
-            DroppingCenterFeedbackService::sendFeedbackEmail($organizingContactName, $droppingCenterId, $contactEmailId, $from);
+            DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);
 
             // Update the last_feedback_sent_date to the current date after the email is sent.
             EckEntity::update('Collection_Camp', TRUE)
@@ -73,9 +67,6 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
               ->execute();
           }
         }
-      }
-    }
-  }
   catch (Exception $e) {
     \CRM_Core_Error::debug_log_message('Error processing Dropping Center feedback: ' . $e->getMessage());
   }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -6,7 +6,7 @@
 
 use Civi\Api4\Contact;
 use Civi\Api4\EckEntity;
-use Civi\DroppingCenterFeedbackCron;
+use Civi\DroppingCenterFeedbackService;
 
 /**
  *
@@ -64,7 +64,7 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
           // Send email only if not delivered and not permanently closed
           if (!$status) {
             // Send the feedback email.
-            DroppingCenterFeedbackCron::sendFeedbackEmail($organizingContactName, $droppingCenterId, $contactEmailId, $from);
+            DroppingCenterFeedbackService::sendFeedbackEmail($organizingContactName, $droppingCenterId, $contactEmailId, $from);
 
             // Update the last_feedback_sent_date to the current date after the email is sent.
             EckEntity::update('Collection_Camp', TRUE)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @file
+ */
+
+use Civi\Api4\Contact;
+use Civi\Api4\EckEntity;
+use Civi\Api4\OptionValue;
+
+/**
+ * Goonjcustom.FeedbackDroppingCenterCron API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_feedback_dropping_center_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.DroppingCenterCron API.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
+  $returnValues = [];
+
+  // Retrieve the Status option value.
+  $optionValues = OptionValue::get(FALSE)
+    ->addWhere('option_group_id:name', '=', 'eck_sub_types')
+    ->addWhere('name', '=', 'Status')
+    ->addWhere('grouping', '=', 'Dropping_Center_Meta')
+    ->setLimit(1)
+    ->execute()->single();
+
+  $statusName = $optionValues['value'];
+
+  $droppingCenterMetas = EckEntity::get('Dropping_Center_Meta', TRUE)
+    ->addSelect('Status.Status:name', 'Status.Closing_Date', 'Dropping_Center_Meta.Dropping_Center', 'Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id', 'Status.Feedback_Email_Delivered:name')
+    ->addWhere('subtype', '=', $statusName)
+    ->addWhere('Status.Status:name', '=', 'Parmanently_Closed')
+    ->execute();
+
+  [$defaultFromName, $defaultFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail();
+  $from = "\"$defaultFromName\" <$defaultFromEmail>";
+
+  try {
+    foreach ($droppingCenterMetas as $meta) {
+      $droppingCenterId = $meta['Dropping_Center_Meta.Dropping_Center'];
+      $initiatorId = $meta['Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id'];
+      $status = $meta['Status.Feedback_Email_Delivered:name'];
+
+      // Get recipient email and name.
+      $campAttendedBy = Contact::get(TRUE)
+        ->addSelect('email.email', 'display_name')
+        ->addJoin('Email AS email', 'LEFT')
+        ->addWhere('id', '=', $initiatorId)
+        ->execute()->single();
+
+      $contactEmailId = $campAttendedBy['email.email'];
+      $organizingContactName = $campAttendedBy['display_name'];
+      if (!$status) {
+        $mailParams = [
+          'subject' => 'Your Feedback on Managing the Goonj Dropping Center',
+          'from' => $from,
+          'toEmail' => $contactEmailId,
+          'replyTo' => $from,
+          'html' => goonjcustom_volunteer_feedback_email_html($organizingContactName, $droppingCenterId),
+        ];
+        $feedbackEmailSendResult = CRM_Utils_Mail::send($mailParams);
+
+        if ($feedbackEmailSendResult) {
+          EckEntity::update('Dropping_Center_Meta', TRUE)
+            ->addValue('Status.Feedback_Email_Delivered:name', 1)
+            ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
+            ->execute();
+        }
+
+      }
+    }
+  }
+  catch (Exception $e) {
+    error_log("Error processing: " . $e->getMessage());
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'feedback_dropping_center_cron');
+}
+
+/**
+ * Generate HTML for feedback email.
+ *
+ * @param string $organizingContactName
+ * @param int $droppingCenterId
+ *
+ * @return string HTML content for email
+ */
+function goonjcustom_volunteer_feedback_email_html($organizingContactName, $droppingCenterId) {
+  $homeUrl = \CRM_Utils_System::baseCMSURL();
+
+  // URL for the  feedback form.
+  $volunteerFeedback = $homeUrl . 'volunteer-feedback/#?Eck_Collection_Camp1=' . $droppingCenterId;
+
+  $html = "
+    <p>Dear $organizingContactName,</p>
+  
+    <p>Thank you for being such an outstanding representative of Goonj! 
+    Your dedication, time, and passion are truly making a difference as we work to bring essential materials to remote villages across the country.</p>
+  
+    <p>As part of our commitment to constant improvement, we would greatly appreciate hearing about your experience managing the Dropping Center. 
+    If you could spare a few moments to complete our feedback form, your input would be invaluable to us!</p>
+  
+    <p><a href='$volunteerFeedback'>Click here to access the feedback form.</a></p>
+  
+    <p>We encourage you to share any highlights, suggestions, or challenges you’ve encountered. Together, we can refine and enhance this process even further.</p>
+  
+    <p>We look forward to continuing this important journey with you!</p>
+  
+    <p>Warm Regards,<br>
+    Team Goonj</p>
+  ";
+
+  return $html;
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -76,7 +76,7 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
           'from' => $from,
           'toEmail' => $contactEmailId,
           'replyTo' => $from,
-          'html' => goonjcustom_volunteer_feedback_email_html($organizingContactName, $droppingCenterId),
+          'html' => sendFeedbackEmail($organizingContactName, $droppingCenterId),
         ];
         $feedbackEmailSendResult = CRM_Utils_Mail::send($mailParams);
 
@@ -105,7 +105,7 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
  *
  * @return string HTML content for email
  */
-function goonjcustom_volunteer_feedback_email_html($organizingContactName, $droppingCenterId) {
+function sendFeedbackEmail($organizingContactName, $droppingCenterId) {
   $homeUrl = \CRM_Utils_System::baseCMSURL();
 
   // URL for the  feedback form.

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -4,9 +4,9 @@
  * @file
  */
 
-use Civi\Api4\Contact;
 use Civi\Api4\EckEntity;
 use Civi\Api4\OptionValue;
+use Civi\DroppingCenterFeedbackCron;
 
 /**
  * Goonjcustom.FeedbackDroppingCenterCron API specification (optional)
@@ -46,7 +46,7 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
 
   $statusName = $optionValues['value'];
 
-  $droppingCenterMetas = EckEntity::get('Dropping_Center_Meta', TRUE)
+  $droppingCenterMeta = EckEntity::get('Dropping_Center_Meta', TRUE)
     ->addSelect('Status.Status:name', 'Status.Closing_Date', 'Dropping_Center_Meta.Dropping_Center', 'Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id', 'Status.Feedback_Email_Delivered:name')
     ->addWhere('subtype', '=', $statusName)
     ->addWhere('Status.Status:name', '=', 'Parmanently_Closed')
@@ -56,38 +56,8 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
   $from = "\"$defaultFromName\" <$defaultFromEmail>";
 
   try {
-    foreach ($droppingCenterMetas as $meta) {
-      $droppingCenterId = $meta['Dropping_Center_Meta.Dropping_Center'];
-      $initiatorId = $meta['Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id'];
-      $status = $meta['Status.Feedback_Email_Delivered:name'];
-
-      // Get recipient email and name.
-      $campAttendedBy = Contact::get(TRUE)
-        ->addSelect('email.email', 'display_name')
-        ->addJoin('Email AS email', 'LEFT')
-        ->addWhere('id', '=', $initiatorId)
-        ->execute()->single();
-
-      $contactEmailId = $campAttendedBy['email.email'];
-      $organizingContactName = $campAttendedBy['display_name'];
-      if (!$status) {
-        $mailParams = [
-          'subject' => 'Your Feedback on Managing the Goonj Dropping Center',
-          'from' => $from,
-          'toEmail' => $contactEmailId,
-          'replyTo' => $from,
-          'html' => sendFeedbackEmail($organizingContactName, $droppingCenterId),
-        ];
-        $feedbackEmailSendResult = CRM_Utils_Mail::send($mailParams);
-
-        if ($feedbackEmailSendResult) {
-          EckEntity::update('Dropping_Center_Meta', TRUE)
-            ->addValue('Status.Feedback_Email_Delivered:name', 1)
-            ->addWhere('Dropping_Center_Meta.Dropping_Center', '=', $droppingCenterId)
-            ->execute();
-        }
-
-      }
+    foreach ($droppingCenterMeta as $meta) {
+      DroppingCenterFeedbackCron::processDroppingCenterStatus($meta, $from);
     }
   }
   catch (Exception $e) {
@@ -95,40 +65,4 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
   }
 
   return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'feedback_dropping_center_cron');
-}
-
-/**
- * Generate HTML for feedback email.
- *
- * @param string $organizingContactName
- * @param int $droppingCenterId
- *
- * @return string HTML content for email
- */
-function sendFeedbackEmail($organizingContactName, $droppingCenterId) {
-  $homeUrl = \CRM_Utils_System::baseCMSURL();
-
-  // URL for the  feedback form.
-  $volunteerFeedback = $homeUrl . 'volunteer-feedback/#?Eck_Collection_Camp1=' . $droppingCenterId;
-
-  $html = "
-    <p>Dear $organizingContactName,</p>
-  
-    <p>Thank you for being such an outstanding representative of Goonj! 
-    Your dedication, time, and passion are truly making a difference as we work to bring essential materials to remote villages across the country.</p>
-  
-    <p>As part of our commitment to constant improvement, we would greatly appreciate hearing about your experience managing the Dropping Center. 
-    If you could spare a few moments to complete our feedback form, your input would be invaluable to us!</p>
-  
-    <p><a href='$volunteerFeedback'>Click here to access the feedback form.</a></p>
-  
-    <p>We encourage you to share any highlights, suggestions, or challenges you’ve encountered. Together, we can refine and enhance this process even further.</p>
-  
-    <p>We look forward to continuing this important journey with you!</p>
-  
-    <p>Warm Regards,<br>
-    Team Goonj</p>
-  ";
-
-  return $html;
 }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -6,7 +6,7 @@
 
 use Civi\Api4\EckEntity;
 use Civi\Api4\OptionValue;
-use Civi\DroppingCenterFeedbackCron;
+use Civi\DroppingCenterFeedbackService;
 
 /**
  * Goonjcustom.FeedbackDroppingCenterCron API specification (optional)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -48,7 +48,7 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
   $statusName = $optionValues['value'];
 
   $droppingCenterMeta = EckEntity::get('Dropping_Center_Meta', TRUE)
-    ->addSelect('Status.Status:name', 'Status.Closing_Date', 'Dropping_Center_Meta.Dropping_Center', 'Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id', 'Status.Feedback_Email_Delivered:name')
+    ->addSelect('Dropping_Center_Meta.Dropping_Center', 'Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id', 'Status.Feedback_Email_Delivered:name')
     ->addWhere('subtype', '=', $statusName)
     ->addWhere('Status.Status:name', '=', 'Permanently_Closed')
     ->execute();

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -56,11 +56,10 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
 
   try {
     foreach ($droppingCenterMeta as $meta) {
-
       $droppingCenterId = $meta['Dropping_Center_Meta.Dropping_Center'];
       $initiatorId = $meta['Dropping_Center_Meta.Dropping_Center.Collection_Camp_Core_Details.Contact_Id'];
       $status = $meta['Status.Feedback_Email_Delivered:name'];
-
+      
       DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);
     }
   }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -6,8 +6,8 @@
 
 use Civi\Api4\EckEntity;
 use Civi\Api4\OptionValue;
-use Civi\HelperService;
 use Civi\DroppingCenterFeedbackService;
+use Civi\HelperService;
 
 /**
  * Goonjcustom.FeedbackDroppingCenterCron API specification (optional)
@@ -53,7 +53,7 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
     ->addWhere('Status.Status:name', '=', 'Permanently_Closed')
     ->execute();
 
-    $from = HelperService::getDefaultFromEmail();
+  $from = HelperService::getDefaultFromEmail();
 
   try {
     foreach ($droppingCenterMeta as $meta) {

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -42,7 +42,6 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
     ->addWhere('option_group_id:name', '=', 'eck_sub_types')
     ->addWhere('name', '=', 'Status')
     ->addWhere('grouping', '=', 'Dropping_Center_Meta')
-    ->setLimit(1)
     ->execute()->single();
 
   $statusName = $optionValues['value'];

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/FeedbackDroppingCenterCron.php
@@ -61,7 +61,7 @@ function civicrm_api3_goonjcustom_feedback_dropping_center_cron($params) {
     }
   }
   catch (Exception $e) {
-    error_log("Error processing: " . $e->getMessage());
+    \CRM_Core_Error::debug_log_message('Error processing Dropping Center ID: ' . $meta['Dropping_Center_Meta.Dropping_Center']);
   }
 
   return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'feedback_dropping_center_cron');


### PR DESCRIPTION
1. The feedback email is triggered automatically when the status of the Dropping Center is set to "Permanently Closed" during the cron job execution.
2. Added the new custom field `Feedback_Email_Delivered` so that After the email is successfully sent, the Feedback_Email_Delivered status is updated to 1 (true) for that Dropping Center.
 `This prevents the same email from being sent again in the next cron execution for the same center.`
3. Implemented a new cron job to send feedback emails to the dropping center every six months, based on the opening date.
 
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/26a9d88b-570b-4553-8aea-b7394e71c0bf">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced automated feedback email system for Dropping Centers.
	- Added cron jobs for managing biannual and immediate feedback requests.
	- Implemented a service class to streamline the sending of feedback emails, including generating customized email content.

- **Bug Fixes**
	- Enhanced error handling for email sending processes to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->