### PR TITLE
Added cron to update induction status and send followup email

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -502,7 +502,6 @@ class InductionService extends AutoSubscriber {
    *
    */
   public static function updateInductionStatusNoShow() {
-    \Civi::log()->info('cjecka');
 		$followUpDays = 30;
 		$followUpTimestamp = strtotime("-$followUpDays days");
 		$batchSize = 25;
@@ -559,11 +558,6 @@ class InductionService extends AutoSubscriber {
 						->addValue('status_id:name', 'No_show')
 						->addWhere('id', '=', $inductionActivity['id'])
 						->execute();
-
-					\Civi::log()->info('Induction activity status updated to No_show', [
-						'inductionActivityId' => $inductionActivity['id'],
-						'updateResult' => $updateResult
-					]);
 				}
 
 				// Increment the offset by the batch size
@@ -571,9 +565,8 @@ class InductionService extends AutoSubscriber {
 			} while (count($followUpEmailActivities) === $batchSize);
 
 		} catch (\Exception $e) {
-			// Log any errors encountered during the process
 			\Civi::log()->error('Error in updating induction status: ' . $e->getMessage());
-			throw $e; // Re-throw the exception to handle it at a higher level
+			throw $e;
 		}
 	}
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -498,4 +498,82 @@ class InductionService extends AutoSubscriber {
     } while (count($unscheduledInductionActivities) === $batchSize);
   }
 
+  /**
+   *
+   */
+  public static function updateInductionStatusNoShow() {
+    \Civi::log()->info('cjecka');
+		$followUpDays = 30;
+		$followUpTimestamp = strtotime("-$followUpDays days");
+		$batchSize = 25;
+		$offset = 0;
+
+		try {
+			// Fetch the follow-up message template
+			$template = MessageTemplate::get(FALSE)
+				->addSelect('id', 'msg_subject')
+				->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
+				->execute()->single();
+
+			if (!$template) {
+				throw new \Exception('Follow-up email template not found.');
+			}
+
+			do {
+				// Fetch email activities older than 30 days
+				$followUpEmailActivities = Activity::get(TRUE)
+					->addSelect('source_contact_id', 'activity_date_time')
+					->addWhere('subject', '=', $template['msg_subject'])
+					->addWhere('activity_type_id:label', '=', 'Email')
+					->addWhere('created_date', '<', date('Y-m-d H:i:s', $followUpTimestamp))
+					->setLimit($batchSize)
+					->setOffset($offset)->execute();
+
+				foreach ($followUpEmailActivities as $activity) {
+					// Fetch the associated induction activity
+					$inductionActivity = Activity::get(FALSE)
+						->addSelect('id', 'source_contact_id', 'status_id:name')
+						->addWhere('activity_type_id:name', '=', 'Induction')
+						->addWhere('source_contact_id', '=', $activity['source_contact_id'])
+						->execute()
+						->single();
+
+					if (!$inductionActivity) {
+						\Civi::log()->info('No induction activity found for source contact', [
+							'source_contact_id' => $activity['source_contact_id'],
+						]);
+						continue;
+					}
+
+					// Check if the status is 'Completed' or 'Scheduled'
+					if (in_array($inductionActivity['status_id:name'], ['Completed', 'Scheduled'])) {
+						\Civi::log()->info('Induction activity is already completed or scheduled, skipping', [
+							'inductionActivityId' => $inductionActivity['id'],
+							'status' => $inductionActivity['status_id:name']
+						]);
+						continue;
+					}
+
+					// Update the induction status to 'No_show'
+					$updateResult = Activity::update(FALSE)
+						->addValue('status_id:name', 'No_show')
+						->addWhere('id', '=', $inductionActivity['id'])
+						->execute();
+
+					\Civi::log()->info('Induction activity status updated to No_show', [
+						'inductionActivityId' => $inductionActivity['id'],
+						'updateResult' => $updateResult
+					]);
+				}
+
+				// Increment the offset by the batch size
+				$offset += $batchSize;
+			} while (count($followUpEmailActivities) === $batchSize);
+
+		} catch (\Exception $e) {
+			// Log any errors encountered during the process
+			\Civi::log()->error('Error in updating induction status: ' . $e->getMessage());
+			throw $e; // Re-throw the exception to handle it at a higher level
+		}
+	}
 }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
