### PR TITLE
Add Cron to send Reschedule email volunteer induction status is not Visited

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -85,13 +85,13 @@ class InductionService extends AutoSubscriber {
       \Civi::log()->info('Induction already exists for contact', ['id' => $contactId]);
       return FALSE;
     }
-
+    \Civi::log()->info('check4');
     $office = self::findOfficeForState($stateId);
     if (!$office) {
       \Civi::log()->info('Cannot find office for: ' . $stateId);
       return FALSE;
     }
-
+    \Civi::log()->info('check5');
     $coordinatorId = self::findCoordinatorForOffice($office['id']);
     if (!$coordinatorId) {
       \Civi::log()->info('Cannot found induction coordinator for office:', ['id' => $office['id']]);
@@ -113,7 +113,7 @@ class InductionService extends AutoSubscriber {
     if ($contactInductionExists->count() > 0) {
       return;
     }
-
+    \Civi::log()->info('check6');
     Activity::create(FALSE)
       ->addValue('activity_type_id:name', self::INDUCTION_ACTIVITY_TYPE_NAME)
       ->addValue('status_id:name', self::INDUCTION_DEFAULT_STATUS_NAME)
@@ -131,18 +131,20 @@ class InductionService extends AutoSubscriber {
    * Handles induction creation for a volunteer.
    */
   public static function createInductionForVolunteer(string $op, string $objectName, int $objectId, &$objectRef) {
+    \Civi::log()->info('check1');
     if ($op !== 'create' || $objectName !== 'Address' || self::$volunteerId !== $objectRef->contact_id || !$objectRef->is_primary) {
       return FALSE;
     }
-
+    \Civi::log()->info('check2');
     $stateId = $objectRef->state_province_id;
 
     if (!$stateId) {
       \Civi::log()->info('state not found', ['VolunteerId' => self::$volunteerId, 'stateId' => $stateId]);
       return FALSE;
     }
-
+    \Civi::log()->info('check3');
     self::createInduction(self::$volunteerId, $stateId);
+    \Civi::log()->info('check4');
   }
 
   /**
@@ -490,9 +492,16 @@ class InductionService extends AutoSubscriber {
         ->setLimit($batchSize)
         ->setOffset($offset)
         ->execute();
+      \Civi::log()->info('unscheduledInductionActivities', ['unscheduledInductionActivities'=>$unscheduledInductionActivities]);
 
       // Process each activity in the batch
       foreach ($unscheduledInductionActivities as $activity) {
+        // Check if a reschedule email has already been sent and handled
+        if (self::handleRescheduleEmailActivity($activity['source_contact_id'], $activity['id'])) {
+          \Civi::log()->info('Skipping follow-up email due to existing reschedule email activity');
+          continue;
+        }
+
         // Check if a follow-up email has already been sent to avoid duplication.
         $emailActivities = Activity::get(FALSE)
           ->addWhere('activity_type_id:name', '=', 'Email')
@@ -589,4 +598,112 @@ class InductionService extends AutoSubscriber {
 			throw $e;
 		}
 	}
+
+
+/**
+ *
+ */
+public static function sendInductionRescheduleEmail() {
+  $rescheduleEmailDelayDays = 1;
+  $rescheduleEmailTimestamp = strtotime("-{$rescheduleEmailDelayDays} days");
+
+  // Retrieve the email template for follow-up.
+  $template = MessageTemplate::get(FALSE)
+    ->addSelect('id', 'msg_subject')
+    ->addWhere('msg_title', 'LIKE', 'Induction_reschedule_slot_booking%')
+    ->execute()->single();
+  \Civi::log()->info('template', ['template'=>$template]);
+
+  $batchSize = 25;
+  $offset = 0;
+
+  do {
+    // Retrieve a batch of unscheduled induction activities older than 7 days
+    $notVisitedInductionActivities = Activity::get(FALSE)
+      ->addSelect('id', 'source_contact_id', 'created_date')
+      ->addWhere('activity_type_id:name', '=', 'Induction')
+      ->addWhere('status_id:name', '=', 'Not Visited')
+      ->addWhere('modified_date', '<', date('Y-m-d H:i:s', $rescheduleEmailTimestamp))
+      ->setLimit($batchSize)
+      ->setOffset($offset)
+      ->execute();
+
+    \Civi::log()->info('notVisitedInductionActivities', ['notVisitedInductionActivities'=>$notVisitedInductionActivities]);
+
+    // // Process each activity in the batch
+    foreach ($notVisitedInductionActivities as $activity) {
+      // Check if a follow-up email has already been sent to avoid duplication.
+      $emailActivities = Activity::get(FALSE)
+        ->addWhere('activity_type_id:name', '=', 'Email')
+        ->addWhere('subject', '=', $template['msg_subject'])
+        ->addWhere('source_contact_id', '=', $activity['source_contact_id'])
+        ->execute();
+
+      \Civi::log()->info('emailActivities', ['emailActivities'=>$emailActivities]);
+
+      $emailActivity = $emailActivities->first();
+
+      if (!$emailActivity) {
+        \Civi::log()->info('activity', ['activity'=>$activity]);
+
+        $updateResult = Activity::update(FALSE)
+        ->addValue('status_id:name', 'To be scheduled')
+        ->addWhere('id', '=', $activity['id'])
+        ->execute();
+        $emailParams = [
+          'contact_id' => $activity['source_contact_id'],
+          'template_id' => $template['id'],
+        ];
+        civicrm_api3('Email', 'send', $emailParams);
+      }
+
+      if (!empty($emailActivity)){
+        \Civi::log()->info('check email sent for rescheduling');
+        $updateResult = Activity::update(FALSE)
+        ->addValue('status_id:name', 'No_show')
+        ->addWhere('id', '=', $activity['id'])
+        ->execute();
+      }
+    }
+
+    // Move to the next batch by increasing the offset
+    $offset += $batchSize;
+
+  } while (count($notVisitedInductionActivities) === $batchSize);
+}
+
+/**
+ *
+ */
+public static function handleRescheduleEmailActivity($contactId, $activityId) {
+  $template = MessageTemplate::get(FALSE)
+    ->addSelect('id', 'msg_subject')
+    ->addWhere('msg_title', 'LIKE', 'Induction_reschedule_slot_booking%')
+    ->execute()->single();
+
+  $emailActivities = Activity::get(FALSE)
+    ->addWhere('activity_type_id:name', '=', 'Email')
+    ->addWhere('subject', '=', $template['msg_subject'])
+    ->addWhere('source_contact_id', '=', $contactId)
+    ->execute();
+
+  $emailActivity = $emailActivities->first();
+
+  if (!empty($emailActivity)) {
+    // Update the activity status to 'No_show' if a reschedule email was sent
+    $updateResult = Activity::update(FALSE)
+      ->addValue('status_id:name', 'No_show')
+      ->addWhere('id', '=', $activityId)
+      ->execute();
+
+    // Return true if the update was successful
+    if ($updateResult) {
+      return true;
+    }
+  }
+
+  // Return false if no reschedule email activity exists or update failed
+  return false;
+}
+
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -131,7 +131,6 @@ class InductionService extends AutoSubscriber {
    * Handles induction creation for a volunteer.
    */
   public static function createInductionForVolunteer(string $op, string $objectName, int $objectId, &$objectRef) {
-
     if ($op !== 'create' || $objectName !== 'Address' || self::$volunteerId !== $objectRef->contact_id || !$objectRef->is_primary) {
       return FALSE;
     }
@@ -144,7 +143,6 @@ class InductionService extends AutoSubscriber {
     }
 
     self::createInduction(self::$volunteerId, $stateId);
-
   }
 
   /**
@@ -492,7 +490,6 @@ class InductionService extends AutoSubscriber {
         ->setLimit($batchSize)
         ->setOffset($offset)
         ->execute();
-
 
       // Process each activity in the batch
       foreach ($unscheduledInductionActivities as $activity) {

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRescheduleCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRescheduleCron.php
@@ -1,0 +1,47 @@
+<?php
+
+use Civi\Api4\Activity;
+use Civi\Api4\MessageTemplate;
+use Civi\InductionService;
+
+/**
+ * Goonjcustom.InductionSlotBookingRescheduleMail API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_induction_reschedule_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.induction_slot_booking_follow_up_cron API implementation.
+ *
+ * This function checks for unscheduled induction activities older than 7 days 
+ * and sends follow-up emails to the respective contacts if they haven't already 
+ * received one.
+ *
+ * @param array $params
+ *   Parameters passed to the API call.
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_induction_reschedule_cron($params) {
+    $returnValues = [];
+    try {
+        InductionService::sendInductionRescheduleEmail();
+    } catch (Exception $e) {
+        \Civi::log()->error('Error in induction reschedule cron: ' . $e->getMessage());
+        return civicrm_api3_create_error($e->getMessage());
+    }
+
+    return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'induction_reschedule_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRescheduleCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRescheduleCron.php
@@ -20,8 +20,8 @@ function _civicrm_api3_goonjcustom_induction_reschedule_cron_spec(&$spec) {
 /**
  * Goonjcustom.induction_slot_booking_follow_up_cron API implementation.
  *
- * This function checks for unscheduled induction activities older than 7 days 
- * and sends follow-up emails to the respective contacts if they haven't already 
+ * This function checks for not visited induction activities older than 1 days 
+ * and sends reschedule emails to the respective contacts if they haven't already 
  * received one.
  *
  * @param array $params


### PR DESCRIPTION
- Implemented a new cron job to send reschedule induction emails.  
- Added logic to mark a volunteer as "No Show" if they receive a reschedule email but fail to schedule an induction slot.  
- Enhanced checks to mark a volunteer as "No Show" if they do not attend after rescheduling their slot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to send reschedule emails for induction activities.
	- Added a cron job API for managing unscheduled induction activities and sending follow-up emails.

- **Improvements**
	- Enhanced logic for handling email notifications related to induction activities.
	- Improved error handling for email sending operations, ensuring better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->