### PR TITLE
Update Content For Dropping Center Feedback Email

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterFeedbackService.php
@@ -115,7 +115,7 @@ class DroppingCenterFeedbackService {
       <p>As part of our commitment to constant improvement, we would greatly appreciate hearing about your experience managing the Dropping Center. 
       If you could spare a few moments to complete our feedback form, your input would be invaluable to us!</p>
     
-      <p><a href='$volunteerFeedback'>Click here to access the feedback form.</a></p>
+      <p><a href='$volunteerFeedback'>Feedback Form Link.</a></p>
     
       <p>We encourage you to share any highlights, suggestions, or challenges you’ve encountered. Together, we can refine and enhance this process even further.</p>
     

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -46,6 +46,7 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
         ->execute();
 
       $status = !empty($droppingCenterMeta) ? $droppingCenterMeta[0]['Status.Feedback_Email_Delivered'] : null;
+
       // Send email only if not delivered and not permanently closed
       // Send the feedback email.
       DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -46,7 +46,6 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
         ->execute();
 
       $status = !empty($droppingCenterMeta) ? $droppingCenterMeta[0]['Status.Feedback_Email_Delivered'] : null;
-
       // Send email only if not delivered and not permanently closed
       // Send the feedback email.
       DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);


### PR DESCRIPTION
### Description

Instead of `Click here to access the feedback form` updated the text as `Feedback Form Link`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the text of a hyperlink in the feedback email to "Feedback Form Link" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->