### PR TITLE
Add read-only custom field for displaying Goonj Office name in vehicle dispatch form

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -364,12 +364,13 @@ class DroppingCenterService extends AutoSubscriber {
     }
 
     $droppingCenterData = EckEntity::get('Collection_Camp', TRUE)
-      ->addSelect('Collection_Camp_Core_Details.Contact_Id', 'Dropping_Centre.Goonj_Office')
+      ->addSelect('Collection_Camp_Core_Details.Contact_Id', 'Dropping_Centre.Goonj_Office','Dropping_Centre.Goonj_Office.display_name')
       ->addWhere('id', '=', $droppingCenterId)
       ->execute()->single();
 
     $contactId = $droppingCenterData['Collection_Camp_Core_Details.Contact_Id'] ?? NULL;
     $goonjOffice = $droppingCenterData['Dropping_Centre.Goonj_Office'] ?? 'N/A';
+    $goonjOfficeName = $droppingCenterData['Dropping_Centre.Goonj_Office.display_name'];
 
     if (!$contactId) {
       return;
@@ -385,15 +386,15 @@ class DroppingCenterService extends AutoSubscriber {
     $initiatorName = $contactInfo['display_name'];
 
     // Send the dispatch email.
-    self::sendDispatchEmail($email, $initiatorName, $droppingCenterId, $contactId, $goonjOffice);
+    self::sendDispatchEmail($email, $initiatorName, $droppingCenterId, $contactId, $goonjOffice, $goonjOfficeName);
   }
 
   /**
    *
    */
-  public static function sendDispatchEmail($email, $initiatorName, $droppingCenterId, $contactId, $goonjOffice) {
+  public static function sendDispatchEmail($email, $initiatorName, $droppingCenterId, $contactId, $goonjOffice, $goonjOfficeName) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
-    $vehicleDispatchFormUrl = $homeUrl . '/vehicle-dispatch/#?Camp_Vehicle_Dispatch.Collection_Camp=' . $droppingCenterId . '&Camp_Vehicle_Dispatch.Filled_by=' . $contactId . '&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent=' . $goonjOffice . '&Eck_Collection_Camp1=' . $droppingCenterId;
+    $vehicleDispatchFormUrl = $homeUrl . '/vehicle-dispatch/#?Camp_Vehicle_Dispatch.Collection_Camp=' . $droppingCenterId . '&Camp_Vehicle_Dispatch.Filled_by=' . $contactId . '&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent=' . $goonjOffice . '&Camp_Vehicle_Dispatch.Goonj_Office_Name=' . $goonjOfficeName  . '&Eck_Collection_Camp1=' . $droppingCenterId;
 
     $emailHtml = "
     <html>


### PR DESCRIPTION
### Description

The requirement is to display the Goonj Office field as read-only. Currently, it shows the Goonj Office ID via autocomplete, but we need to display the office name instead. To resolve this issue, a new custom field should be created specifically for the Goonj Office name. The office name should be passed to this field, and it should be set to display-only, ensuring the field cannot be edited by the user.

<img width="357" alt="image" src="https://github.com/user-attachments/assets/d37f9b94-c20b-4638-b89a-695b9637ef93">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dispatch email notifications to include the Goonj office display name in the vehicle dispatch form URL.

- **Bug Fixes**
	- Improved method parameters for better data handling within dispatch email processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->