### PR TITLE
make data dynamic

### DIFF
--- a/wp-content/civi-extensions/com.coloredcow.civirazorpay/CRM/Civirazorpay/Page/Payment.php
+++ b/wp-content/civi-extensions/com.coloredcow.civirazorpay/CRM/Civirazorpay/Page/Payment.php
@@ -3,27 +3,24 @@
 /**
  *
  */
+
+use Civi\Api4\Contribution;
+use Civi\Api4\Email;
+use Civi\Api4\PaymentProcessor;
+
+/**
+ *
+ */
 class CRM_Civirazorpay_Page_Payment extends CRM_Core_Page {
 
   /**
    *
    */
   public function run() {
-    $orderId = CRM_Utils_Request::retrieve('order_id', 'String', $this);
-    $amount = CRM_Utils_Request::retrieve('amount', 'Integer', $this);
-    $currency = CRM_Utils_Request::retrieve('currency', 'String', $this);
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $this);
+    $contributionId = CRM_Utils_Request::retrieve('contribution', 'Integer', $this);
+    $paymentProcessorId = CRM_Utils_Request::retrieve('processor', 'Integer', $this);
 
-    $apiKey = $this->_paymentProcessor['user_name'];
-
-    $data = [
-      'apiKey' => $apiKey,
-      'amount' => $amount,
-      'currency' => $currency,
-      'orderId' => $orderId,
-      'qfKey' => $qfKey,
-      'email' => $this->getUserEmail($qfKey),
-    ];
+    $data = $this->getDataForTemplate($contributionId, $paymentProcessorId);
 
     $this->assign($data);
 
@@ -31,10 +28,40 @@ class CRM_Civirazorpay_Page_Payment extends CRM_Core_Page {
   }
 
   /**
+   * Retrieve contribution details and primary email from contact.
    *
+   * @param int $contributionId
+   *   The contribution ID to retrieve.
+   *
+   * @return array
+   *   Array containing amount, currency, email, and order ID.
    */
-  public function getUserEmail($qfKey) {
-    return 'abhip099@gmail.com';
+  public function getDataForTemplate($contributionId, $paymentProcessorId) {
+    $contribution = Contribution::get(FALSE)
+      ->addSelect('total_amount', 'currency', 'contact_id', 'trxn_id', 'payment_processor_id')
+      ->addWhere('id', '=', $contributionId)
+      ->execute()->single();
+
+    $email = Email::get(FALSE)
+      ->addWhere('is_primary', '=', TRUE)
+      ->addWhere('contact_id', '=', $contribution['contact_id'])
+      ->execute()->single();
+
+    $organizationName = CRM_Core_BAO_Domain::getDomain()->name;
+
+    $paymentProcessor = PaymentProcessor::get(FALSE)
+      ->addSelect('user_name')
+      ->addWhere('id', '=', $paymentProcessorId)
+      ->execute()->single();
+
+    return [
+      'amount' => $contribution['total_amount'] * 100,
+      'currency' => $contribution['currency'],
+      'email' => $email['email'],
+      'orderId' => $contribution['trxn_id'],
+      'organizationName' => $organizationName,
+      'apiKey' => $paymentProcessor['user_name'],
+    ];
   }
 
 }

--- a/wp-content/civi-extensions/com.coloredcow.civirazorpay/templates/CRM/Civirazorpay/Page/Payment.tpl
+++ b/wp-content/civi-extensions/com.coloredcow.civirazorpay/templates/CRM/Civirazorpay/Page/Payment.tpl
@@ -1,30 +1,30 @@
 <script src="https://checkout.razorpay.com/v1/checkout.js"></script>
 
-<div id="razorpay-button"
+<div id="razorpay-options"
      data-key="{$apiKey}"
      data-amount="{$amount}"
      data-currency="{$currency}"
      data-order-id="{$orderId}"
-     data-qf-key="{$qfKey}"
-     data-email="{$email}">
+     data-email="{$email}"
+     data-organization-name="{$organizationName}">
 </div>
 
 {literal}
 <script type="text/javascript">
   document.addEventListener("DOMContentLoaded", function() {
-    var razorpayButton = document.getElementById('razorpay-button');
+    var razorpayOptions = document.getElementById('razorpay-options');
     var options = {
-      key: razorpayButton.getAttribute('data-key'),
-      amount: razorpayButton.getAttribute('data-amount'),
-      currency: razorpayButton.getAttribute('data-currency'),
-      name: "Your Organization",
+      key: razorpayOptions.getAttribute('data-key'),
+      amount: razorpayOptions.getAttribute('data-amount'),
+      currency: razorpayOptions.getAttribute('data-currency'),
+      name: razorpayOptions.getAttribute('data-organization-name'),
       description: "Contribution Payment",
-      order_id: razorpayButton.getAttribute('data-order-id'),
+      order_id: razorpayOptions.getAttribute('data-order-id'),
       handler: function(response) {
-        window.location.href = "/civicrm/contribute/transact/?_qf_ThankYou_display=1&qfKey=" + razorpayButton.getAttribute('data-qf-key') + "&payment_id=" + response.razorpay_payment_id + "&order_id=" + response.razorpay_order_id;
+        window.location.href = "/civicrm/contribute/transact/?_qf_ThankYou_display=1&qfKey=" + razorpayOptions.getAttribute('data-qf-key') + "&payment_id=" + response.razorpay_payment_id + "&order_id=" + response.razorpay_order_id;
       },
       prefill: {
-        email: razorpayButton.getAttribute('data-email')
+        email: razorpayOptions.getAttribute('data-email')
       },
       theme: {
         color: "#528FF0"


### PR DESCRIPTION
## Description

This PR enhances the Razorpay payment processing integration in CiviCRM by ensuring that the correct payment processor credentials (API key) are used when multiple processors are associated with a single contribution page.

## Changes Made

1. Pass `payment_processor_id` in the Redirect URL:
    - In the `doPayment` method, the selected `payment_processor_id` is now included in the redirect URL when navigating to the custom Razorpay payment page. This ensures that the selected payment processor’s credentials can be correctly identified on the payment page.
1. Retrieve payment_processor_id on the Payment Page:
    - The `getDataForTemplate` method now retrieves the `payment_processor_id` from the URL parameters to access the API key of the selected payment processor dynamically. This eliminates the dependency on a static or default processor ID, allowing users to utilize multiple processors on the same contribution page effectively.
1. Fetch API Key for Payment Processor:
    - Using the `payment_processor_id`, the system fetches the relevant API key stored in the user_name field of the `PaymentProcessor` entity, ensuring that the correct credentials are used for each transaction.

## Why This Is Needed

In scenarios where multiple payment processors are available on a single contribution page, users select one at the time of contribution. Previously, there was no straightforward way to determine which processor was selected, as the contribution record does not store the processor ID. By passing `payment_processor_id` as a URL parameter, this PR provides a reliable method to retrieve and use the correct API key for the transaction.
