### PR TITLE
Separate Common Tabs

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -33,7 +33,6 @@ class CollectionBaseService extends AutoSubscriber {
    */
   public static function getSubscribedEvents() {
     return [
-      '&hook_civicrm_tabset' => 'collectionBaseTabset',
       '&hook_civicrm_selectWhereClause' => 'aclCollectionCamp',
       '&hook_civicrm_pre' => [
         ['handleAuthorizationEmails'],
@@ -176,41 +175,6 @@ class CollectionBaseService extends AutoSubscriber {
     else {
       \Civi::log()->debug("Failed to generate poster image, return code: $returnCode");
       return FALSE;
-    }
-  }
-
-  /**
-   *
-   */
-  public static function collectionBaseTabset($tabsetName, &$tabs, $context) {
-    if ($tabsetName !== 'civicrm/eck/entity' || empty($context) || $context['entity_type']['name'] !== self::ENTITY_NAME) {
-      return;
-    }
-
-    $tabConfigs = [
-      'vehicleDispatch' => [
-        'title' => ts('Dispatch'),
-        'module' => 'afsearchCampVehicleDispatchData',
-        'directive' => 'afsearch-camp-vehicle-dispatch-data',
-      ],
-      'materialAuthorization' => [
-        'title' => ts('Material Authorization'),
-        'module' => 'afsearchAcknowledgementForLogisticsData',
-        'directive' => 'afsearch-acknowledgement-for-logistics-data',
-      ],
-    ];
-
-    foreach ($tabConfigs as $key => $config) {
-      $tabs[$key] = [
-        'id' => $key,
-        'title' => $config['title'],
-        'is_active' => 1,
-        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-        'module' => $config['module'],
-        'directive' => $config['directive'],
-      ];
-
-      \Civi::service('angularjs.loader')->addModules($config['module']);
     }
   }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -91,6 +91,18 @@ class CollectionCampService extends AutoSubscriber {
         'directive' => 'afsearch-event-volunteer',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
+      'vehicleDispatch' => [
+        'title' => ts('Dispatch'),
+        'module' => 'afsearchCampVehicleDispatchData',
+        'directive' => 'afsearch-camp-vehicle-dispatch-data',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
+      'materialAuthorization' => [
+        'title' => ts('Material Authorization'),
+        'module' => 'afsearchAcknowledgementForLogisticsData',
+        'directive' => 'afsearch-acknowledgement-for-logistics-data',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
       'materialContribution' => [
         'title' => ts('Material Contribution'),
         'module' => 'afsearchCollectionCampMaterialContributions',

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -85,6 +85,12 @@ class CollectionCampService extends AutoSubscriber {
       //   'directive' => 'afsearch-collection-camp-activity',
       //   'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       // ],
+      'logistics' => [
+        'title' => ts('Logistics'),
+        'module' => 'afsearchCollectionCampLogistics',
+        'directive' => 'afsearch-collection-camp-logistics',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
       'eventVolunteers' => [
         'title' => ts('Event Volunteers'),
         'module' => 'afsearchEventVolunteer',
@@ -107,12 +113,6 @@ class CollectionCampService extends AutoSubscriber {
         'title' => ts('Material Contribution'),
         'module' => 'afsearchCollectionCampMaterialContributions',
         'directive' => 'afsearch-collection-camp-material-contributions',
-        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      ],
-      'logistics' => [
-        'title' => ts('Logistics'),
-        'module' => 'afsearchCollectionCampLogistics',
-        'directive' => 'afsearch-collection-camp-logistics',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
       'campOutcome' => [

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -464,18 +464,30 @@ class DroppingCenterService extends AutoSubscriber {
       return;
     }
     $tabConfigs = [
+      'logistics' => [
+        'title' => ts('Logistics'),
+        'module' => 'afsearchLogistics',
+        'directive' => 'afsearch-logistics',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ], 
       'eventCoordinators' => [
         'title' => ts('Event Coordinators'),
         'module' => 'afsearchCoordinator',
         'directive' => 'afsearch-coordinator',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
-      'logistics' => [
-        'title' => ts('Logistics'),
-        'module' => 'afsearchLogistics',
-        'directive' => 'afsearch-logistics',
+      'vehicleDispatch' => [
+        'title' => ts('Dispatch'),
+        'module' => 'afsearchCampVehicleDispatchData',
+        'directive' => 'afsearch-camp-vehicle-dispatch-data',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      ],    
+      ],
+      'materialAuthorization' => [
+        'title' => ts('Material Authorization'),
+        'module' => 'afsearchAcknowledgementForLogisticsData',
+        'directive' => 'afsearch-acknowledgement-for-logistics-data',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],   
       'materialContribution' => [
         'title' => ts('Material Contribution'),
         'module' => 'afsearchDroppingCenterMaterialContributions',

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -469,7 +469,7 @@ class DroppingCenterService extends AutoSubscriber {
         'module' => 'afsearchLogistics',
         'directive' => 'afsearch-logistics',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      ], 
+      ],
       'eventCoordinators' => [
         'title' => ts('Event Coordinators'),
         'module' => 'afsearchCoordinator',
@@ -487,7 +487,7 @@ class DroppingCenterService extends AutoSubscriber {
         'module' => 'afsearchAcknowledgementForLogisticsData',
         'directive' => 'afsearch-acknowledgement-for-logistics-data',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      ],   
+      ],
       'materialContribution' => [
         'title' => ts('Material Contribution'),
         'module' => 'afsearchDroppingCenterMaterialContributions',
@@ -523,7 +523,7 @@ class DroppingCenterService extends AutoSubscriber {
         'module' => 'afsearchFeedback',
         'directive' => 'afsearch-feedback',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      ],   
+      ],
     ];
 
     foreach ($tabConfigs as $key => $config) {


### PR DESCRIPTION
### Description

Separate Common Tabs

- The 'Vehicle Dispatch' and 'Material Authorization' tabs should be separated and added individually to the Dropping Center and Collection Camp sections.
The reason for this change is to allow flexibility in ordering these tabs as needed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new tab configurations for vehicle dispatch and material authorization in the collection camp management interface.
	- Introduced a new 'Logistics' tab in the dropping center management interface, replacing the previous configuration.

- **Enhancements**
	- Improved address setting logic for collection camps based on form submissions.
	- Refined camp status updates to ensure accurate tracking of collection camp states.
	- Enhanced tab management for the dropping center service with updated configurations.

- **Bug Fixes**
	- Enhanced error handling for collection camp code generation to prevent issues with missing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->