### PR TITLE
Added Token and Cron to send email to volunteer on induction

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRemainderEmailCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRemainderEmailCron.php
@@ -1,0 +1,47 @@
+<?php
+
+use Civi\Api4\Activity;
+use Civi\Api4\MessageTemplate;
+use Civi\InductionService;
+
+/**
+ * Goonjcustom.InductionRemainderEmail to Volunteer API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_induction_remainder_email_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.induction_remainder_email_cron API implementation.
+ *
+ * This function checks for unscheduled induction activities older than 7 days 
+ * and sends follow-up emails to the respective contacts if they haven't already 
+ * received one.
+ *
+ * @param array $params
+ *   Parameters passed to the API call.
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_induction_remainder_email_cron($params) {
+    $returnValues = [];
+    try {
+        InductionService::sendRemainderEmails();
+    } catch (Exception $e) {
+        \Civi::log()->error('Error in Remainder Email cron: ' . $e->getMessage());
+        return civicrm_api3_create_error($e->getMessage());
+    }
+
+    return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'induction_remainder_email_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRemainderEmailCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRemainderEmailCron.php
@@ -5,7 +5,7 @@ use Civi\Api4\MessageTemplate;
 use Civi\InductionService;
 
 /**
- * Goonjcustom.InductionRemainderEmail to Volunteer API specification (optional)
+ * Goonjcustom.InductionRemainderEmail to Volunteer on Induction Day API specification (optional)
  * This is used for documentation and validation.
  *
  * @param array $spec
@@ -20,9 +20,8 @@ function _civicrm_api3_goonjcustom_induction_remainder_email_cron_spec(&$spec) {
 /**
  * Goonjcustom.induction_remainder_email_cron API implementation.
  *
- * This function checks for unscheduled induction activities older than 7 days 
- * and sends follow-up emails to the respective contacts if they haven't already 
- * received one.
+ * This function checks for scheduled induction for current day
+ * and send emails to the respective contacts 
  *
  * @param array $params
  *   Parameters passed to the API call.

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRescheduleCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InductionRescheduleCron.php
@@ -18,7 +18,7 @@ function _civicrm_api3_goonjcustom_induction_reschedule_cron_spec(&$spec) {
 }
 
 /**
- * Goonjcustom.induction_slot_booking_follow_up_cron API implementation.
+ * Goonjcustom.induction_slot_booking_reschedule_cron API implementation.
  *
  * This function checks for not visited induction activities older than 1 days 
  * and sends reschedule emails to the respective contacts if they haven't already 

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -67,7 +67,11 @@ function goonjcustom_register_tokens(TokenRegisterEvent $e) {
   $e->entity('contact')
     ->register('inductionDetails', ts('Induction details'))
     ->register('inductionDateTime', ts('Induction Scheduled Date & Time'))
-    ->register('inductionOnlineMeetlink', ts('Induction Online Meet link'));
+    ->register('inductionOnlineMeetlink', ts('Induction Online Meet link'))
+    ->register('inductionOfficeAddress', ts('Induction Office Address'))
+    ->register('inductionOfficeCity', ts('Induction Office City'))
+    ->register('inductionAssigneeFirstName', ts('Induction Assignee First Name'))
+    ->register('inductionAssigneePhone', ts('Induction Assignee Phone'));
 }
 
 /**
@@ -131,7 +135,7 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
       $row->tokens('contact', 'inductionDetails', $inductionDetailsMarkup);
 			// Fetch induction activity details
 			$inductionActivities = \Civi\Api4\Activity::get(FALSE)
-				->addSelect('activity_date_time', 'Induction_Fields.Goonj_Office')
+				->addSelect('activity_date_time', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
 				->addWhere('activity_type_id:name', '=', 'Induction')
 				->addWhere('source_contact_id', '=', $contactId)
 				->execute();
@@ -145,23 +149,56 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
 			$inductionActivity = $inductionActivities->first();
 			$inductionDateTime = $inductionActivity['activity_date_time'] ?? 'Not Scheduled';
 			$inductionGoonjOffice = $inductionActivity['Induction_Fields.Goonj_Office'] ?? '';
+      $inductionAssigneeId = $inductionActivity['Induction_Fields.Assign']?? '';
 
 			// Fetch office online meet link details if induction office is specified
 			$inductionOnlineMeetlink = '';
+      $completeAddress = '';
+      $inductionOfficeCity = '';
+      $inductionAssigneeFirstName = '';
+      $inductionAssigneePhone = '70423 99564';
+
+      if( $inductionAssigneeId){
+        $assigneeDetails = \Civi\Api4\Contact::get(FALSE)
+          ->addSelect('first_name', 'phone.phone')
+          ->addJoin('Phone AS phone', 'LEFT')
+          ->addWhere('id', '=', $inductionAssigneeId)
+          ->execute()->single();
+
+        $inductionAssigneeFirstName = $assigneeDetails['first_name'] ?? '';
+
+        $inductionAssigneePhone = $assigneeDetails['phone.phone'] ?? '';
+
+      }
+
 			if ($inductionGoonjOffice) {
 				$officeDetails = \Civi\Api4\Contact::get(FALSE)
-					->addSelect('Goonj_Office_Details.Induction_Meeting_Access_Link')
+					->addSelect('Goonj_Office_Details.Induction_Meeting_Access_Link', 'address_primary.city')
 					->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
 					->addWhere('id', '=', $inductionGoonjOffice)
 					->execute()->single();
 
 				$inductionOnlineMeetlink = $officeDetails['Goonj_Office_Details.Induction_Meeting_Access_Link'] ?? '';
+        $inductionOfficeCity = $officeDetails['address_primary.city'] ?? '';
+
+        $addresses = \Civi\Api4\Address::get( false )
+          ->addWhere( 'contact_id', '=', $officeDetails['id'] )
+          ->addWhere( 'is_primary', '=', true )
+          ->setLimit( 1 )
+          ->execute();
+
+        $address = $addresses->count() > 0 ? $addresses->first() : null;
+        $completeAddress = CRM_Utils_Address::format($address);
+
 			}
 
 			// Assign tokens
 			$row->tokens('contact', 'inductionDateTime', $inductionDateTime);
 			$row->tokens('contact', 'inductionOnlineMeetlink', $inductionOnlineMeetlink);
-
+      $row->tokens('contact', 'inductionOfficeAddress', $completeAddress);
+      $row->tokens('contact', 'inductionOfficeCity', $inductionOfficeCity);
+      $row->tokens('contact', 'inductionAssigneeFirstName', $inductionAssigneeFirstName);
+      $row->tokens('contact', 'inductionAssigneePhone', $inductionAssigneePhone);
     }
   }
 }

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -6,6 +6,7 @@
 
 require_once 'goonjcustom.civix.php';
 
+use Civi\InductionService;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Token\Event\TokenRegisterEvent;
@@ -96,6 +97,10 @@ function goonjcustom_evaluate_tokens(TokenValueEvent $e) {
 
     $statedata = $contacts->first();
     $stateId = $statedata['address_primary.state_province_id'];
+    $office = InductionService::findOfficeForState($stateId);
+    \Civi::log()->info('office', ['office'=>$office]);
+    $coordinatorId = InductionService::findCoordinatorForOffice($office['id']);
+    \Civi::log()->info('coordinatorId', ['coordinatorId'=>$coordinatorId]);
 
     $processingCenters = Contact::get(FALSE)
       ->addSelect('Goonj_Office_Details.Days_for_Induction', '*', 'custom.*', 'addressee_id', 'id')


### PR DESCRIPTION
- Added Tokens for adding dynamic data in emails for induction office address, city , coordinator phone, coordinator email
- Added cron job to send remainder email to induction volunteer on day of induction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced automated reminder emails for scheduled induction activities.
	- Added a new API for managing induction reminder emails.
	- Expanded token system to include additional information about induction offices and coordinators.
	- Enhanced functionality for rescheduling induction activities with updated email notifications.

- **Bug Fixes**
	- Improved error handling for email sending processes.

- **Enhancements**
	- Updated logic for fetching and evaluating tokens, providing more comprehensive information related to induction processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->