### PR TITLE
Update label from 'City' to 'Address of Contribution' in material contribution receipt

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -197,7 +197,7 @@ class MaterialContributionService extends AutoSubscriber {
             <td style="text-align: center;">{$activity['contact.display_name']}</td>
           </tr>
           <tr>
-            <td class="table-header">City</td>
+            <td class="table-header">Address of contribution </td>
             <td style="text-align: center;">{$locationAreaOfCamp}</td>
           </tr>
           <tr>

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -197,7 +197,7 @@ class MaterialContributionService extends AutoSubscriber {
             <td style="text-align: center;">{$activity['contact.display_name']}</td>
           </tr>
           <tr>
-            <td class="table-header">Address of contribution </td>
+            <td class="table-header">Address of contribution</td>
             <td style="text-align: center;">{$locationAreaOfCamp}</td>
           </tr>
           <tr>


### PR DESCRIPTION
Update label from `City` to `Address of Contribution`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated contribution receipt HTML to reflect a broader description for the address field.
	- Enhanced email and phone handling in receipts, defaulting to 'N/A' if data is missing.

- **Bug Fixes**
	- Improved error handling for fetching reminder IDs to provide better logging context.
	- Streamlined retrieval of "Material Contribution" activity data.

- **Improvements**
	- Added checks for `entity_id` to prevent unnecessary execution in receipt attachment logic.
	- Updated HTML generation logic to ensure proper formatting of the new address label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->