@@ -35,7 +35,6 @@ function _civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron_spec(&$
  */
 function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params) {
     $returnValues = [];
-    \Civi::log()->info('Check for unscheduled induction activities');
 
     // Configurable number of days to check for scheduling
     $followUpDays = 7;

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
@@ -49,9 +49,7 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
         $template = MessageTemplate::get(FALSE)
             ->addSelect('id', 'msg_subject')
             ->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
-            ->setLimit(1)
-            ->execute()
-            ->single();
+            ->execute()->single();
 
         do {
             // Retrieve a batch of unscheduled induction activities older than 7 days
@@ -71,8 +69,7 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
                     ->addWhere('activity_type_id:name', '=', 'Email')
                     ->addWhere('subject', '=', $template['msg_subject'])
                     ->addWhere('source_contact_id', '=', $activity['source_contact_id'])
-                    ->setLimit(1)
-                    ->execute()->first();
+                    ->execute()->single();
 
                 if (!$emailActivities) {
                     $emailParams = [

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
@@ -39,6 +39,8 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
 
     // Configurable number of days to check for scheduling
     $followUpDays = 7;
+
+    // Calculate the timestamp for 7 days ago from the current date
     $followUpTimestamp = strtotime("-$followUpDays days");
 
     $batchSize = 25;

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
@@ -41,11 +41,11 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
     $followUpDays = 7;
     $followUpTimestamp = strtotime("-$followUpDays days");
 
-    $batchSize = 25; // Process activities in batches of 25
+    $batchSize = 25;
     $offset = 0;
 
     try {
-        // Retrieve the email template for follow-up once outside the loop.
+        // Retrieve the email template for follow-up.
         $template = MessageTemplate::get(FALSE)
             ->addSelect('id', 'msg_subject')
             ->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
@@ -66,7 +66,7 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
 
             // Process each activity in the batch
             foreach ($unscheduledInductionActivities as $activity) {
-                // Check if an email has already been sent to avoid duplication.
+                // Check if an followup email has already been sent to avoid duplication.
                 $emailActivities = Activity::get(FALSE)
                     ->addWhere('activity_type_id:name', '=', 'Email')
                     ->addWhere('subject', '=', $template['msg_subject'])
@@ -75,22 +75,20 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
                     ->execute()->first();
 
                 if (!$emailActivities) {
-                    // Prepare email parameters and send the email.
                     $emailParams = [
                         'contact_id' => $activity['source_contact_id'],
                         'template_id' => $template['id'],
                     ];
                     $emailResult = civicrm_api3('Email', 'send', $emailParams);
                     \Civi::log()->info('Follow-up email sent', ['result' => $emailResult]);
-                } else {
-                    \Civi::log()->info('Email already sent to contact', ['contact_id' => $activity['source_contact_id']]);
                 }
+
             }
 
             // Move to the next batch by increasing the offset
             $offset += $batchSize;
 
-        } while (count($unscheduledInductionActivities) === $batchSize); // Continue until no more records
+        } while (count($unscheduledInductionActivities) === $batchSize);
 
     } catch (Exception $e) {
         // Log any errors encountered during the process.

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
@@ -78,7 +78,6 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
                         'template_id' => $template['id'],
                     ];
                     $emailResult = civicrm_api3('Email', 'send', $emailParams);
-                    \Civi::log()->info('Follow-up email sent', ['result' => $emailResult]);
                 }
 
             }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
