### PR TITLE
Fix/update change in induction slot page

### DIFF
--- a/wp-content/plugins/goonj-blocks/build/functions.php
+++ b/wp-content/plugins/goonj-blocks/build/functions.php
@@ -65,6 +65,11 @@ function generate_induction_slots($contactId = null, $days = 30) {
         }
 
         $contactStateId = intval($contactData['address_primary.state_province_id']);
+
+        // Capitalize first letter of each word
+        $contactCityFormatted = ucwords(strtolower($contactData['address_primary.city']));
+
+        
         $inductionSlotStartDate = (new DateTime($contactData['Individual_fields.Created_Date']))->modify('+1 day');
         $physicalInductionType = 'Processing_Unit';
         $onlineInductionType = 'Online_only_selected_by_Urban_P';
@@ -95,7 +100,9 @@ function generate_induction_slots($contactId = null, $days = 30) {
             ->addSelect('id', 'display_name')
             ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
             ->addWhere('address_primary.state_province_id', '=', $contactStateId)
+            ->addWhere('address_primary.city', 'LIKE', $contactCityFormatted . '%')
             ->execute();
+
 
         if ($officeContact->count() === 0) {
             // generate online induction slots for state having no office

--- a/wp-content/plugins/goonj-blocks/build/functions.php
+++ b/wp-content/plugins/goonj-blocks/build/functions.php
@@ -69,7 +69,6 @@ function generate_induction_slots($contactId = null, $days = 30) {
         // Capitalize first letter of each word
         $contactCityFormatted = ucwords(strtolower($contactData['address_primary.city']));
 
-        
         $inductionSlotStartDate = (new DateTime($contactData['Individual_fields.Created_Date']))->modify('+1 day');
         $physicalInductionType = 'Processing_Unit';
         $onlineInductionType = 'Online_only_selected_by_Urban_P';
@@ -102,7 +101,6 @@ function generate_induction_slots($contactId = null, $days = 30) {
             ->addWhere('address_primary.state_province_id', '=', $contactStateId)
             ->addWhere('address_primary.city', 'LIKE', $contactCityFormatted . '%')
             ->execute();
-
 
         if ($officeContact->count() === 0) {
             // generate online induction slots for state having no office

--- a/wp-content/plugins/goonj-blocks/build/functions.php
+++ b/wp-content/plugins/goonj-blocks/build/functions.php
@@ -68,7 +68,7 @@ function generate_induction_slots($contactId = null, $days = 30) {
         $inductionSlotStartDate = (new DateTime($contactData['Individual_fields.Created_Date']))->modify('+1 day');
         $physicalInductionType = 'Processing_Unit';
         $onlineInductionType = 'Online_only_selected_by_Urban_P';
-        $defaultMaxSlot = 30;
+        $defaultMaxSlot = 15;
 
         // List of states with both physical and online inductions based on cities
         $statesWithMixedInductionTypes = \Civi\Api4\StateProvince::get(FALSE)

--- a/wp-content/plugins/goonj-blocks/build/functions.php
+++ b/wp-content/plugins/goonj-blocks/build/functions.php
@@ -169,7 +169,7 @@ function generate_slots($assignedOfficeId, $maxSlots, $inductionType, $startDate
         // Generate slots
         generateActivitySlots($slots, $maxSlots, $validInductionDays, $hour, $minute, $startDate, $scheduledActivityDates, $slotCount, $highActivityCountDays, $inductionType);
 
-        if ($highActivityCountDays >= 23) {
+        if ($highActivityCountDays >= 8) {
             $slotCount = 0;
             $startDate = new DateTime(end($slots)['date']);
             generateActivitySlots($slots, $highActivityCountDays, $validInductionDays, $hour, $minute, $startDate, $scheduledActivityDates, $slotCount, $highActivityCountDays, $inductionType);
@@ -198,13 +198,15 @@ function generateActivitySlots(&$slots, $maxSlots, $validInductionDays, $hour, $
             // Determine activity count based on scheduled activities
             $activityCount = count(array_filter($scheduledActivityDates, fn($scheduledActivityDate) => $scheduledActivityDate === $activityDate));
 
-            $slots[] = [
-                'day' => $dayName,
-                'date' => $date->format('d-m-Y'),
-                'time' => $date->format('h:i A'),
-                'activity_count' => $activityCount,
-                'induction_type' => $inductionType,
-            ];
+            if ($activityCount < 20){
+                $slots[] = [
+                    'day' => $dayName,
+                    'date' => $date->format('d-m-Y'),
+                    'time' => $date->format('h:i A'),
+                    'activity_count' => $activityCount,
+                    'induction_type' => $inductionType,
+                ];
+            }
             $slotCount++;
 
             // Count days with activity count greater than 20

--- a/wp-content/plugins/goonj-blocks/src/functions.php
+++ b/wp-content/plugins/goonj-blocks/src/functions.php
@@ -68,7 +68,7 @@ function generate_induction_slots($contactId = null, $days = 30) {
         $inductionSlotStartDate = (new DateTime($contactData['Individual_fields.Created_Date']))->modify('+1 day');
         $physicalInductionType = 'Processing_Unit';
         $onlineInductionType = 'Online_only_selected_by_Urban_P';
-        $defaultMaxSlot = 30;
+        $defaultMaxSlot = 15;
 
         // List of states with both physical and online inductions based on cities
         $statesWithMixedInductionTypes = \Civi\Api4\StateProvince::get(FALSE)

--- a/wp-content/plugins/goonj-blocks/src/functions.php
+++ b/wp-content/plugins/goonj-blocks/src/functions.php
@@ -169,7 +169,7 @@ function generate_slots($assignedOfficeId, $maxSlots, $inductionType, $startDate
         // Generate slots
         generateActivitySlots($slots, $maxSlots, $validInductionDays, $hour, $minute, $startDate, $scheduledActivityDates, $slotCount, $highActivityCountDays, $inductionType);
 
-        if ($highActivityCountDays >= 23) {
+        if ($highActivityCountDays >= 8) {
             $slotCount = 0;
             $startDate = new DateTime(end($slots)['date']);
             generateActivitySlots($slots, $highActivityCountDays, $validInductionDays, $hour, $minute, $startDate, $scheduledActivityDates, $slotCount, $highActivityCountDays, $inductionType);
@@ -198,13 +198,15 @@ function generateActivitySlots(&$slots, $maxSlots, $validInductionDays, $hour, $
             // Determine activity count based on scheduled activities
             $activityCount = count(array_filter($scheduledActivityDates, fn($scheduledActivityDate) => $scheduledActivityDate === $activityDate));
 
-            $slots[] = [
-                'day' => $dayName,
-                'date' => $date->format('d-m-Y'),
-                'time' => $date->format('h:i A'),
-                'activity_count' => $activityCount,
-                'induction_type' => $inductionType,
-            ];
+            if ($activityCount < 20){
+                $slots[] = [
+                    'day' => $dayName,
+                    'date' => $date->format('d-m-Y'),
+                    'time' => $date->format('h:i A'),
+                    'activity_count' => $activityCount,
+                    'induction_type' => $inductionType,
+                ];
+            }
             $slotCount++;
 
             // Count days with activity count greater than 20

--- a/wp-content/plugins/goonj-blocks/src/functions.php
+++ b/wp-content/plugins/goonj-blocks/src/functions.php
@@ -65,6 +65,10 @@ function generate_induction_slots($contactId = null, $days = 30) {
         }
 
         $contactStateId = intval($contactData['address_primary.state_province_id']);
+
+        // Capitalize first letter of each word
+        $contactCityFormatted = ucwords(strtolower($contactData['address_primary.city']));
+
         $inductionSlotStartDate = (new DateTime($contactData['Individual_fields.Created_Date']))->modify('+1 day');
         $physicalInductionType = 'Processing_Unit';
         $onlineInductionType = 'Online_only_selected_by_Urban_P';
@@ -95,6 +99,7 @@ function generate_induction_slots($contactId = null, $days = 30) {
             ->addSelect('id', 'display_name')
             ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
             ->addWhere('address_primary.state_province_id', '=', $contactStateId)
+            ->addWhere('address_primary.city', 'LIKE', $contactCityFormatted . '%')
             ->execute();
 
         if ($officeContact->count() === 0) {


### PR DESCRIPTION
1. Update the induction slot limit from 30 to 15, so only 15 slots are displayed.
2. Implement a check to determine if the contact's city has a PU; if it does, a physical induction email will be sent; otherwise, an online induction email will be sent.
3. Add a condition to hide the slot for a day if the activity count exceeds 20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and validation for slot generation.
	- City names are now formatted with capitalized first letters for improved queries.
	- Slot generation logic refined to consider activity levels and limits.

- **Bug Fixes**
	- Adjusted maximum slots from 30 to 15 and high activity threshold from 23 to 8 to improve slot availability. 

- **Documentation**
	- Updated function signatures to reflect logic modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->