### PR TITLE
Institution Collection Camp

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/InstitutionCollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/InstitutionCollectionCamp.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ *
+ */
+
+use Civi\Api4\Contact;
+use Civi\Api4\EckEntity;
+use Civi\Api4\Phone;
+use Civi\Api4\Relationship;
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\TokenRow;
+
+/**
+ *
+ */
+class CRM_Goonjcustom_Token_InstitutionCollectionCamp extends AbstractTokenSubscriber {
+
+  const ACTIVITY_TARGET_RECORD_TYPE_ID = 3;
+
+  public function __construct() {
+    parent::__construct('institution_collection_camp', [
+      'venue' => \CRM_Goonjcustom_ExtensionUtil::ts('Venue'),
+      'date' => \CRM_Goonjcustom_ExtensionUtil::ts('Date'),
+      'time' => \CRM_Goonjcustom_ExtensionUtil::ts('Time'),
+      'volunteers' => \CRM_Goonjcustom_ExtensionUtil::ts('Volunteers'),
+      'coordinator' => \CRM_Goonjcustom_ExtensionUtil::ts('Coordinator (Goonj)'),
+      'remarks' => \CRM_Goonjcustom_ExtensionUtil::ts('Remarks'),
+      'type' => \CRM_Goonjcustom_ExtensionUtil::ts('Type (Camp/Drive)'),
+      'address_city' => \CRM_Goonjcustom_ExtensionUtil::ts('City'),
+    ]);
+  }
+
+  /**
+   *
+   */
+  public function evaluateToken(
+    TokenRow $row,
+    $entity,
+    $field,
+    $prefetch = NULL,
+  ) {
+
+    if (empty($row->context['collectionSourceId'])) {
+      \Civi::log()->debug(__CLASS__ . '::' . __METHOD__ . ' There is no collectionSourceId in the context, you can\'t use collection_camp tokens.');
+      $row->format('text/plain')->tokens($entity, $field, '');
+      return;
+    }
+
+    $newCustomData = $row->context['collectionSourceCustomData'];
+
+    $currentCustomData = EckEntity::get('Collection_Camp', FALSE)
+      ->addSelect('custom.*')
+      ->addWhere('id', '=', $row->context['collectionSourceId'])
+      ->execute()->single();
+
+    $collectionSource = array_merge($currentCustomData, $newCustomData);
+    error_log("collectionSource: " . print_r($collectionSource, TRUE));
+    switch ($field) {
+      case 'venue':
+        $value = $this->formatVenue($collectionSource);
+        break;
+
+      case 'date':
+      case 'time':
+      case 'type':
+        $start = new DateTime($collectionSource['Collections_will_start_on_Date_']);
+        $end = new DateTime($collectionSource['Collections_will_end_on_Date_']);
+
+        if ($field === 'type') {
+          $value = $start->format('Y-m-d') === $end->format('Y-m-d') ? 'Camp' : 'Drive';
+        }
+        elseif ($field === 'date') {
+          $value = $this->formatDate($start, $end);
+        }
+        else {
+          $value = $this->formatTime($start, $end);
+        }
+        break;
+
+      case 'volunteers':
+        $value = $this->formatVolunteers($collectionSource);
+        break;
+
+      case 'coordinator':
+        $value = $this->formatCoordinator($collectionSource);
+        break;
+
+      case 'address_city':
+        $value = $collectionSource['Institution_Collection_Camp_Intent.District_City'];
+        break;
+
+      default:
+        $value = '';
+        break;
+
+    }
+
+    $row->format('text/html')->tokens($entity, $field, $value);
+    $row->format('text/plain')->tokens($entity, $field, $value);
+    return;
+
+  }
+
+  /**
+   *
+   */
+  private function formatDate($start, $end) {
+
+    $startFormatted = $start->format('M jS, Y (l)');
+    $endFormatted = $end->format('M jS, Y (l)');
+
+    if ($start->format('Y-m-d') === $end->format('Y-m-d')) {
+      return $startFormatted;
+    }
+
+    return "$startFormatted - $endFormatted";
+  }
+
+  /**
+   *
+   */
+  private function formatTime($start, $end) {
+
+    $startTime = $start->format('h:i A');
+    $endTime = $end->format('h:i A');
+
+    return "$startTime to $endTime";
+  }
+
+  /**
+   *
+   */
+  private function formatVolunteers($collectionSource) {
+    $organizationId = $collectionSource['Institution_Collection_Camp_Intent.Organization_Name'];
+
+    $relationships = Relationship::get(FALSE)
+      ->addWhere('contact_id_a', '=', $organizationId)
+      ->addWhere('relationship_type_id:name', '=', 'Primary Institution POC of')
+      ->execute();
+
+    // If no relationships found for 'Primary Institution POC of', check for 'Secondary Institution POC of'.
+    if (empty($relationships)) {
+      $relationships = Relationship::get(FALSE)
+        ->addWhere('contact_id_a', '=', $organizationId)
+        ->addWhere('relationship_type_id:name', '=', 'Secondary Institution POC of')
+        ->execute();
+    }
+
+    // Return contact_id_b as initiator if found.
+    $initiatorId = NULL;
+    if (!empty($relationships) && isset($relationships[0]['contact_id_b'])) {
+      $initiatorId = $relationships[0]['contact_id_b'];
+    }
+
+    if (!$initiatorId) {
+      return '';
+    }
+
+    $volunteers = Contact::get(FALSE)
+      ->addSelect('phone.phone', 'phone.is_primary', 'display_name', 'id')
+      ->addJoin('Phone AS phone', 'LEFT')
+      ->addWhere('id', '=', $initiatorId)
+      ->execute();
+
+    $volunteersArray = $volunteers->jsonSerialize();
+    $volunteersDetails = [];
+
+    $primaryVolunteer = array_filter($volunteersArray, function ($volunteer) {
+        return $volunteer['phone.is_primary'];
+    });
+
+    if (!empty($primaryVolunteer)) {
+      $volunteersDetails[] = reset($primaryVolunteer);
+    }
+    else {
+      $volunteersDetails[] = reset($volunteersArray);
+    }
+
+    $volunteersWithPhone = array_map(
+        fn($volunteer) => isset($volunteer['phone.phone']) && !empty($volunteer['phone.phone'])
+            ? sprintf('%1$s (%2$s)', $volunteer['display_name'], $volunteer['phone.phone'])
+            : $volunteer['display_name'],
+        $volunteersDetails
+    );
+
+    return join(', ', $volunteersWithPhone);
+  }
+
+  /**
+   *
+   */
+  private function formatVenue($collectionSource) {
+    $addressParts = [
+      $collectionSource['Institution_Collection_Camp_Intent.Collection_Camp_Address'],
+      $collectionSource['Institution_Collection_Camp_Intent.District_City'],
+    ];
+
+    return join(', ', array_filter($addressParts));
+
+  }
+
+  /**
+   *
+   */
+  private function formatCoordinator($collectionSource) {
+    $officeId = $collectionSource['Institution_collection_camp_Review.Goonj_Office'];
+
+    $officePhones = Phone::get(FALSE)
+      ->addSelect('phone')
+      ->addWhere('contact_id', '=', $officeId)
+      ->execute();
+
+    $phoneNumbers = $officePhones->column('phone');
+
+    return sprintf('%1$s (%2$s)', \CRM_Goonjcustom_ExtensionUtil::ts('Team Goonj'), join(', ', $phoneNumbers));
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/InstitutionCollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/InstitutionCollectionCamp.php
@@ -55,7 +55,7 @@ class CRM_Goonjcustom_Token_InstitutionCollectionCamp extends AbstractTokenSubsc
       ->execute()->single();
 
     $collectionSource = array_merge($currentCustomData, $newCustomData);
-    error_log("collectionSource: " . print_r($collectionSource, TRUE));
+
     switch ($field) {
       case 'venue':
         $value = $this->formatVenue($collectionSource);

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -10,6 +10,7 @@ use Civi\Api4\Group;
 use Civi\Api4\GroupContact;
 use Civi\Api4\MessageTemplate;
 use Civi\Api4\OptionValue;
+use Civi\Api4\Relationship;
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Traits\CollectionSource;
 
@@ -71,7 +72,7 @@ class CollectionBaseService extends AutoSubscriber {
       $baseFileName = "collection_camp_{$collectionSourceId}.png";
     }
     else {
-      $baseFileName = "dropping_center_{$collectionSourceId}.png";
+      $baseFileName = "Institution_collection_camp_{$collectionSourceId}.png";
     }
 
     return $baseFileName;
@@ -92,7 +93,6 @@ class CollectionBaseService extends AutoSubscriber {
       ->addWhere('id', '=', $messageTemplateId)
       ->execute()->single();
     $html = $messageTemplate['msg_html'];
-
     // Regular expression to find <style>...</style> and replace it with {literal}<style>...</style>{/literal}.
     $pattern = '/<style\b[^>]*>(.*?)<\/style>/is';
     $replacement = '{literal}<style>$1</style>{/literal}';
@@ -104,7 +104,6 @@ class CollectionBaseService extends AutoSubscriber {
     $replacement = '{literal}<script>$1</script>{/literal}';
 
     $modifiedHtml = preg_replace($pattern, $replacement, $modifiedHtml);
-
     $rendered = \CRM_Core_TokenSmarty::render(
     ['html' => $modifiedHtml],
     [
@@ -137,7 +136,6 @@ class CollectionBaseService extends AutoSubscriber {
     }
 
     $posterFieldId = 'custom_' . $posterField['id'];
-
     // Save the poster image as an attachment linked to the collection camp.
     $params = [
       'entity_id' => $collectionSourceId,
@@ -148,7 +146,6 @@ class CollectionBaseService extends AutoSubscriber {
         'move-file' => $tempFilePath,
       ],
     ];
-
     $result = civicrm_api3('Attachment', 'create', $params);
     if (empty($result['id'])) {
       \CRM_Core_Error::debug_log_message('Failed to upload poster image for collection camp ID ' . $collectionSourceId);
@@ -165,7 +162,6 @@ class CollectionBaseService extends AutoSubscriber {
     $htmlContent = escapeshellarg($htmlContent);
 
     $command = "$nodePath $puppeteerJsPath $htmlContent $outputPath";
-
     exec($command, $output, $returnCode);
 
     if ($returnCode === 0) {
@@ -288,12 +284,13 @@ class CollectionBaseService extends AutoSubscriber {
     }
 
     $currentCollectionCamp = EckEntity::get('Collection_Camp', FALSE)
-      ->addSelect('Collection_Camp_Core_Details.Status', 'Collection_Camp_Core_Details.Contact_Id')
+      ->addSelect('Collection_Camp_Core_Details.Status', 'Collection_Camp_Core_Details.Contact_Id', 'Institution_Collection_Camp_Intent.Organization_Name.id', 'subtype:name')
       ->addWhere('id', '=', $objectId)
       ->execute()->single();
 
+    $initiatorId = self::getInitiatorId($currentCollectionCamp);
+
     $currentStatus = $currentCollectionCamp['Collection_Camp_Core_Details.Status'];
-    $initiatorId = $currentCollectionCamp['Collection_Camp_Core_Details.Contact_Id'];
 
     if (!in_array($newStatus, ['authorized', 'unauthorized'])) {
       return;
@@ -315,24 +312,56 @@ class CollectionBaseService extends AutoSubscriber {
     }
 
     $collectionCamp = EckEntity::get('Collection_Camp', FALSE)
-      ->addSelect('Collection_Camp_Core_Details.Status', 'Collection_Camp_Core_Details.Contact_Id', 'subtype')
+      ->addSelect('Collection_Camp_Core_Details.Status', 'Collection_Camp_Core_Details.Contact_Id', 'Institution_Collection_Camp_Intent.Organization_Name.id', 'subtype', 'subtype:name')
       ->addWhere('id', '=', $objectRef->id)
       ->execute()->single();
 
-    $initiator = $collectionCamp['Collection_Camp_Core_Details.Contact_Id'];
-    $subtype = $collectionCamp['subtype'];
+    $initiatorId = self::getInitiatorId($collectionCamp);
 
     $collectionSourceId = $collectionCamp['id'];
+    $subtype = $collectionCamp['subtype'];
 
     if (!self::$authorizationEmailQueued) {
-      self::queueAuthorizationEmail($initiator, $subtype, self::$collectionAuthorizedStatus, $collectionSourceId);
+      self::queueAuthorizationEmail($initiatorId, $subtype, self::$collectionAuthorizedStatus, $collectionSourceId);
     }
+  }
+
+  /**
+   *
+   */
+  private static function getInitiatorId(array $collectionCamp) {
+    $subtypeName = $collectionCamp['subtype:name'];
+
+    $organizationId = $collectionCamp['Institution_Collection_Camp_Intent.Organization_Name.id'];
+
+    if ($subtypeName === 'Institution_Collection_Camp') {
+      $relationships = Relationship::get(FALSE)
+        ->addWhere('contact_id_a', '=', $organizationId)
+        ->addWhere('relationship_type_id:name', '=', 'Primary Institution POC of')
+        ->execute();
+      // If no relationships found for 'Primary Institution POC of', check for 'Secondary Institution POC of'.
+      if (empty($relationships)) {
+        $relationships = Relationship::get(FALSE)
+          ->addWhere('contact_id_a', '=', $organizationId)
+          ->addWhere('relationship_type_id:name', '=', 'Secondary Institution POC of')
+          ->execute();
+      }
+
+      // Return contact_id_b as initiator if found.
+      if (!empty($relationships) && isset($relationships[0]['contact_id_b'])) {
+        return $relationships[0]['contact_id_b'];
+      }
+    }
+
+    // If the subtype is not 'Institution_Collection_Camp', or no relationship was found, use the default contact_id.
+    return $collectionCamp['Collection_Camp_Core_Details.Contact_Id'];
   }
 
   /**
    * Send Authorization Email to contact.
    */
   private static function queueAuthorizationEmail($initiatorId, $subtype, $status, $collectionSourceId) {
+
     try {
       $params = [
         'initiatorId' => $initiatorId,
@@ -373,7 +402,6 @@ class CollectionBaseService extends AutoSubscriber {
   public static function processQueuedEmail($queue, $params) {
     try {
       $emailParams = self::getAuthorizationEmailParams($params);
-
       civicrm_api3('MessageTemplate', 'send', $emailParams);
     }
     catch (\Exception $ex) {
@@ -388,13 +416,13 @@ class CollectionBaseService extends AutoSubscriber {
     $collectionSourceId = $params['collectionSourceId'];
     $collectionSourceType = $params['subtype'];
     $status = $params['status'];
+
     $initiatorId = $params['initiatorId'];
 
     $collectionCampSubtypes = OptionValue::get(FALSE)
       ->addWhere('option_group_id:name', '=', 'eck_sub_types')
       ->addWhere('grouping', '=', 'Collection_Camp')
       ->execute();
-
     foreach ($collectionCampSubtypes as $subtype) {
       $subtypeValue = $subtype['value'];
       $subtypeName = $subtype['name'];
@@ -404,7 +432,6 @@ class CollectionBaseService extends AutoSubscriber {
     }
 
     $msgTitleStartsWith = $mapper[$collectionSourceType][$status] . '%';
-
     $messageTemplates = MessageTemplate::get(FALSE)
       ->addSelect('id')
       ->addWhere('msg_title', 'LIKE', $msgTitleStartsWith)
@@ -418,7 +445,6 @@ class CollectionBaseService extends AutoSubscriber {
       ->addWhere('contact_id', '=', $initiatorId)
       ->addWhere('is_primary', '=', TRUE)
       ->execute()->single();
-
     $fromEmail = OptionValue::get(FALSE)
       ->addSelect('label')
       ->addWhere('option_group_id:name', '=', 'from_email_address')

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -20,7 +20,6 @@ use Civi\Traits\CollectionSource;
 class CollectionBaseService extends AutoSubscriber {
   use CollectionSource;
 
-  const ENTITY_NAME = 'Collection_Camp';
   const INTENT_CUSTOM_GROUP_NAME = 'Collection_Camp_Intent_Details';
 
   private static $stateCustomFieldDbDetails = [];
@@ -68,12 +67,10 @@ class CollectionBaseService extends AutoSubscriber {
    *
    */
   private static function generateBaseFileName($collectionSourceId) {
-    if (self::getEntitySubtypeName($collectionSourceId) == self::ENTITY_NAME) {
-      $baseFileName = "collection_camp_{$collectionSourceId}.png";
-    }
-    else {
-      $baseFileName = "Institution_collection_camp_{$collectionSourceId}.png";
-    }
+    // Get the entity subtype name for the collection source.
+    $entitySubtype = self::getEntitySubtypeName($collectionSourceId);
+
+    $baseFileName = strtolower($entitySubtype) . "_{$collectionSourceId}.png";
 
     return $baseFileName;
   }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -242,6 +242,18 @@ class InstitutionCollectionCampService extends AutoSubscriber {
         'directive' => 'afsearch-institution-collection-camp-material-contribution',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
+      'vehicleDispatch' => [
+        'title' => ts('Dispatch'),
+        'module' => 'afsearchInstitutionCampVehicleDispatchData',
+        'directive' => 'afsearch-institution-camp-vehicle-dispatch-data',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
+      'materialAuthorization' => [
+        'title' => ts('Material Authorization'),
+        'module' => 'afsearchInstitutionCampAcknowledgementDispatch',
+        'directive' => 'afsearch-institution-camp-acknowledgement-dispatch',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
     ];
 
     foreach ($tabConfigs as $key => $config) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -115,6 +115,7 @@ class MaterialContributionService extends AutoSubscriber {
         ->execute()->single();
       return $organization['address_primary.street_address'] ?? '';
     }
+
     $campField = ($subtype == 'Collection_Camp')
     ? 'Material_Contribution.Collection_Camp'
     : (($subtype == 'Dropping_Center')
@@ -139,6 +140,7 @@ class MaterialContributionService extends AutoSubscriber {
         : (($subtype == 'Institution_Collection_Camp')
             ? 'Institution_Collection_Camp_Intent.Collection_Camp_Address'
             : NULL));
+
     $collectionCamp = EckEntity::get('Collection_Camp', TRUE)
       ->addSelect($addressField)
       ->addWhere('id', '=', $activity[$campField])

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -122,7 +122,6 @@ class MaterialContributionService extends AutoSubscriber {
         : (($subtype == 'Institution_Collection_Camp')
             ? 'Material_Contribution.Institution_Collection_Camp'
             : NULL));
-    error_log("campField: " . print_r($campField, TRUE));
 
     $activity = Activity::get(FALSE)
       ->addSelect($campField)
@@ -140,7 +139,6 @@ class MaterialContributionService extends AutoSubscriber {
         : (($subtype == 'Institution_Collection_Camp')
             ? 'Institution_Collection_Camp_Intent.Collection_Camp_Address'
             : NULL));
-    error_log("addressField: " . print_r($addressField, TRUE));
     $collectionCamp = EckEntity::get('Collection_Camp', TRUE)
       ->addSelect($addressField)
       ->addWhere('id', '=', $activity[$campField])

--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -58,7 +58,7 @@ class MaterialContributionService extends AutoSubscriber {
 
     // Hack: Retrieve the most recent "Material Contribution" activity for this contact.
     $activities = Activity::get(FALSE)
-      ->addSelect('*', 'contact.display_name', 'Material_Contribution.Delivered_By', 'Material_Contribution.Delivered_By_Contact', 'Material_Contribution.Goonj_Office', 'Material_Contribution.Collection_Camp.subtype:name')
+      ->addSelect('*', 'contact.display_name', 'Material_Contribution.Delivered_By', 'Material_Contribution.Delivered_By_Contact', 'Material_Contribution.Goonj_Office', 'Material_Contribution.Collection_Camp.subtype:name', 'Material_Contribution.Institution_Collection_Camp.subtype:name', 'Material_Contribution.Dropping_Center.subtype:name')
       ->addJoin('ActivityContact AS activity_contact', 'LEFT')
       ->addJoin('Contact AS contact', 'LEFT')
       ->addWhere('source_contact_id', '=', $params['contactId'])
@@ -71,7 +71,17 @@ class MaterialContributionService extends AutoSubscriber {
     $contribution = $activities->first();
 
     $goonjOfficeId = $contribution['Material_Contribution.Goonj_Office'];
-    $subtype = $contribution['Material_Contribution.Collection_Camp.subtype:name'];
+    $subtype = NULL;
+    if (!empty($contribution['Material_Contribution.Collection_Camp.subtype:name'])) {
+      $subtype = $contribution['Material_Contribution.Collection_Camp.subtype:name'];
+    }
+    elseif (!empty($contribution['Material_Contribution.Institution_Collection_Camp.subtype:name'])) {
+      $subtype = $contribution['Material_Contribution.Institution_Collection_Camp.subtype:name'];
+    }
+    elseif (!empty($contribution['Material_Contribution.Dropping_Center.subtype:name'])) {
+      $subtype = $contribution['Material_Contribution.Dropping_Center.subtype:name'];
+    }
+
     $contactData = Contact::get(FALSE)
       ->addSelect('email_primary.email', 'phone_primary.phone')
       ->addWhere('id', '=', $params['contactId'])
@@ -105,10 +115,14 @@ class MaterialContributionService extends AutoSubscriber {
         ->execute()->single();
       return $organization['address_primary.street_address'] ?? '';
     }
-
     $campField = ($subtype == 'Collection_Camp')
-        ? 'Material_Contribution.Collection_Camp'
-        : 'Material_Contribution.Dropping_Center';
+    ? 'Material_Contribution.Collection_Camp'
+    : (($subtype == 'Dropping_Center')
+        ? 'Material_Contribution.Dropping_Center'
+        : (($subtype == 'Institution_Collection_Camp')
+            ? 'Material_Contribution.Institution_Collection_Camp'
+            : NULL));
+    error_log("campField: " . print_r($campField, TRUE));
 
     $activity = Activity::get(FALSE)
       ->addSelect($campField)
@@ -120,9 +134,13 @@ class MaterialContributionService extends AutoSubscriber {
     }
 
     $addressField = ($subtype == 'Collection_Camp')
-        ? 'Collection_Camp_Intent_Details.Location_Area_of_camp'
-        : 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_';
-
+    ? 'Collection_Camp_Intent_Details.Location_Area_of_camp'
+    : (($subtype == 'Dropping_Center')
+        ? 'Dropping_Centre.Where_do_you_wish_to_open_dropping_center_Address_'
+        : (($subtype == 'Institution_Collection_Camp')
+            ? 'Institution_Collection_Camp_Intent.Collection_Camp_Address'
+            : NULL));
+    error_log("addressField: " . print_r($addressField, TRUE));
     $collectionCamp = EckEntity::get('Collection_Camp', TRUE)
       ->addSelect($addressField)
       ->addWhere('id', '=', $activity[$campField])

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -24,6 +24,7 @@ function goonjcustom_civicrm_config(&$config): void {
 
   \Civi::dispatcher()->addSubscriber(new CRM_Goonjcustom_Token_CollectionCamp());
   \Civi::dispatcher()->addSubscriber(new CRM_Goonjcustom_Token_DroppingCenter());
+  Civi::dispatcher()->addSubscriber(new CRM_Goonjcustom_Token_InstitutionCollectionCamp());
 }
 
 /**


### PR DESCRIPTION
1. Send an authorized email and an unauthorized email to the institution's point of contact (POC).
2. Attach the poster along with the authorized email when sending it to the institution's POC.
3. Send the material contribution receipt to the institution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new class for handling institution collection camp tokens, enhancing token functionality within the CiviCRM system.
  - Expanded data retrieval for material contributions, improving the accuracy of contribution information.
  - Enhanced handling of authorization emails by refining the logic for identifying initiators based on relationships.
  - Added new tab configurations for 'vehicleDispatch' and 'materialAuthorization' in the institution collection camp interface.

- **Bug Fixes**
  - Improved error handling and logging for various processes related to authorization emails and contribution data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->