### PR TITLE
Autofills Source for monetary contribution

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1361,16 +1361,34 @@ class CollectionCampService extends AutoSubscriber {
     $custom554 = NULL;
     $custom555 = NULL;
 
+    // Fetching custom field for collection source.
+    $sourceField = CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
+      ->addWhere('name', '=', 'Source')
+      ->execute()->single();
+
+    $sourceFieldId = 'custom_' . $sourceField['id'] . '_-1';
+
+    // Fetching custom field for goonj offfice.
+    $puSourceField = CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
+      ->addWhere('name', '=', 'PU_Source')
+      ->execute()->single();
+
+    $puSourceFieldId = 'custom_' . $puSourceField['id'] . '_-1';
+
     // Determine the parameter to use based on the form and query parameters.
     if ($formName === 'CRM_Contribute_Form_Contribution') {
-      if (isset($_GET['custom_554_-1'])) {
-        $custom554 = $_GET['custom_554_-1'];
+      if (isset($_GET[$sourceFieldId])) {
+        $custom554 = $_GET[$sourceFieldId];
         $_SESSION['custom_554'] = $custom554;
         // Ensure only one session value is active.
         unset($_SESSION['custom_555']);
       }
-      elseif (isset($_GET['custom_555_-1'])) {
-        $custom555 = $_GET['custom_555_-1'];
+      elseif (isset($_GET[$puSourceFieldId])) {
+        $custom555 = $_GET[$puSourceFieldId];
         $_SESSION['custom_555'] = $custom555;
         // Ensure only one session value is active.
         unset($_SESSION['custom_554']);
@@ -1386,10 +1404,10 @@ class CollectionCampService extends AutoSubscriber {
     if ($formName === 'CRM_Custom_Form_CustomDataByType') {
       $autoFillData = [];
       if (!empty($custom554)) {
-        $autoFillData['custom_554_-1'] = $custom554;
+        $autoFillData[$sourceFieldId] = $custom554;
       }
       elseif (!empty($custom555)) {
-        $autoFillData['custom_555_-1'] = $custom555;
+        $autoFillData[$puSourceFieldId] = $custom555;
       }
 
       // Set default values for the specified fields.

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1419,6 +1419,7 @@ class CollectionCampService extends AutoSubscriber {
             }
             $apiParams = json_decode($element->_attributes['data-api-params'], TRUE);
             if ($apiParams['fieldName'] === 'Contribution.Contribution_Details.Source') {
+              $formFieldName = $fieldName . '_+1';
               $form->setDefaults([$fieldName => $value]);
             }
           }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -69,7 +69,62 @@ class CollectionCampService extends AutoSubscriber {
         ['setEventVolunteersAddress', 8],
       ],
       '&hook_civicrm_tabset' => 'collectionCampTabset',
+      '&hook_civicrm_buildForm' => [
+        ['autofillMonetaryFormSource'],
+
+      ],
     ];
+  }
+
+  /**
+   * Implements hook_civicrm_buildForm.
+   *
+   * Auto-fills custom fields in the form.
+   *
+   * @param string $formName
+   *   The name of the form being built.
+   * @param object $form
+   *   The form object.
+   */
+  public function autofillMonetaryFormSource($formName, &$form) {
+    $custom554 = NULL;
+
+    // Check if this is the initial form that provides the value.
+    if ($formName === 'CRM_Contribute_Form_Contribution' && isset($_GET['custom_554_-1'])) {
+      $custom554 = $_GET['custom_554_-1'];
+      // Store the value in the session for subsequent use.
+      $_SESSION['custom_554'] = $custom554;
+    }
+    else {
+      // Retrieve the value from the session.
+      $custom554 = $_SESSION['custom_554'] ?? NULL;
+    }
+
+    if (empty($custom554)) {
+      return;
+    }
+
+    if ($formName === 'CRM_Custom_Form_CustomDataByType') {
+      $autoFillData = [
+      // Autofills the Collection camp and Droppung center.
+        'custom_554_-1' => $custom554,
+      // Autofills the Office.
+        'custom_555_-1' => '19',
+      ];
+      error_log("autoFillData: " . print_r($autoFillData, TRUE));
+
+      // Set default values for the specified fields.
+      foreach ($autoFillData as $fieldName => $value) {
+        if (isset($form->_elements) && is_array($form->_elements)) {
+          foreach ($form->_elements as $element) {
+            if (isset($element->_attributes['name']) && $element->_attributes['name'] === $fieldName) {
+              $form->setDefaults([$fieldName => $value]);
+              error_log("Auto-filled $fieldName with value $value.");
+            }
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -71,73 +71,10 @@ class CollectionCampService extends AutoSubscriber {
       '&hook_civicrm_tabset' => 'collectionCampTabset',
       '&hook_civicrm_buildForm' => [
         ['autofillMonetaryFormSource'],
-
       ],
     ];
   }
 
-  /**
-   * Implements hook_civicrm_buildForm.
-   *
-   * Auto-fills custom fields in the form based on the provided parameters.
-   *
-   * @param string $formName
-   *   The name of the form being built.
-   * @param object $form
-   *   The form object.
-   */
-  public function autofillMonetaryFormSource($formName, &$form) {
-    $custom554 = NULL;
-    $custom555 = NULL;
-
-    // Determine the parameter to use based on the form and query parameters.
-    if ($formName === 'CRM_Contribute_Form_Contribution') {
-      if (isset($_GET['custom_554_-1'])) {
-        $custom554 = $_GET['custom_554_-1'];
-        $_SESSION['custom_554'] = $custom554;
-        // Ensure only one session value is active.
-        unset($_SESSION['custom_555']);
-      }
-      elseif (isset($_GET['custom_555_-1'])) {
-        $custom555 = $_GET['custom_555_-1'];
-        $_SESSION['custom_555'] = $custom555;
-        // Ensure only one session value is active.
-        unset($_SESSION['custom_554']);
-      }
-    }
-    else {
-      // Retrieve from session if not provided in query parameters.
-      $custom554 = $_SESSION['custom_554'] ?? NULL;
-      $custom555 = $_SESSION['custom_555'] ?? NULL;
-    }
-
-    error_log("_GET: " . print_r($_GET, TRUE));
-
-    // Autofill logic for the custom fields.
-    if ($formName === 'CRM_Custom_Form_CustomDataByType') {
-      $autoFillData = [];
-      if (!empty($custom554)) {
-        $autoFillData['custom_554_-1'] = $custom554;
-      }
-      elseif (!empty($custom555)) {
-        $autoFillData['custom_555_-1'] = $custom555;
-      }
-
-      error_log("autoFillData: " . print_r($autoFillData, TRUE));
-
-      // Set default values for the specified fields.
-      foreach ($autoFillData as $fieldName => $value) {
-        if (isset($form->_elements) && is_array($form->_elements)) {
-          foreach ($form->_elements as $element) {
-            if (isset($element->_attributes['name']) && $element->_attributes['name'] === $fieldName) {
-              $form->setDefaults([$fieldName => $value]);
-              error_log("Auto-filled $fieldName with value $value.");
-            }
-          }
-        }
-      }
-    }
-  }
 
   /**
    *
@@ -1409,6 +1346,69 @@ class CollectionCampService extends AutoSubscriber {
       'newStatus' => $newStatus,
       'currentStatus' => $currentStatus,
     ];
+  }
+
+  /**
+   * Implements hook_civicrm_buildForm.
+   *
+   * Auto-fills custom fields in the form based on the provided parameters.
+   *
+   * @param string $formName
+   *   The name of the form being built.
+   * @param object $form
+   *   The form object.
+   */
+  public function autofillMonetaryFormSource($formName, &$form) {
+    $custom554 = NULL;
+    $custom555 = NULL;
+
+    // Determine the parameter to use based on the form and query parameters.
+    if ($formName === 'CRM_Contribute_Form_Contribution') {
+      if (isset($_GET['custom_554_-1'])) {
+        $custom554 = $_GET['custom_554_-1'];
+        $_SESSION['custom_554'] = $custom554;
+        // Ensure only one session value is active.
+        unset($_SESSION['custom_555']);
+      }
+      elseif (isset($_GET['custom_555_-1'])) {
+        $custom555 = $_GET['custom_555_-1'];
+        $_SESSION['custom_555'] = $custom555;
+        // Ensure only one session value is active.
+        unset($_SESSION['custom_554']);
+      }
+    }
+    else {
+      // Retrieve from session if not provided in query parameters.
+      $custom554 = $_SESSION['custom_554'] ?? NULL;
+      $custom555 = $_SESSION['custom_555'] ?? NULL;
+    }
+
+    error_log("_GET: " . print_r($_GET, TRUE));
+
+    // Autofill logic for the custom fields.
+    if ($formName === 'CRM_Custom_Form_CustomDataByType') {
+      $autoFillData = [];
+      if (!empty($custom554)) {
+        $autoFillData['custom_554_-1'] = $custom554;
+      }
+      elseif (!empty($custom555)) {
+        $autoFillData['custom_555_-1'] = $custom555;
+      }
+
+      error_log("autoFillData: " . print_r($autoFillData, TRUE));
+
+      // Set default values for the specified fields.
+      foreach ($autoFillData as $fieldName => $value) {
+        if (isset($form->_elements) && is_array($form->_elements)) {
+          foreach ($form->_elements as $element) {
+            if (isset($element->_attributes['name']) && $element->_attributes['name'] === $fieldName) {
+              $form->setDefaults([$fieldName => $value]);
+              error_log("Auto-filled $fieldName with value $value.");
+            }
+          }
+        }
+      }
+    }
   }
 
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1423,7 +1423,7 @@ class CollectionCampService extends AutoSubscriber {
             }
             $apiParams = json_decode($element->_attributes['data-api-params'], TRUE);
             if ($apiParams['fieldName'] === 'Contribution.Contribution_Details.Source') {
-              $formFieldName = $fieldName . '_+1';
+              $formFieldName = $fieldName . '_-1';
               $form->setDefaults([$formFieldName => $value]);
             }
           }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1348,7 +1348,7 @@ class CollectionCampService extends AutoSubscriber {
   }
 
   /**
-   * Implements hook_civicrm_buildForm.
+   * Implements hook_civicrm_buildForm().
    *
    * Auto-fills custom fields in the form based on the provided parameters.
    *

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1358,7 +1358,7 @@ class CollectionCampService extends AutoSubscriber {
    *   The form object.
    */
   public function autofillMonetaryFormSource($formName, &$form) {
-    if (!in_array($formName, ['CRM_Contribute_Form_Contribution', 'CRM_Custom_Form_CustomDataByType']) {
+    if (!in_array($formName, ['CRM_Contribute_Form_Contribution', 'CRM_Custom_Form_CustomDataByType'])) {
       return;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1358,8 +1358,8 @@ class CollectionCampService extends AutoSubscriber {
    *   The form object.
    */
   public function autofillMonetaryFormSource($formName, &$form) {
-    $custom554 = NULL;
-    $custom555 = NULL;
+    $campSource = NULL;
+    $puSource = NULL;
 
     // Fetching custom field for collection source.
     $sourceField = CustomField::get(FALSE)
@@ -1382,32 +1382,32 @@ class CollectionCampService extends AutoSubscriber {
     // Determine the parameter to use based on the form and query parameters.
     if ($formName === 'CRM_Contribute_Form_Contribution') {
       if (isset($_GET[$sourceFieldId])) {
-        $custom554 = $_GET[$sourceFieldId];
-        $_SESSION['custom_554'] = $custom554;
+        $campSource = $_GET[$sourceFieldId];
+        $_SESSION['camp_source'] = $campSource;
         // Ensure only one session value is active.
-        unset($_SESSION['custom_555']);
+        unset($_SESSION['pu_source']);
       }
       elseif (isset($_GET[$puSourceFieldId])) {
-        $custom555 = $_GET[$puSourceFieldId];
-        $_SESSION['custom_555'] = $custom555;
+        $puSource = $_GET[$puSourceFieldId];
+        $_SESSION['pu_source'] = $puSource;
         // Ensure only one session value is active.
-        unset($_SESSION['custom_554']);
+        unset($_SESSION['camp_source']);
       }
     }
     else {
       // Retrieve from session if not provided in query parameters.
-      $custom554 = $_SESSION['custom_554'] ?? NULL;
-      $custom555 = $_SESSION['custom_555'] ?? NULL;
+      $campSource = $_SESSION['camp_source'] ?? NULL;
+      $puSource = $_SESSION['pu_source'] ?? NULL;
     }
 
     // Autofill logic for the custom fields.
     if ($formName === 'CRM_Custom_Form_CustomDataByType') {
       $autoFillData = [];
-      if (!empty($custom554)) {
-        $autoFillData[$sourceFieldId] = $custom554;
+      if (!empty($campSource)) {
+        $autoFillData[$sourceFieldId] = $campSource;
       }
-      elseif (!empty($custom555)) {
-        $autoFillData[$puSourceFieldId] = $custom555;
+      elseif (!empty($puSource)) {
+        $autoFillData[$puSourceFieldId] = $puSource;
       }
 
       // Set default values for the specified fields.

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1368,7 +1368,7 @@ class CollectionCampService extends AutoSubscriber {
       ->addWhere('name', '=', 'Source')
       ->execute()->single();
 
-    $sourceFieldId = 'custom_' . $sourceField['id'] . '_-1';
+    $sourceFieldId = 'custom_' . $sourceField['id'];
 
     // Fetching custom field for goonj offfice.
     $puSourceField = CustomField::get(FALSE)
@@ -1377,7 +1377,7 @@ class CollectionCampService extends AutoSubscriber {
       ->addWhere('name', '=', 'PU_Source')
       ->execute()->single();
 
-    $puSourceFieldId = 'custom_' . $puSourceField['id'] . '_-1';
+    $puSourceFieldId = 'custom_' . $puSourceField['id'];
 
     // Determine the parameter to use based on the form and query parameters.
     if ($formName === 'CRM_Contribute_Form_Contribution') {
@@ -1414,7 +1414,11 @@ class CollectionCampService extends AutoSubscriber {
       foreach ($autoFillData as $fieldName => $value) {
         if (isset($form->_elements) && is_array($form->_elements)) {
           foreach ($form->_elements as $element) {
-            if (isset($element->_attributes['name']) && $element->_attributes['name'] === $fieldName) {
+            if (!isset($element->_attributes['data-api-params'])) {
+              continue;
+            }
+            $apiParams = json_decode($element->_attributes['data-api-params'], TRUE);
+            if ($apiParams['fieldName'] === 'Contribution.Contribution_Details.Source') {
               $form->setDefaults([$fieldName => $value]);
             }
           }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1420,7 +1420,7 @@ class CollectionCampService extends AutoSubscriber {
             $apiParams = json_decode($element->_attributes['data-api-params'], TRUE);
             if ($apiParams['fieldName'] === 'Contribution.Contribution_Details.Source') {
               $formFieldName = $fieldName . '_+1';
-              $form->setDefaults([$fieldName => $value]);
+              $form->setDefaults([$formFieldName => $value]);
             }
           }
         }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1416,7 +1416,6 @@ class CollectionCampService extends AutoSubscriber {
           foreach ($form->_elements as $element) {
             if (isset($element->_attributes['name']) && $element->_attributes['name'] === $fieldName) {
               $form->setDefaults([$fieldName => $value]);
-              error_log("Auto-filled $fieldName with value $value.");
             }
           }
         }

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1382,8 +1382,6 @@ class CollectionCampService extends AutoSubscriber {
       $custom555 = $_SESSION['custom_555'] ?? NULL;
     }
 
-    error_log("_GET: " . print_r($_GET, TRUE));
-
     // Autofill logic for the custom fields.
     if ($formName === 'CRM_Custom_Form_CustomDataByType') {
       $autoFillData = [];
@@ -1393,8 +1391,6 @@ class CollectionCampService extends AutoSubscriber {
       elseif (!empty($custom555)) {
         $autoFillData['custom_555_-1'] = $custom555;
       }
-
-      error_log("autoFillData: " . print_r($autoFillData, TRUE));
 
       // Set default values for the specified fields.
       foreach ($autoFillData as $fieldName => $value) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1358,6 +1358,10 @@ class CollectionCampService extends AutoSubscriber {
    *   The form object.
    */
   public function autofillMonetaryFormSource($formName, &$form) {
+    if (!in_array($formName, ['CRM_Contribute_Form_Contribution', 'CRM_Custom_Form_CustomDataByType']) {
+      return;
+    }
+
     $campSource = NULL;
     $puSource = NULL;
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -75,7 +75,6 @@ class CollectionCampService extends AutoSubscriber {
     ];
   }
 
-
   /**
    *
    */

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -79,7 +79,7 @@ class CollectionCampService extends AutoSubscriber {
   /**
    * Implements hook_civicrm_buildForm.
    *
-   * Auto-fills custom fields in the form.
+   * Auto-fills custom fields in the form based on the provided parameters.
    *
    * @param string $formName
    *   The name of the form being built.
@@ -88,29 +88,41 @@ class CollectionCampService extends AutoSubscriber {
    */
   public function autofillMonetaryFormSource($formName, &$form) {
     $custom554 = NULL;
+    $custom555 = NULL;
 
-    // Check if this is the initial form that provides the value.
-    if ($formName === 'CRM_Contribute_Form_Contribution' && isset($_GET['custom_554_-1'])) {
-      $custom554 = $_GET['custom_554_-1'];
-      // Store the value in the session for subsequent use.
-      $_SESSION['custom_554'] = $custom554;
+    // Determine the parameter to use based on the form and query parameters.
+    if ($formName === 'CRM_Contribute_Form_Contribution') {
+      if (isset($_GET['custom_554_-1'])) {
+        $custom554 = $_GET['custom_554_-1'];
+        $_SESSION['custom_554'] = $custom554;
+        // Ensure only one session value is active.
+        unset($_SESSION['custom_555']);
+      }
+      elseif (isset($_GET['custom_555_-1'])) {
+        $custom555 = $_GET['custom_555_-1'];
+        $_SESSION['custom_555'] = $custom555;
+        // Ensure only one session value is active.
+        unset($_SESSION['custom_554']);
+      }
     }
     else {
-      // Retrieve the value from the session.
+      // Retrieve from session if not provided in query parameters.
       $custom554 = $_SESSION['custom_554'] ?? NULL;
+      $custom555 = $_SESSION['custom_555'] ?? NULL;
     }
 
-    if (empty($custom554)) {
-      return;
-    }
+    error_log("_GET: " . print_r($_GET, TRUE));
 
+    // Autofill logic for the custom fields.
     if ($formName === 'CRM_Custom_Form_CustomDataByType') {
-      $autoFillData = [
-      // Autofills the Collection camp and Droppung center.
-        'custom_554_-1' => $custom554,
-      // Autofills the Office.
-        'custom_555_-1' => '19',
-      ];
+      $autoFillData = [];
+      if (!empty($custom554)) {
+        $autoFillData['custom_554_-1'] = $custom554;
+      }
+      elseif (!empty($custom555)) {
+        $autoFillData['custom_555_-1'] = $custom555;
+      }
+
       error_log("autoFillData: " . print_r($autoFillData, TRUE));
 
       // Set default values for the specified fields.


### PR DESCRIPTION
When admin adds the monetary contribution then we are auto-filling the source for that camp or office.
1. Adds button on searchKit to add monetary contribution for camp and offices 

**Camp URL:** `civicrm/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fcontribute%2Fadd&reset=1&action=add&context=standalone&custom_554_-1=[Contribution_Details.Source]`

**Office URL:** `civicrm/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fcontribute%2Fadd&reset=1&action=add&context=standalone&custom_555_-1=[Contribution_Details.PU_Source]`

2. Fetches the custom_554_-1 and custom_555_-1 data with the help of the `hook_civicrm_buildForm()` hook
3. After fetching Set default values for the specified fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an autofill feature for monetary forms that automatically populates fields based on session data and URL parameters.
	- Enhanced event subscription mechanism to support the new autofill functionality during form build processes.

- **Bug Fixes**
	- Improved error handling for processing auto-filled data in forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->