### PR TITLE
Set Organization Name for collection camp

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -29,7 +29,35 @@ class InstitutionCollectionCampService extends AutoSubscriber {
       '&hook_civicrm_pre' => 'generateInstitutionCollectionCampQr',
       '&hook_civicrm_custom' => 'setOfficeDetails',
       '&hook_civicrm_tabset' => 'institutionCollectionCampTabset',
+      '&hook_civicrm_post' => [
+        ['setOrganizationNameForCollectionCamp'],
+      ],
     ];
+  }
+
+  /**
+   *
+   */
+  public static function setOrganizationNameForCollectionCamp(string $op, string $objectName, int $objectId, &$objectRef) {
+    // Check if afform_name is set and matches the required value.
+    if (empty($objectRef->afform_name) || $objectRef->afform_name !== 'afformInstitutionCollectionCampIntentVerification') {
+      return;
+    }
+
+    $data = json_decode($objectRef->data, TRUE);
+
+    // Retrieve organizationId and entityId, return if not set.
+    $organizationId = $data['Organization1'][0]['fields']['id'] ?? NULL;
+    $entityId = $data['Eck_Collection_Camp1'][0]['fields']['id'] ?? NULL;
+
+    if (!$organizationId || !$entityId) {
+      return;
+    }
+
+    EckEntity::update('Collection_Camp', TRUE)
+      ->addValue('Institution_collection_camp_Review.Institution_Name', $organizationId)
+      ->addWhere('id', '=', $entityId)
+      ->execute();
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -68,14 +68,21 @@ class InstitutionService extends AutoSubscriber {
    *   The parameters that were sent into the calling function.
    */
   public static function setOfficeDetails($op, $groupID, $entityID, &$params) {
+    error_log("updateOrganization: " . print_r(self::getOrgSubtypeName($entityID), TRUE));
 
     if ($op !== 'create' || self::getOrgSubtypeName($entityID) !== self::ENTITY_SUBTYPE_NAME) {
       return;
     }
+    error_log("entityID: " . print_r($entityID, TRUE));
+    error_log("groupID: " . print_r($groupID, TRUE));
+    error_log("params: " . print_r($params, TRUE));
 
     if (!($stateField = self::findStateField($params))) {
       return;
     }
+
+    error_log("stateId: " . print_r($stateId, TRUE));
+    error_log("contactId: " . print_r($contactId, TRUE));
 
     $stateId = $stateField['value'];
     $contactId = $stateField['entity_id'];


### PR DESCRIPTION
### PR Description:

Once the organization is mapped to the collection camp during the review of the intent details, and after it's authorized, users should be able to see the organization directly on the collection camp list. This will allow them to click on the organization name and be redirected straight to its details.


<img width="1152" alt="image" src="https://github.com/user-attachments/assets/b4855789-7a78-4bbe-a34e-7e4e8f5dd7b8">


