### PR TITLE
Stop sending receipt when user don't have pan card

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1464,7 +1464,7 @@ class CollectionCampService extends AutoSubscriber {
    *
    */
   public function suppressEmailIfPanCardMissing(&$params, $context = NULL) {
-    if (!$params['valueName'] === 'contribution_online_receipt') {
+    if ($params['valueName'] !== 'contribution_online_receipt') {
       return;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -8,6 +8,7 @@ use Civi\Afform\Event\AfformSubmitEvent;
 use Civi\Api4\Activity;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
+use Civi\Api4\Contribution;
 use Civi\Api4\CustomField;
 use Civi\Api4\EckEntity;
 use Civi\Api4\Email;
@@ -72,6 +73,7 @@ class CollectionCampService extends AutoSubscriber {
       '&hook_civicrm_buildForm' => [
         ['autofillMonetaryFormSource'],
       ],
+      '&hook_civicrm_alterMailParams' => 'suppressEmailIfPanCardMissing',
     ];
   }
 
@@ -1455,6 +1457,40 @@ class CollectionCampService extends AutoSubscriber {
           }
         }
       }
+    }
+  }
+
+  /**
+   *
+   */
+  public function suppressEmailIfPanCardMissing(&$params, $context = NULL) {
+    if (!$params['valueName'] === 'contribution_online_receipt') {
+      return;
+    }
+
+    $contributionId = $params['tplParams']['contributionID'] ?? NULL;
+
+    if (!$contributionId) {
+      return;
+    }
+
+    try {
+      $contribution = Contribution::get(FALSE)
+        ->addSelect('Contribution_Details.PAN_Card_Number')
+        ->addWhere('id', '=', $contributionId)
+        ->execute()
+        ->single();
+
+      $panCard = $contribution['Contribution_Details.PAN_Card_Number'] ?? '';
+
+      if (empty($panCard)) {
+        // Modify params to suppress email (set the toEmail as null, or mark as test)
+        // Empty out the recipient email address.
+        $params['toEmail'] = '';
+      }
+    }
+    catch (Exception $e) {
+      \Civi::log()->error("Error retrieving contribution data for ID $contributionId: " . $e->getMessage());
     }
   }
 


### PR DESCRIPTION
Stop sending receipt when user don't have pan card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to suppress email notifications if a contribution's PAN card number is missing.
	- Added a new event hook to enhance email parameter handling.

- **Bug Fixes**
	- Improved error handling for retrieving contribution data related to email notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->