### PR TITLE
feat: add Indian state options to Institution Collection Camp form

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Civi;
+
+use Civi\Api4\CustomField;
+use Civi\Api4\StateProvince;
+use Civi\Core\Service\AutoSubscriber;
+
+/**
+ *
+ */
+class InstitutionCollectionCampService extends AutoSubscriber {
+
+  /**
+   *
+   */
+  public static function getSubscribedEvents() {
+    return [
+      '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
+    ];
+  }
+
+  /**
+   *
+   */
+  public static function setIndianStateOptions(string $entity, string $field, array &$options, array $params) {
+    if ($entity !== 'Eck_Collection_Camp') {
+      return;
+    }
+
+    $intentStateFields = CustomField::get(FALSE)
+      ->addWhere('custom_group_id:name', '=', 'Institution_Collection_Camp_Intent')
+      ->addWhere('name', '=', 'State')
+      ->execute();
+
+    $stateField = $intentStateFields->first();
+
+    $statefieldId = $stateField['id'];
+
+    if ($field !== "custom_$statefieldId") {
+      return;
+    }
+
+    $indianStates = StateProvince::get(FALSE)
+      ->addWhere('country_id.iso_code', '=', 'IN')
+      ->addOrderBy('name', 'ASC')
+      ->execute();
+
+    $stateOptions = [];
+    foreach ($indianStates as $state) {
+      if ($state['is_active']) {
+        $stateOptions[$state['id']] = $state['name'];
+      }
+    }
+
+    $options = $stateOptions;
+
+  }
+
+}


### PR DESCRIPTION
- Implemented hook_civicrm_fieldOptions to set state options 
- Fetched and displayed active Indian states for the 'State' field in the Institution Collection Camp Intent group .

<img width="683" alt="image" src="https://github.com/user-attachments/assets/65a8cc4c-36d4-40eb-a5a0-8c80ee100308">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic state options for the `Eck_Collection_Camp` entity, allowing for the selection of active Indian states based on user context.
- **Bug Fixes**
	- Improved validation to ensure that only relevant fields are modified, enhancing the overall reliability of the state options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->