### PR TITLE
Remove functionality that stops to send the receipt

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -73,7 +73,6 @@ class CollectionCampService extends AutoSubscriber {
       '&hook_civicrm_buildForm' => [
         ['autofillMonetaryFormSource'],
       ],
-      '&hook_civicrm_alterMailParams' => 'suppressEmailIfPanCardMissing',
     ];
   }
 
@@ -1481,40 +1480,6 @@ class CollectionCampService extends AutoSubscriber {
           }
         }
       }
-    }
-  }
-
-  /**
-   *
-   */
-  public function suppressEmailIfPanCardMissing(&$params, $context = NULL) {
-    if ($params['valueName'] !== 'contribution_online_receipt') {
-      return;
-    }
-
-    $contributionId = $params['tplParams']['contributionID'] ?? NULL;
-
-    if (!$contributionId) {
-      return;
-    }
-
-    try {
-      $contribution = Contribution::get(FALSE)
-        ->addSelect('Contribution_Details.PAN_Card_Number')
-        ->addWhere('id', '=', $contributionId)
-        ->execute()
-        ->single();
-
-      $panCard = $contribution['Contribution_Details.PAN_Card_Number'] ?? '';
-
-      if (empty($panCard)) {
-        // Modify params to suppress email (set the toEmail as null, or mark as test)
-        // Empty out the recipient email address.
-        $params['toEmail'] = '';
-      }
-    }
-    catch (Exception $e) {
-      \Civi::log()->error("Error retrieving contribution data for ID $contributionId: " . $e->getMessage());
     }
   }
 


### PR DESCRIPTION
Remove functionality that stops to send the receipt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified event subscription logic by removing the email suppression feature related to missing PAN card numbers.
  
- **Bug Fixes**
	- Eliminated potential errors from email notifications by removing outdated suppression logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->