### PR TITLE
Do Not Send Feedback Emails for Closed Status in Biannual Cron

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/BiannualDroppingCenterFeedbackCron.php
@@ -49,10 +49,16 @@ function civicrm_api3_goonjcustom_biannual_dropping_center_feedback_cron($params
 
       // Send email only if not delivered and not permanently closed
       // Send the feedback email.
-      DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);
+      if (empty($droppingCenterMeta[0])) {
+        // Proceed with sending the feedback email.
+        DroppingCenterFeedbackService::processDroppingCenterStatus($droppingCenterId, $initiatorId, $status, $from);
 
-      // Update the last_feedback_sent_date to the current date after the email is sent.
-      DroppingCenterFeedbackService::updateFeedbackLastSentDate($droppingCenterId);
+        // Update the last_feedback_sent_date to the current date after the email is sent
+        DroppingCenterFeedbackService::updateFeedbackLastSentDate($droppingCenterId);
+      }
+      else {
+        \CRM_Core_Error::debug_log_message("Feedback cron: Dropping Center ID {$droppingCenterId} is marked as 'Permanently Closed'. As a result, no email will be sent by the biannual feedback cron.");
+      }
     }
   }
   catch (Exception $e) {


### PR DESCRIPTION
### Description 

1. The biannual cron is responsible for sending feedback emails when a dropping center is active. Currently, it sends an email if the dropping center has been open for six months, even if the status is closed. To address this issue, the code has been updated to include a check that prevents emails from being sent to dropping centers that are closed.

2. Send the feedback cron email only if the status is authorized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced feedback email logic to ensure emails are sent only for active dropping centers.
	- Improved clarity in comments regarding the email sending process.
	- Added selection of additional data for better feedback processing based on dropping center status.

- **Bug Fixes**
	- Added conditional checks to prevent sending emails for permanently closed dropping centers.
	- Updated error logging to include more detailed information for better troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->