### PR TITLE
Generate QR Code for the institution Collection Camp

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -27,13 +27,13 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
-      '&hook_civicrm_pre' => 'generateDroppingCenterQr',
+      '&hook_civicrm_pre' => 'generateInstitutionCollectionCampQr',
       '&hook_civicrm_custom' => 'setOfficeDetails',
     ];
   }
 
 
-  public static function generateDroppingCenterQr(string $op, string $objectName, $objectId, &$objectRef) {
+  public static function generateInstitutionCollectionCampQr(string $op, string $objectName, $objectId, &$objectRef) {
     if ($objectName !== 'Eck_Collection_Camp' || !$objectId || !self::isCurrentSubtype($objectRef)) {
       return;
     }
@@ -54,11 +54,11 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
     // Check for status change.
     if ($currentStatus !== $newStatus && $newStatus === 'authorized') {
-      self::generateDroppingCenterQrCode($collectionCampId);
+      self::generateInstitutionCollectionCampQrCode($collectionCampId);
     }
   }
 
-  private static function generateDroppingCenterQrCode($id) {
+  private static function generateInstitutionCollectionCampQrCode($id) {
     $baseUrl = \CRM_Core_Config::singleton()->userFrameworkBaseURL;
     $data = "{$baseUrl}actions/insititution-collection-camp/{$id}";
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -44,14 +44,13 @@ class InstitutionCollectionCampService extends AutoSubscriber {
       return;
     }
 
-    $collectionCamps = EckEntity::get('Collection_Camp', TRUE)
+    $collectionCamp = EckEntity::get('Collection_Camp', TRUE)
       ->addSelect('Collection_Camp_Core_Details.Status', 'Collection_Camp_Core_Details.Contact_Id')
       ->addWhere('id', '=', $objectId)
-      ->execute();
+      ->execute()->first();
 
-    $currentCollectionCamp = $collectionCamps->first();
-    $currentStatus = $currentCollectionCamp['Collection_Camp_Core_Details.Status'];
-    $collectionCampId = $currentCollectionCamp['id'];
+    $currentStatus = $collectionCamp['Collection_Camp_Core_Details.Status'];
+    $collectionCampId = $collectionCamp['id'];
 
     // Check for status change.
     if ($currentStatus !== $newStatus && $newStatus === 'authorized') {

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -8,13 +8,17 @@ use Civi\Api4\EckEntity;
 use Civi\Api4\StateProvince;
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Traits\CollectionSource;
+use Civi\Traits\QrCodeable;
+
 
 /**
  *
  */
 class InstitutionCollectionCampService extends AutoSubscriber {
+  use QrCodeable;
   use CollectionSource;
   const ENTITY_SUBTYPE_NAME = 'Institution_Collection_Camp';
+  const ENTITY_NAME = 'Collection_Camp';
   const FALLBACK_OFFICE_NAME = 'Delhi';
 
   /**
@@ -23,8 +27,47 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
+      '&hook_civicrm_pre' => 'generateDroppingCenterQr',
       '&hook_civicrm_custom' => 'setOfficeDetails',
     ];
+  }
+
+
+  public static function generateDroppingCenterQr(string $op, string $objectName, $objectId, &$objectRef) {
+    if ($objectName !== 'Eck_Collection_Camp' || !$objectId || !self::isCurrentSubtype($objectRef)) {
+      return;
+    }
+
+    $newStatus = $objectRef['Collection_Camp_Core_Details.Status'] ?? '';
+    if (!$newStatus) {
+      return;
+    }
+
+    $collectionCamps = EckEntity::get('Collection_Camp', TRUE)
+      ->addSelect('Collection_Camp_Core_Details.Status', 'Collection_Camp_Core_Details.Contact_Id')
+      ->addWhere('id', '=', $objectId)
+      ->execute();
+
+    $currentCollectionCamp = $collectionCamps->first();
+    $currentStatus = $currentCollectionCamp['Collection_Camp_Core_Details.Status'];
+    $collectionCampId = $currentCollectionCamp['id'];
+
+    // Check for status change.
+    if ($currentStatus !== $newStatus && $newStatus === 'authorized') {
+      self::generateDroppingCenterQrCode($collectionCampId);
+    }
+  }
+
+  private static function generateDroppingCenterQrCode($id) {
+    $baseUrl = \CRM_Core_Config::singleton()->userFrameworkBaseURL;
+    $data = "{$baseUrl}actions/insititution-collection-camp/{$id}";
+
+    $saveOptions = [
+      'customGroupName' => 'Collection_Camp_QR_Code',
+      'customFieldName' => 'QR_Code',
+    ];
+
+    self::generateQrCode($data, $id, $saveOptions);
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -10,7 +10,6 @@ use Civi\Core\Service\AutoSubscriber;
 use Civi\Traits\CollectionSource;
 use Civi\Traits\QrCodeable;
 
-
 /**
  *
  */
@@ -32,7 +31,9 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     ];
   }
 
-
+  /**
+   *
+   */
   public static function generateInstitutionCollectionCampQr(string $op, string $objectName, $objectId, &$objectRef) {
     if ($objectName !== 'Eck_Collection_Camp' || !$objectId || !self::isCurrentSubtype($objectRef)) {
       return;
@@ -58,6 +59,9 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     }
   }
 
+  /**
+   *
+   */
   private static function generateInstitutionCollectionCampQrCode($id) {
     $baseUrl = \CRM_Core_Config::singleton()->userFrameworkBaseURL;
     $data = "{$baseUrl}actions/insititution-collection-camp/{$id}";

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -63,7 +63,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
    */
   private static function generateInstitutionCollectionCampQrCode($id) {
     $baseUrl = \CRM_Core_Config::singleton()->userFrameworkBaseURL;
-    $data = "{$baseUrl}actions/insititution-collection-camp/{$id}";
+    $data = "{$baseUrl}actions/institution-collection-camp/{$id}";
 
     $saveOptions = [
       'customGroupName' => 'Collection_Camp_QR_Code',


### PR DESCRIPTION
**Description:**
This PR introduces the functionality to generate QR codes for Institution Collection Camps when their status changes to "authorized."

**Key Updates:**

1. Added Hooks:

- &hook_civicrm_pre to trigger QR code generation.

2. QR Code Generation Logic:

- Creates a QR code linking to the camp's URL.
- Saves the generated QR code in the custom field Collection_Camp_QR_Code.QR_Code.

**Utility Functions:**

- Added generateInstitutionCollectionCampQrCode to encapsulate QR code generation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced QR code generation functionality for collection camps.
	- Added event handling to trigger QR code generation when the status of a collection camp changes to 'authorized'.

- **Improvements**
	- Enhanced class capabilities with new methods for QR code generation and event subscription.
	- Defined a new constant to streamline entity identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->