@@ -1,0 +1,102 @@
+<?php
+
+use Civi\Api4\Activity;
+use Civi\Api4\MessageTemplate;
+
+/**
+ * Goonjcustom.InductionSlotBookingFollowUp API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.induction_slot_booking_follow_up_cron API implementation.
+ *
+ * This function checks for unscheduled induction activities older than 7 days 
+ * and sends follow-up emails to the respective contacts if they haven't already 
+ * received one.
+ *
+ * @param array $params
+ *   Parameters passed to the API call.
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params) {
+    $returnValues = [];
+    \Civi::log()->info('Check for unscheduled induction activities');
+
+    // Configurable number of days to check for scheduling
+    $followUpDays = 7;
+    $followUpTimestamp = strtotime("-$followUpDays days");
+
+    $batchSize = 25; // Process activities in batches of 25
+    $offset = 0;
+
+    try {
+        // Retrieve the email template for follow-up once outside the loop.
+        $template = MessageTemplate::get(FALSE)
+            ->addSelect('id', 'msg_subject')
+            ->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
+            ->setLimit(1)
+            ->execute()
+            ->single();
+
+        do {
+            // Retrieve a batch of unscheduled induction activities older than 7 days
+            $unscheduledInductionActivities = Activity::get(FALSE)
+                ->addSelect('id', 'source_contact_id', 'created_date')
+                ->addWhere('activity_type_id:name', '=', 'Induction')
+                ->addWhere('status_id:name', '=', 'To be scheduled')
+                ->addWhere('created_date', '<', date('Y-m-d H:i:s', $followUpTimestamp))
+                ->setLimit($batchSize)
+                ->setOffset($offset)
+                ->execute();
+
+            // Process each activity in the batch
+            foreach ($unscheduledInductionActivities as $activity) {
+                // Check if an email has already been sent to avoid duplication.
+                $emailActivities = Activity::get(FALSE)
+                    ->addWhere('activity_type_id:name', '=', 'Email')
+                    ->addWhere('subject', '=', $template['msg_subject'])
+                    ->addWhere('source_contact_id', '=', $activity['source_contact_id'])
+                    ->setLimit(1)
+                    ->execute()->first();
+
+                if (!$emailActivities) {
+                    // Prepare email parameters and send the email.
+                    $emailParams = [
+                        'contact_id' => $activity['source_contact_id'],
+                        'template_id' => $template['id'],
+                    ];
+                    $emailResult = civicrm_api3('Email', 'send', $emailParams);
+                    \Civi::log()->info('Follow-up email sent', ['result' => $emailResult]);
+                } else {
+                    \Civi::log()->info('Email already sent to contact', ['contact_id' => $activity['source_contact_id']]);
+                }
+            }
+
+            // Move to the next batch by increasing the offset
+            $offset += $batchSize;
+
+        } while (count($unscheduledInductionActivities) === $batchSize); // Continue until no more records
+
+    } catch (Exception $e) {
+        // Log any errors encountered during the process.
+        \Civi::log()->error('Error in follow-up cron: ' . $e->getMessage());
+        return civicrm_api3_create_error($e->getMessage());
+    }
+
+    return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'induction_slot_booking_follow_up_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionSlotBookingFollowUpCron.php
@@ -39,7 +39,6 @@ function civicrm_api3_goonjcustom_induction_slot_booking_follow_up_cron($params)
     try {
         InductionService::sendFollowUpEmails();
     } catch (Exception $e) {
-        // Log any errors encountered during the process.
         \Civi::log()->error('Error in follow-up cron: ' . $e->getMessage());
         return civicrm_api3_create_error($e->getMessage());
     }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -38,7 +38,6 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
     try {
         InductionService::updateInductionStatusNoShow();
     } catch (\Exception $e) {
-        // Log any errors encountered during the process
         \Civi::log()->error('Error in follow-up cron: ' . $e->getMessage());
         return civicrm_api3_create_error($e->getMessage());
     }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -1,0 +1,134 @@
+<?php
+
+use Civi\Api4\Activity;
+use Civi\Api4\MessageTemplate;
+
+/**
+ * Goonjcustom.InductionSlotBookingFollowUp API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_update_induction_status_no_show_cron_spec(&$spec) {
+    // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.induction_slot_booking_follow_up_cron API implementation.
+ *
+ * This function checks for unscheduled induction activities older than 7 days 
+ * and sends follow-up emails to the respective contacts if they haven't already 
+ * received one within a configurable number of days.
+ *
+ * @param array $params
+ *   Parameters passed to the API call.
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) {
+    $returnValues = [];
+    \Civi::log()->info('Starting the induction slot booking follow-up cron job.');
+
+    // Configurable number of days to check for follow-up emails
+    $followUpDays = 30; // You can set this to any number of days as needed
+    $followUpTimestamp = strtotime("-$followUpDays days");
+
+    // Set batch size to process 25 records at a time
+    $batchSize = 25;
+    $offset = 0;
+
+    try {
+        // Fetch the message template for the follow-up email
+        $template = MessageTemplate::get(FALSE)
+            ->addSelect('id', 'msg_subject')
+            ->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
+            ->setLimit(1)
+            ->execute()
+            ->single();
+
+        if (!$template) {
+            throw new \Exception('Follow-up email template not found.');
+        }
+
+        \Civi::log()->info('Email template retrieved successfully', ['template' => $template]);
+
+        // Loop through activities in batches
+        do {
+            // Fetch email activities in the current batch that were sent within the specified follow-up period
+            $followUpEmailActivities = Activity::get(TRUE)
+              ->addSelect('source_contact_id', 'activity_date_time')
+              ->addWhere('subject', '=', $template['msg_subject'])
+              ->addWhere('activity_type_id:label', '=', 'Email')
+              ->addWhere('created_date', '<', date('Y-m-d H:i:s', $followUpTimestamp))
+              ->setLimit($batchSize)
+              ->setOffset($offset)
+              ->execute();
+
+            \Civi::log()->info('Batch of follow-up email activities retrieved', [
+                'followUpEmailActivities' => $followUpEmailActivities,
+            ]);
+
+            // Process each activity in the batch
+            foreach ($followUpEmailActivities as $activity) {
+                \Civi::log()->info('Processing follow-up activity', ['activity' => $activity]);
+
+                // Fetch the associated induction activity
+                $inductionActivity = Activity::get(FALSE)
+                    ->addSelect('id', 'source_contact_id', 'status_id:name')
+                    ->addWhere('activity_type_id:name', '=', 'Induction')
+                    ->addWhere('source_contact_id', '=', $activity['source_contact_id'])
+                    ->execute()
+                    ->single();
+
+                if (!$inductionActivity) {
+                    \Civi::log()->warning('No induction activity found for source contact', [
+                        'source_contact_id' => $activity['source_contact_id'],
+                    ]);
+                    continue;
+                }
+
+                \Civi::log()->info('Induction activity retrieved', ['inductionActivity' => $inductionActivity]);
+
+                // Check if the status is 'Completed' or 'Scheduled'
+                if (in_array($inductionActivity['status_id:name'], ['Completed', 'Scheduled'])) {
+                    \Civi::log()->info('Induction activity is already completed or scheduled, skipping', [
+                        'inductionActivityId' => $inductionActivity['id'],
+                        'status' => $inductionActivity['status_id:name']
+                    ]);
+                    continue;
+                }
+
+                // // Update the induction status to 'No_show'
+                $updateResult = Activity::update(FALSE)
+                    ->addValue('status_id:name', 'No_show')
+                    ->addWhere('id', '=', $inductionActivity['id'])
+                    ->execute();
+
+                \Civi::log()->info('Induction activity status updated to No_show', [
+                    'inductionActivityId' => $inductionActivity['id'],
+                    'updateResult' => $updateResult
+                ]);
+            }
+
+            // Increment the offset by the batch size
+            $offset += $batchSize;
+        } while (count($followUpEmailActivities) === $batchSize); // Continue until there are no more records
+
+    } catch (\Exception $e) {
+        // Log any errors encountered during the process
+        \Civi::log()->error('Error in follow-up cron: ' . $e->getMessage());
+        return civicrm_api3_create_error($e->getMessage());
+    }
+
+    \Civi::log()->info('Induction slot booking follow-up cron job completed successfully.');
+
+    return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'update_induction_status_no_show_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -36,6 +36,8 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
     $returnValues = [];
 
     $followUpDays = 30;
+
+    // Calculate the timestamp for 30 days ago from the current date
     $followUpTimestamp = strtotime("-$followUpDays days");
 
     $batchSize = 25;

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -4,7 +4,7 @@ use Civi\Api4\Activity;
 use Civi\Api4\MessageTemplate;
 
 /**
- * Goonjcustom.InductionSlotBookingFollowUp API specification (optional)
+ * Goonjcustom.Induction Status Update to No Show API specification (optional)
  * This is used for documentation and validation.
  *
  * @param array $spec
@@ -17,11 +17,10 @@ function _civicrm_api3_goonjcustom_update_induction_status_no_show_cron_spec(&$s
 }
 
 /**
- * Goonjcustom.induction_slot_booking_follow_up_cron API implementation.
+ * Goonjcustom.update_induction_status_no_show_cron API implementation.
  *
- * This function checks for unscheduled induction activities older than 7 days 
- * and sends follow-up emails to the respective contacts if they haven't already 
- * received one within a configurable number of days.
+ * This function checks for unscheduled induction activities older than 30 days 
+ * and update induction status to No Show
  *
  * @param array $params
  *   Parameters passed to the API call.
@@ -35,18 +34,15 @@ function _civicrm_api3_goonjcustom_update_induction_status_no_show_cron_spec(&$s
  */
 function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) {
     $returnValues = [];
-    \Civi::log()->info('Starting the induction slot booking follow-up cron job.');
 
-    // Configurable number of days to check for follow-up emails
-    $followUpDays = 30; // You can set this to any number of days as needed
+    $followUpDays = 30;
     $followUpTimestamp = strtotime("-$followUpDays days");
 
-    // Set batch size to process 25 records at a time
     $batchSize = 25;
     $offset = 0;
 
     try {
-        // Fetch the message template for the follow-up email
+        // Fetch the follow up message template for the follow-up email
         $template = MessageTemplate::get(FALSE)
             ->addSelect('id', 'msg_subject')
             ->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
@@ -58,9 +54,6 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
             throw new \Exception('Follow-up email template not found.');
         }
 
-        \Civi::log()->info('Email template retrieved successfully', ['template' => $template]);
-
-        // Loop through activities in batches
         do {
             // Fetch email activities in the current batch that were sent within the specified follow-up period
             $followUpEmailActivities = Activity::get(TRUE)
@@ -72,13 +65,7 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
               ->setOffset($offset)
               ->execute();
 
-            \Civi::log()->info('Batch of follow-up email activities retrieved', [
-                'followUpEmailActivities' => $followUpEmailActivities,
-            ]);
-
-            // Process each activity in the batch
             foreach ($followUpEmailActivities as $activity) {
-                \Civi::log()->info('Processing follow-up activity', ['activity' => $activity]);
 
                 // Fetch the associated induction activity
                 $inductionActivity = Activity::get(FALSE)
@@ -89,13 +76,11 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
                     ->single();
 
                 if (!$inductionActivity) {
-                    \Civi::log()->warning('No induction activity found for source contact', [
+                    \Civi::log()->info('No induction activity found for source contact', [
                         'source_contact_id' => $activity['source_contact_id'],
                     ]);
                     continue;
                 }
-
-                \Civi::log()->info('Induction activity retrieved', ['inductionActivity' => $inductionActivity]);
 
                 // Check if the status is 'Completed' or 'Scheduled'
                 if (in_array($inductionActivity['status_id:name'], ['Completed', 'Scheduled'])) {
@@ -120,7 +105,7 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
 
             // Increment the offset by the batch size
             $offset += $batchSize;
-        } while (count($followUpEmailActivities) === $batchSize); // Continue until there are no more records
+        } while (count($followUpEmailActivities) === $batchSize);
 
     } catch (\Exception $e) {
         // Log any errors encountered during the process

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -48,16 +48,14 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
         $template = MessageTemplate::get(FALSE)
             ->addSelect('id', 'msg_subject')
             ->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
-            ->setLimit(1)
-            ->execute()
-            ->single();
+            ->execute()->single();
 
         if (!$template) {
             throw new \Exception('Follow-up email template not found.');
         }
 
         do {
-            // Fetch email activities in the current batch that were sent within the specified follow-up period
+            // Fetch email activities older than 30 days
             $followUpEmailActivities = Activity::get(TRUE)
               ->addSelect('source_contact_id', 'activity_date_time')
               ->addWhere('subject', '=', $template['msg_subject'])

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -2,6 +2,7 @@
 
 use Civi\Api4\Activity;
 use Civi\Api4\MessageTemplate;
+use Civi\InductionService;
 
 /**
  * Goonjcustom.Induction Status Update to No Show API specification (optional)
@@ -34,78 +35,8 @@ function _civicrm_api3_goonjcustom_update_induction_status_no_show_cron_spec(&$s
  */
 function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) {
     $returnValues = [];
-
-    $followUpDays = 30;
-
-    // Calculate the timestamp for 30 days ago from the current date
-    $followUpTimestamp = strtotime("-$followUpDays days");
-
-    $batchSize = 25;
-    $offset = 0;
-
     try {
-        // Fetch the follow up message template for the follow-up email
-        $template = MessageTemplate::get(FALSE)
-            ->addSelect('id', 'msg_subject')
-            ->addWhere('msg_title', 'LIKE', 'Induction_slot_booking_follow_up_email%')
-            ->execute()->single();
-
-        if (!$template) {
-            throw new \Exception('Follow-up email template not found.');
-        }
-
-        do {
-            // Fetch email activities older than 30 days
-            $followUpEmailActivities = Activity::get(TRUE)
-              ->addSelect('source_contact_id', 'activity_date_time')
-              ->addWhere('subject', '=', $template['msg_subject'])
-              ->addWhere('activity_type_id:label', '=', 'Email')
-              ->addWhere('created_date', '<', date('Y-m-d H:i:s', $followUpTimestamp))
-              ->setLimit($batchSize)
-              ->setOffset($offset)->execute();
-
-            foreach ($followUpEmailActivities as $activity) {
-
-                // Fetch the associated induction activity
-                $inductionActivity = Activity::get(FALSE)
-                    ->addSelect('id', 'source_contact_id', 'status_id:name')
-                    ->addWhere('activity_type_id:name', '=', 'Induction')
-                    ->addWhere('source_contact_id', '=', $activity['source_contact_id'])
-                    ->execute()
-                    ->single();
-
-                if (!$inductionActivity) {
-                    \Civi::log()->info('No induction activity found for source contact', [
-                        'source_contact_id' => $activity['source_contact_id'],
-                    ]);
-                    continue;
-                }
-
-                // Check if the status is 'Completed' or 'Scheduled'
-                if (in_array($inductionActivity['status_id:name'], ['Completed', 'Scheduled'])) {
-                    \Civi::log()->info('Induction activity is already completed or scheduled, skipping', [
-                        'inductionActivityId' => $inductionActivity['id'],
-                        'status' => $inductionActivity['status_id:name']
-                    ]);
-                    continue;
-                }
-
-                // // Update the induction status to 'No_show'
-                $updateResult = Activity::update(FALSE)
-                    ->addValue('status_id:name', 'No_show')
-                    ->addWhere('id', '=', $inductionActivity['id'])
-                    ->execute();
-
-                \Civi::log()->info('Induction activity status updated to No_show', [
-                    'inductionActivityId' => $inductionActivity['id'],
-                    'updateResult' => $updateResult
-                ]);
-            }
-
-            // Increment the offset by the batch size
-            $offset += $batchSize;
-        } while (count($followUpEmailActivities) === $batchSize);
-
+        InductionService::updateInductionStatusNoShow();
     } catch (\Exception $e) {
         // Log any errors encountered during the process
         \Civi::log()->error('Error in follow-up cron: ' . $e->getMessage());

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -62,8 +62,7 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
               ->addWhere('activity_type_id:label', '=', 'Email')
               ->addWhere('created_date', '<', date('Y-m-d H:i:s', $followUpTimestamp))
               ->setLimit($batchSize)
-              ->setOffset($offset)
-              ->execute();
+              ->setOffset($offset)->execute();
 
             foreach ($followUpEmailActivities as $activity) {
 

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateInductionStatusNoShowCron.php
@@ -112,7 +112,5 @@ function civicrm_api3_goonjcustom_update_induction_status_no_show_cron($params) 
         return civicrm_api3_create_error($e->getMessage());
     }
 
-    \Civi::log()->info('Induction slot booking follow-up cron job completed successfully.');
-
     return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'update_induction_status_no_show_cron');
 }


### PR DESCRIPTION
Issue [137](https://github.com/coloredcow-admin/goonj-crm/issues/137)

please refer points: 
- `If a volunteer does not select a slot within 7 (configurable) days of receiving the scheduling email, a follow-up email shall be sent.`
- `If the volunteer does not respond to the follow-up email within 30 (configurable) days, their induction status in the CRM shall be changed to "No-show."`

- Created new cron job `induction_slot_booking_follow_up_cron` 
     - Sends emails to contacts with unscheduled inductions over 7 days old.
     - Checks if an email was previously sent to avoid duplicates.
     - Uses a do-while loop to retrieve and process unscheduled induction activities in batches until all records are checked.

- Created new cron job `update_induction_status_no_show_cron`
    - Retrieves a configurable message template used for sending follow-up emails.
    - In this cron job, a loop is used to process induction activities in batches of 25 records at a time. 
    - Updates the status of induction activities to "No Show" if they are neither completed nor scheduled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an API for managing follow-up actions related to induction slot bookings, including automated email notifications for unscheduled activities older than seven days.
	- Added an API for updating induction statuses to "No Show" for activities older than 30 days, with logging for follow-up email activities and status updates.
	- Enhanced the InductionService with methods for sending follow-up emails and updating induction statuses.

- **Bug Fixes**
	- Implemented error handling to log exceptions and ensure smooth operation during follow-up and status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->