### PR TITLE
Added shotcode and tokens for Automatic induction scheduling

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -134,8 +134,7 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
 					->addSelect('activity_date_time', 'Induction_Fields.Goonj_Office')
 					->addWhere('activity_type_id:name', '=', 'Induction')
 					->addWhere('source_contact_id', '=', $contactId)
-					->execute()
-					->single();
+					->execute()->single();
 
 			$inductionDateTime = $inductionActivity['activity_date_time'] ?? 'Not Scheduled';
 			$inductionGoonjOffice = $inductionActivity['Induction_Fields.Goonj_Office'] ?? '';
@@ -147,8 +146,7 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
 							->addSelect('Goonj_Office_Details.Induction_Meeting_Access_Link')
 							->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
 							->addWhere('id', '=', $inductionGoonjOffice)
-							->execute()
-              ->single();
+							->execute()->single();
 
 					$inductionOnlineMeetlink = $officeDetails['Goonj_Office_Details.Induction_Meeting_Access_Link'] ?? '';
 			}

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -65,8 +65,11 @@ function goonjcustom_civicrm_container(ContainerBuilder $container) {
  */
 function goonjcustom_register_tokens(TokenRegisterEvent $e) {
   $e->entity('contact')
-    ->register('inductionDetails', ts('Induction details'));
+    ->register('inductionDetails', ts('Induction details'))
+    ->register('inductionDateTime', ts('Induction Scheduled Date & Time'))
+    ->register('inductionOnlineMeetlink', ts('Induction Online Meet link'));
 }
+
 
 /**
  *
@@ -127,6 +130,35 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
       }
 
       $row->tokens('contact', 'inductionDetails', $inductionDetailsMarkup);
+			// Fetch induction activity details
+			$inductionActivity = \Civi\Api4\Activity::get(FALSE)
+					->addSelect('activity_date_time', 'Induction_Fields.Goonj_Office')
+					->addWhere('activity_type_id:name', '=', 'Induction')
+					->addWhere('source_contact_id', '=', $contactId)
+					->setLimit(1)
+					->execute()
+					->first();
+
+			$inductionDateTime = $inductionActivity['activity_date_time'] ?? 'Not Scheduled';
+			$inductionGoonjOffice = $inductionActivity['Induction_Fields.Goonj_Office'] ?? '';
+
+			// Fetch office online meet link details if induction office is specified
+			$inductionOnlineMeetlink = '';
+			if ($inductionGoonjOffice) {
+					$officeDetails = \Civi\Api4\Contact::get(FALSE)
+							->addSelect('Goonj_Office_Details.Induction_Meeting_Access_Link')
+							->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
+							->addWhere('id', '=', $inductionGoonjOffice)
+							->execute()
+							->first();
+
+					$inductionOnlineMeetlink = $officeDetails['Goonj_Office_Details.Induction_Meeting_Access_Link'] ?? '';
+			}
+
+			// Assign tokens
+			$row->tokens('contact', 'inductionDateTime', $inductionDateTime);
+			$row->tokens('contact', 'inductionOnlineMeetlink', $inductionOnlineMeetlink);
+
     }
   }
 }

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -70,7 +70,6 @@ function goonjcustom_register_tokens(TokenRegisterEvent $e) {
     ->register('inductionOnlineMeetlink', ts('Induction Online Meet link'));
 }
 
-
 /**
  *
  */
@@ -135,9 +134,8 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
 					->addSelect('activity_date_time', 'Induction_Fields.Goonj_Office')
 					->addWhere('activity_type_id:name', '=', 'Induction')
 					->addWhere('source_contact_id', '=', $contactId)
-					->setLimit(1)
 					->execute()
-					->first();
+					->single();
 
 			$inductionDateTime = $inductionActivity['activity_date_time'] ?? 'Not Scheduled';
 			$inductionGoonjOffice = $inductionActivity['Induction_Fields.Goonj_Office'] ?? '';
@@ -150,7 +148,7 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
 							->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
 							->addWhere('id', '=', $inductionGoonjOffice)
 							->execute()
-							->first();
+              ->single();
 
 					$inductionOnlineMeetlink = $officeDetails['Goonj_Office_Details.Induction_Meeting_Access_Link'] ?? '';
 			}

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -148,7 +148,6 @@ function goonj_induction_slot_details() {
             ->addWhere('activity_type_id:name', '=', 'Induction')
             ->execute()
             ->single();
-		\Civi::log()->info('inductionActivity', ['inductionActivity'=>$inductionActivity]);
 
         // Exit if no activity found or the status is not "To be Scheduled"
         if (!$inductionActivity || $inductionActivity['status_id:name'] !== 'To be scheduled') {
@@ -184,8 +183,7 @@ function goonj_induction_slot_details() {
         // Fetch the email template
         $template = \Civi\Api4\MessageTemplate::get(FALSE)
             ->addWhere('msg_title', 'LIKE', $templateTitle . '%')
-            ->execute()
-            ->single();
+            ->execute()->single();
 
         // If a template is found, send the email notification
         if ($template) {
@@ -193,8 +191,7 @@ function goonj_induction_slot_details() {
                 ->addSelect('email.email')
                 ->addJoin('Email AS email', 'LEFT')
                 ->addWhere('id', '=', $inductionActivity['Induction_Fields.Assign'])
-                ->execute()
-				->single();
+				->execute()->single();
 
             // Prepare email parameters
             $emailParams = [
@@ -205,8 +202,6 @@ function goonj_induction_slot_details() {
 
             // Send the email
             $emailResult = civicrm_api3('Email', 'send', $emailParams);
-        } else {
-            \Civi::log()->error('No email template found', ['template_title' => $templateTitle]);
         }
     } catch (\Exception $e) {
         \Civi::log()->error('Error processing induction slot details', [

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -146,8 +146,7 @@ function goonj_induction_slot_details() {
             ->addSelect('id', 'activity_date_time', 'status_id:name', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
             ->addWhere('source_contact_id', '=', $source_contact_id)
             ->addWhere('activity_type_id:name', '=', 'Induction')
-            ->execute()
-            ->single();
+            ->execute()->single();
 
         // Exit if no activity found or the status is not "To be Scheduled"
         if (!$inductionActivity || $inductionActivity['status_id:name'] !== 'To be scheduled') {

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -146,9 +146,8 @@ function goonj_induction_slot_details() {
             ->addSelect('id', 'activity_date_time', 'status_id:name', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
             ->addWhere('source_contact_id', '=', $source_contact_id)
             ->addWhere('activity_type_id:name', '=', 'Induction')
-            ->setLimit(1)
             ->execute()
-            ->first();
+            ->single();
 		\Civi::log()->info('inductionActivity', ['inductionActivity'=>$inductionActivity]);
 
         // Exit if no activity found or the status is not "To be Scheduled"
@@ -185,7 +184,6 @@ function goonj_induction_slot_details() {
         // Fetch the email template
         $template = \Civi\Api4\MessageTemplate::get(FALSE)
             ->addWhere('msg_title', 'LIKE', $templateTitle . '%')
-            ->setLimit(1)
             ->execute()
             ->single();
 
@@ -195,8 +193,8 @@ function goonj_induction_slot_details() {
                 ->addSelect('email.email')
                 ->addJoin('Email AS email', 'LEFT')
                 ->addWhere('id', '=', $inductionActivity['Induction_Fields.Assign'])
-                ->setLimit(1)
-                ->execute()->single();
+                ->execute()
+				->single();
 
             // Prepare email parameters
             $emailParams = [


### PR DESCRIPTION
- Created a new token for the email message template to include the induction slot date and time, as well as the online induction meeting link, for sending slot booking details via email.
- Added a shortcode to capture source_contact_id, slot_date, slot_time, and induction_type from URL parameters, allowing dynamic handling of induction slot bookings.
Updated the contact induction activity's date, time, and status to "Scheduled" if not already scheduled or completed.
Selected the appropriate email template based on induction type to send acknowledgment emails after slot booking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new tokens for induction processes, including `inductionDateTime` and `inductionOnlineMeetlink`.
	- Added a shortcode for managing induction slot details, allowing for scheduling and email notifications based on induction activities.

- **Bug Fixes**
	- Enhanced error handling for invalid date/time formats and missing email templates during induction slot management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->