### PR TITLE
Updated redirection url to goonj.org on clicked to logo

### DIFF
--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -1122,7 +1122,7 @@ function get_custom_logo( $blog_id = 0 ) {
 
 				$html = sprintf(
 					'<a href="%1$s" class="custom-logo-link" rel="home"%2$s>%3$s</a>',
-					esc_url( home_url( '/' ) ),
+					esc_url( ( 'https://goonj.org/' ) ),
 					$aria_current,
 					$image
 				);


### PR DESCRIPTION
- Added fix to redirect user to goonj.org when custom logo is clicked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The custom logo link now redirects to a new domain (https://goonj.org/) instead of the default home URL.

- **Bug Fixes**
	- No bug fixes were implemented in this release. 

- **Documentation**
	- Updated documentation to reflect the change in the custom logo URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->