### PR TITLE
feat: Assign Goonj Office based on institution collection camp's state

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -4,20 +4,26 @@ namespace Civi;
 
 use Civi\Api4\CustomField;
 use Civi\Api4\StateProvince;
+use Civi\Traits\CollectionSource;
+use Civi\Api4\EckEntity;
+use Civi\Api4\Contact;
 use Civi\Core\Service\AutoSubscriber;
 
 /**
  *
  */
 class InstitutionCollectionCampService extends AutoSubscriber {
-
+    use CollectionSource;
+    const ENTITY_SUBTYPE_NAME = 'Institution_Collection_Camp';
+    const FALLBACK_OFFICE_NAME = 'Delhi';
   /**
    *
    */
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
-    ];
+      '&hook_civicrm_custom' => 'setOfficeDetails',
+    ];  
   }
 
   /**
@@ -57,4 +63,84 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
   }
 
+  private static function findStateField(array $array) {
+    $institutionCollectionCampStateField = CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('name', '=', 'state')
+      ->addWhere('custom_group_id:name', '=', 'Institution_Collection_Camp_Intent')
+      ->execute()
+      ->first();
+
+    if (!$institutionCollectionCampStateField) {
+      return FALSE;
+    }
+
+    $stateFieldId = $institutionCollectionCampStateField['id'];
+
+    foreach ($array as $item) {
+      if ($item['entity_table'] === 'civicrm_eck_collection_camp' &&
+            $item['custom_field_id'] === $stateFieldId) {
+        return $item;
+      }
+    }
+
+    return FALSE;
+  }
+
+  private static function getFallbackOffice() {
+    $fallbackOffices = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('organization_name', 'CONTAINS', self::FALLBACK_OFFICE_NAME)
+      ->execute();
+
+    return $fallbackOffices->first();
+  }
+
+
+  public static function setOfficeDetails($op, $groupID, $entityID, &$params) {
+    if ($op !== 'create' || self::getEntitySubtypeName($entityID) !== self::ENTITY_SUBTYPE_NAME) {
+      return;
+    }
+
+    if (!($stateField = self::findStateField($params))) {
+      return;
+    }
+
+    $stateId = $stateField['value'];
+    $institutionCollectionCampId = $stateField['entity_id'];
+
+    $institutionCollectionCampData = EckEntity::get('Collection_Camp', FALSE)
+      ->addSelect('Institution_Collection_Camp_Intent.Will_your_collection_drive_be_open_for_general_public_as_well')
+      ->addWhere('id', '=', $institutionCollectionCampId)
+      ->execute()->single();
+
+    $isPublicDriveOpen = $institutionCollectionCampData['Institution_Collection_Camp_Intent.Will_your_collection_drive_be_open_for_general_public_as_well'];
+
+    if (!$stateId) {
+      \CRM_Core_Error::debug_log_message('Cannot assign Goonj Office to institution collection camp: ' . $institutionCollectionCampData['id']);
+      return FALSE;
+    }
+
+    $officesFound = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('contact_type', '=', 'Organization')
+      ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
+      ->addWhere('Goonj_Office_Details.Institution_Catchment', 'CONTAINS', $stateId)
+      ->execute();
+
+    $stateOffice = $officesFound->first();
+
+    // If no state office is found, assign the fallback state office.
+    if (!$stateOffice) {
+      $stateOffice = self::getFallbackOffice();
+    }
+
+    $stateOfficeId = $stateOffice['id'];
+
+    EckEntity::update('Collection_Camp', FALSE)
+      ->addValue('Institution_collection_camp_Review.Goonj_Office', $stateOfficeId)
+      ->addValue('Institution_Collection_Camp_Intent.Camp_Type', $isPublicDriveOpen)
+      ->addWhere('id', '=', $institutionCollectionCampId)
+      ->execute();
+  }
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -2,20 +2,21 @@
 
 namespace Civi;
 
-use Civi\Api4\CustomField;
-use Civi\Api4\StateProvince;
-use Civi\Traits\CollectionSource;
-use Civi\Api4\EckEntity;
 use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\EckEntity;
+use Civi\Api4\StateProvince;
 use Civi\Core\Service\AutoSubscriber;
+use Civi\Traits\CollectionSource;
 
 /**
  *
  */
 class InstitutionCollectionCampService extends AutoSubscriber {
-    use CollectionSource;
-    const ENTITY_SUBTYPE_NAME = 'Institution_Collection_Camp';
-    const FALLBACK_OFFICE_NAME = 'Delhi';
+  use CollectionSource;
+  const ENTITY_SUBTYPE_NAME = 'Institution_Collection_Camp';
+  const FALLBACK_OFFICE_NAME = 'Delhi';
+
   /**
    *
    */
@@ -23,7 +24,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     return [
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       '&hook_civicrm_custom' => 'setOfficeDetails',
-    ];  
+    ];
   }
 
   /**
@@ -63,6 +64,9 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
   }
 
+  /**
+   *
+   */
   private static function findStateField(array $array) {
     $institutionCollectionCampStateField = CustomField::get(FALSE)
       ->addSelect('id')
@@ -87,6 +91,9 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     return FALSE;
   }
 
+  /**
+   *
+   */
   private static function getFallbackOffice() {
     $fallbackOffices = Contact::get(FALSE)
       ->addSelect('id')
@@ -96,7 +103,9 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     return $fallbackOffices->first();
   }
 
-
+  /**
+   *
+   */
   public static function setOfficeDetails($op, $groupID, $entityID, &$params) {
     if ($op !== 'create' || self::getEntitySubtypeName($entityID) !== self::ENTITY_SUBTYPE_NAME) {
       return;
@@ -143,4 +152,5 @@ class InstitutionCollectionCampService extends AutoSubscriber {
       ->addWhere('id', '=', $institutionCollectionCampId)
       ->execute();
   }
+
 }


### PR DESCRIPTION
1. Added function setOfficeDetails() to assign the appropriate Goonj Office based on the state.
2. Integrated logic to set the camp type for public drives.
3. Fallback mechanism implemented to assign the Delhi office if no state-specific office is found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced management of institution collection camp details, including state-specific office assignments and fallback mechanisms.
	- Introduced new event hook for improved handling of office details during entity operations.
	- Added functionality to retrieve and log state field and fallback office information.

- **Bug Fixes**
	- Improved error handling for cases where state ID is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->