### PR TITLE
Implement Goonj Office and Coordinat0r POC  Assignment Logic For Institution

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -69,7 +69,7 @@ class InstitutionService extends AutoSubscriber {
 
     if (!$stateId) {
       \CRM_Core_Error::debug_log_message('Cannot assign Goonj Office to institution id: ' . $contactId);
-      return FALSE;
+      return;
     }
 
     $officesFound = Contact::get(FALSE)
@@ -80,8 +80,6 @@ class InstitutionService extends AutoSubscriber {
       ->execute();
 
     $stateOffice = $officesFound->first();
-
-    error_log("stateOffice: " . print_r($stateOffice, TRUE));
 
     // If no state office is found, assign the fallback state office.
     if (!$stateOffice) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Civi;
+
+use Civi\Api4\Contact;
+use Civi\Api4\Organization;
+use Civi\Api4\Relationship;
+use Civi\Core\Service\AutoSubscriber;
+
+/**
+ *
+ */
+class InstitutionService extends AutoSubscriber {
+
+  const FALLBACK_OFFICE_NAME = 'Delhi';
+  const RELATIONSHIP_TYPE_NAME = [
+  // For Corporate.
+    'Corporate Coordinator of',
+  // For family foundation.
+    'Family Foundation Coordinator of',
+  // For Education Institute.
+    'Education Coordinator of',
+  // For Government Entity.
+    'Government Coordinator of',
+  // For Hospital (spelling corrected from Hosptial)
+    'Hospital Coordinator of',
+  // For NGO.
+    'NGO Coordinator of',
+  // For Others.
+    'Default Coordinator of',
+  ];
+
+
+
+  private static $individualId = NULL;
+  private static $collectionCampAddress = NULL;
+  private static $fromAddress = NULL;
+
+  /**
+   *
+   */
+  public static function getSubscribedEvents() {
+    return [
+      '&hook_civicrm_custom' => [
+        ['setOfficeDetails'],
+      ],
+    ];
+  }
+
+  /**
+   * This hook is called after the database write on a custom table.
+   *
+   * @param string $op
+   *   The type of operation being performed.
+   * @param string $objectName
+   *   The custom group ID.
+   * @param int $objectId
+   *   The entityID of the row in the custom table.
+   * @param object $objectRef
+   *   The parameters that were sent into the calling function.
+   */
+  public static function setOfficeDetails($op, $groupID, $entityID, &$params) {
+    if ($op !== 'create') {
+      return;
+    }
+
+    if (!($stateField = self::findStateField($params, $entityID))) {
+      return;
+    }
+
+    $stateId = $stateField['value'];
+    $institutionContactId = $stateField['entity_id'];
+
+    if (!$stateId) {
+      \CRM_Core_Error::debug_log_message('Cannot assign Goonj Office to institution: ' . $institutionContactId);
+      \CRM_Core_Error::debug_log_message('No state provided on the intent for institution: ' . $institutionContactId);
+      return FALSE;
+    }
+
+    $officesFound = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('contact_type', '=', 'Organization')
+      ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
+      ->addWhere('Goonj_Office_Details.Institution_Catchment', 'CONTAINS', $stateId)
+      ->execute();
+
+    $stateOffice = $officesFound->first();
+
+    // If no state office is found, assign the fallback state office.
+    if (!$stateOffice) {
+      $stateOffice = self::getFallbackOffice();
+    }
+
+    $stateOfficeId = $stateOffice['id'];
+
+    Organization::update(TRUE)
+      ->addValue('Review.Goonj_Office', $stateOfficeId)
+      ->addWhere('id', '=', $institutionContactId)
+      ->execute();
+    // Get the relationship type name based on the institution type.
+    $relationshipTypeName = self::getRelationshipTypeName($entityID);
+
+    $coordinators = Relationship::get(FALSE)
+      ->addWhere('contact_id_b', '=', $stateOfficeId)
+      ->addWhere('relationship_type_id:name', '=', $relationshipTypeName)
+      ->addWhere('is_current', '=', TRUE)
+      ->execute();
+
+    $coordinatorCount = $coordinators->count();
+
+    if ($coordinatorCount === 0) {
+      $coordinator = self::getFallbackCoordinator($entityID);
+    }
+    elseif ($coordinatorCount > 1) {
+      $randomIndex = rand(0, $coordinatorCount - 1);
+      $coordinator = $coordinators->itemAt($randomIndex);
+    }
+    else {
+      $coordinator = $coordinators->first();
+    }
+
+    if (!$coordinator) {
+      \CRM_Core_Error::debug_log_message('No coordinator available to assign.');
+      return FALSE;
+    }
+
+    $coordinatorId = $coordinator['contact_id_a'];
+
+    Organization::update(TRUE)
+      ->addValue('Review.Coordinating_POC', $coordinatorId)
+      ->addWhere('id', '=', $institutionContactId)
+      ->execute();
+
+    return TRUE;
+
+  }
+
+  /**
+   * This hook is called after the database write on a custom table.
+   *
+   * @param string $op
+   *   The type of operation being performed.
+   * @param string $objectName
+   *   The custom group ID.
+   * @param int $objectId
+   *   The entityID of the row in the custom table.
+   * @param object $objectRef
+   *   The parameters that were sent into the calling function.
+   */
+
+  /**
+   *
+   */
+  private static function findStateField(array $array, $entityID) {
+    $instituteStateField = Contact::get(FALSE)
+      ->addSelect('address_primary.state_province_id', 'address_primary.state_province_id:label')
+      ->addWhere('contact_sub_type', '=', 'Institute')
+      ->addWhere('id', '=', $entityID)
+      ->execute();
+
+    if (!$instituteStateField) {
+      return FALSE;
+    }
+
+    // $stateFieldId = $instituteStateField['address_primary.state_province_id'];
+    $stateFieldId = 1098;
+
+    foreach ($array as $item) {
+      if ($item['entity_table'] === 'civicrm_contact') {
+        return $item;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   *
+   */
+  private static function getFallbackOffice() {
+    $fallbackOffices = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('organization_name', 'CONTAINS', self::FALLBACK_OFFICE_NAME)
+      ->execute();
+
+    return $fallbackOffices->first();
+  }
+
+  /**
+   *
+   */
+  private static function getFallbackCoordinator($entityID) {
+    $fallbackOffice = self::getFallbackOffice();
+
+    // Get the relationship type name based on the institution type.
+    $relationshipTypeName = self::getRelationshipTypeName($entityID);
+
+    $fallbackCoordinators = Relationship::get(FALSE)
+      ->addWhere('contact_id_b', '=', $fallbackOffice['id'])
+      ->addWhere('relationship_type_id:name', '=', $relationshipTypeName)
+      ->addWhere('is_current', '=', TRUE)
+      ->execute();
+
+    $coordinatorCount = $fallbackCoordinators->count();
+
+    $randomIndex = rand(0, $coordinatorCount - 1);
+    $coordinator = $fallbackCoordinators->itemAt($randomIndex);
+
+    return $coordinator;
+  }
+
+  /**
+   *
+   */
+  private static function getRelationshipTypeName($entityID) {
+    $organizations = Organization::get(TRUE)
+      ->addSelect('Institute_Registration.Type_of_Institution:label')
+      ->addWhere('id', '=', $entityID)
+      ->execute()->single();
+
+    $typeOfInstitution = $organizations['Institute_Registration.Type_of_Institution:label'];
+
+    $typeToRelationshipMap = [
+      'Corporate'    => 'Corporate Coordinator of',
+      'Family'       => 'Family Foundation Coordinator of',
+      'Education'    => 'Education Coordinator of',
+      'Government'   => 'Government Coordinator of',
+      'Hospital'     => 'Hospital Coordinator of',
+      'NGO'          => 'NGO Coordinator of',
+      'Others'       => 'Default Coordinator of',
+    ];
+
+    $firstWord = strtok($typeOfInstitution, ' ');
+
+    // Return the corresponding relationship type, or default if not found.
+    return $typeToRelationshipMap[$firstWord] ?? 'Default Coordinator of';
+  }
+
+  /**
+   *
+   */
+
+}

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -13,23 +13,6 @@ use Civi\Core\Service\AutoSubscriber;
 class InstitutionService extends AutoSubscriber {
 
   const FALLBACK_OFFICE_NAME = 'Delhi';
-  const RELATIONSHIP_TYPE_NAME = [
-  // For Corporate.
-    'Corporate Coordinator of',
-  // For family foundation.
-    'Family Foundation Coordinator of',
-  // For Education Institute.
-    'Education Coordinator of',
-  // For Government Entity.
-    'Government Coordinator of',
-  // For Hospital.
-    'Hospital Coordinator of',
-  // For NGO.
-    'NGO Coordinator of',
-  // For Others.
-    'Default Coordinator of',
-  ];
-
   /**
    *
    */
@@ -143,13 +126,6 @@ class InstitutionService extends AutoSubscriber {
    *   The parameters that were sent into the calling function.
    */
 
-  /**
-   *
-   */
-
-  /**
-   *
-   */
   private static function getFallbackOffice() {
     $fallbackOffices = Contact::get(FALSE)
       ->addSelect('id')
@@ -186,12 +162,12 @@ class InstitutionService extends AutoSubscriber {
    *
    */
   private static function getRelationshipTypeName($contactId) {
-    $organizations = Organization::get(TRUE)
+    $organization = Organization::get(TRUE)
       ->addSelect('Institute_Registration.Type_of_Institution:label')
       ->addWhere('id', '=', $contactId)
       ->execute()->single();
 
-    $typeOfInstitution = $organizations['Institute_Registration.Type_of_Institution:label'];
+    $typeOfInstitution = $organization['Institute_Registration.Type_of_Institution:label'];
 
     $typeToRelationshipMap = [
       'Corporate'    => 'Corporate Coordinator of',

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -13,7 +13,10 @@ use Civi\Core\Service\AutoSubscriber;
 class InstitutionService extends AutoSubscriber {
 
   const FALLBACK_OFFICE_NAME = 'Delhi';
-  
+
+  /**
+   *
+   */
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_post' => [
@@ -73,6 +76,7 @@ class InstitutionService extends AutoSubscriber {
       ->addValue('Review.Goonj_Office', $stateOfficeId)
       ->addWhere('id', '=', $contactId)
       ->execute();
+
     // Get the relationship type name based on the institution type.
     $relationshipTypeName = self::getRelationshipTypeName($contactId);
 
@@ -123,7 +127,6 @@ class InstitutionService extends AutoSubscriber {
    * @param object $objectRef
    *   The parameters that were sent into the calling function.
    */
-
   private static function getFallbackOffice() {
     $fallbackOffices = Contact::get(FALSE)
       ->addSelect('id')
@@ -132,7 +135,10 @@ class InstitutionService extends AutoSubscriber {
 
     return $fallbackOffices->first();
   }
-  
+
+  /**
+   *
+   */
   private static function getFallbackCoordinator($contactId) {
     $fallbackOffice = self::getFallbackOffice();
 
@@ -153,6 +159,9 @@ class InstitutionService extends AutoSubscriber {
     return $coordinator;
   }
 
+  /**
+   *
+   */
   private static function getRelationshipTypeName($contactId) {
     $organization = Organization::get(TRUE)
       ->addSelect('Institute_Registration.Type_of_Institution:label')
@@ -176,6 +185,5 @@ class InstitutionService extends AutoSubscriber {
     // Return the corresponding relationship type, or default if not found.
     return $typeToRelationshipMap[$firstWord] ?? 'Default Coordinator of';
   }
-
 
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -88,7 +88,7 @@ class InstitutionService extends AutoSubscriber {
 
     $stateOfficeId = $stateOffice['id'];
 
-    Organization::update(TRUE)
+    Organization::update(FALSE)
       ->addValue('Review.Goonj_Office', $stateOfficeId)
       ->addWhere('id', '=', $contactId)
       ->execute();
@@ -121,7 +121,7 @@ class InstitutionService extends AutoSubscriber {
 
     $coordinatorId = $coordinator['contact_id_a'];
 
-    Organization::update(TRUE)
+    Organization::update(FALSE)
       ->addValue('Review.Coordinating_POC', $coordinatorId)
       ->addWhere('id', '=', $contactId)
       ->execute();

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -30,12 +30,6 @@ class InstitutionService extends AutoSubscriber {
     'Default Coordinator of',
   ];
 
-
-
-  private static $individualId = NULL;
-  private static $collectionCampAddress = NULL;
-  private static $fromAddress = NULL;
-
   /**
    *
    */

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -22,7 +22,7 @@ class InstitutionService extends AutoSubscriber {
     'Education Coordinator of',
   // For Government Entity.
     'Government Coordinator of',
-  // For Hospital (spelling corrected from Hosptial)
+  // For Hospital.
     'Hospital Coordinator of',
   // For NGO.
     'NGO Coordinator of',

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -69,7 +69,6 @@ class InstitutionService extends AutoSubscriber {
 
     if (!$stateId) {
       \CRM_Core_Error::debug_log_message('Cannot assign Goonj Office to institution id: ' . $contactId);
-      \CRM_Core_Error::debug_log_message('No state provided on the intent for institution id: ' . $contactId);
       return FALSE;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -13,9 +13,7 @@ use Civi\Core\Service\AutoSubscriber;
 class InstitutionService extends AutoSubscriber {
 
   const FALLBACK_OFFICE_NAME = 'Delhi';
-  /**
-   *
-   */
+  
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_post' => [
@@ -134,10 +132,7 @@ class InstitutionService extends AutoSubscriber {
 
     return $fallbackOffices->first();
   }
-
-  /**
-   *
-   */
+  
   private static function getFallbackCoordinator($contactId) {
     $fallbackOffice = self::getFallbackOffice();
 
@@ -158,9 +153,6 @@ class InstitutionService extends AutoSubscriber {
     return $coordinator;
   }
 
-  /**
-   *
-   */
   private static function getRelationshipTypeName($contactId) {
     $organization = Organization::get(TRUE)
       ->addSelect('Institute_Registration.Type_of_Institution:label')
@@ -185,8 +177,5 @@ class InstitutionService extends AutoSubscriber {
     return $typeToRelationshipMap[$firstWord] ?? 'Default Coordinator of';
   }
 
-  /**
-   *
-   */
 
 }


### PR DESCRIPTION
### Description

**Goonj Office Assignment:**
When a new institution is created, the system attempts to assign it to a relevant state office based on the provided state ID.
If no specific state office is found, the fallback office (Delhi) is assigned.

**Coordinator POC Assignment:**
The system assigns the appropriate coordinator for the institution by checking existing relationships between the state office and the institution.
If no coordinator is found, the fallback coordinator is assigned based on the institution type (Corporate, Education, etc.).

**Handling Different Institution Types:**
A map is used to determine the correct relationship type (e.g., "Corporate Coordinator of", "Family Foundation Coordinator of", etc.) based on the institution's type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `InstitutionService` class to manage institution-related operations within CiviCRM.
	- Added functionality to automatically set office and coordinator details based on specific conditions after database updates.

- **Bug Fixes**
	- Improved error handling for missing state IDs when processing institution data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->