### PR TITLE
Send Institution Collection Camp Dispatch Email

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -275,11 +275,11 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
           $from = HelperService::getDefaultFromEmail();
           $mailParams = [
-            'subject' => 'Dummy Dispatch Notification for Self Managed Camp: ' . $campCode,
+            'subject' => 'Dispatch Notification for Self Managed Camp: ' . $campCode,
             'from' => $from,
             'toEmail' => $recipientEmail,
             'replyTo' => $from,
-            'html' => self::getDummyDispatchEmailHtml($recipientName, $campId, $coordinatingPOCId, $campOffice, $campCode, $campAddress),
+            'html' => self::getLogisticsEmailHtml($recipientName, $campId, $coordinatingPOCId, $campOffice, $campCode, $campAddress),
           ];
 
           $emailSendResult = \CRM_Utils_Mail::send($mailParams);

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -189,7 +189,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
    */
   public static function sendEmailToMmt($collectionCampId, $campCode, $campAddress, $vehicleDispatchId) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
-    $materialdispatchUrl = $homeUrl . 'acknowledgement-form-for-logistics/#?Eck_Collection_Source_Vehicle_Dispatch1=' . $vehicleDispatchId . '&Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&id=' . $vehicleDispatchId . '&Eck_Collection_Camp1=' . $collectionCampId;
+    $materialdispatchUrl = $homeUrl . 'institution-camp-acknowledgement-dispatch/#?Eck_Collection_Source_Vehicle_Dispatch1=' . $vehicleDispatchId . '&Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&id=' . $vehicleDispatchId . '&Eck_Collection_Camp1=' . $collectionCampId;
     $html = "
     <p>Dear MMT team,</p>
     <p>This is to inform you that a vehicle has been sent from camp <strong>$campCode</strong> at <strong>$campAddress</strong>.</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -338,7 +338,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
           }
 
           $mailParams = [
-            'subject' => 'Dummy Outcome Notification for Self Managed Camp: ' . $campCode,
+            'subject' => 'Outcome Notification for Self Managed Camp: ' . $campCode,
             'from' => $from,
             'toEmail' => $recipientEmail,
             'replyTo' => $from,

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -81,7 +81,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   /**
    *
    */
-  private static function findOfficeId(array $array) {
+  private static function getOfficeId(array $array) {
     $filteredItems = array_filter($array, fn($item) => $item['entity_table'] === 'civicrm_eck_collection_source_vehicle_dispatch');
 
     if (empty($filteredItems)) {
@@ -117,7 +117,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     if ($op !== 'create') {
       return;
     }
-    if (!($goonjField = self::findOfficeId($params))) {
+    if (!($goonjField = self::getOfficeId($params))) {
       return;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -571,6 +571,12 @@ class InstitutionCollectionCampService extends AutoSubscriber {
         'directive' => 'afsearch-institution-camp-acknowledgement-dispatch',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
       ],
+      'campOutcome' => [
+        'title' => ts('Camp Outcome'),
+        'module' => 'afsearchInstitutionCampOutcome',
+        'directive' => 'afsearch-institution-camp-outcome',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+      ],
     ];
 
     foreach ($tabConfigs as $key => $config) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -182,9 +182,9 @@ private static function getLogisticsEmailHtml($contactName, $collectionCampId, $
     $homeUrl = \CRM_Utils_System::baseCMSURL();
 
     // Construct URLs for the dispatch and outcome forms
-    $campVehicleDispatchFormUrl = $homeUrl . 'camp-vehicle-dispatch-form/#?Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $campAttendedById . '&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent=' . $collectionCampGoonjOffice . '&Eck_Collection_Camp1=' . $collectionCampId;
+    $campVehicleDispatchFormUrl = $homeUrl . 'institution-camp-vehicle-dispatch-form/#?Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $campAttendedById . '&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent=' . $collectionCampGoonjOffice . '&Eck_Collection_Camp1=' . $collectionCampId;
 
-    $campOutcomeFormUrl = $homeUrl . '/camp-outcome-form/#?Eck_Collection_Camp1=' . $collectionCampId . '&Camp_Outcome.Filled_By=' . $campAttendedById;
+    $campOutcomeFormUrl = $homeUrl . '/institution-camp-outcome-form/#?Eck_Collection_Camp1=' . $collectionCampId . '&Camp_Outcome.Filled_By=' . $campAttendedById;
 
     // Construct email HTML
     $html = "

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -19,6 +19,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   const ENTITY_SUBTYPE_NAME = 'Institution_Collection_Camp';
   const ENTITY_NAME = 'Collection_Camp';
   const FALLBACK_OFFICE_NAME = 'Delhi';
+  const MATERIAL_RELATIONSHIP_TYPE_NAME = 'Material Management Team of';
 
   /**
    *
@@ -27,7 +28,10 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     return [
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       '&hook_civicrm_pre' => 'generateInstitutionCollectionCampQr',
-      '&hook_civicrm_custom' => 'setOfficeDetails',
+      '&hook_civicrm_custom' => [
+        ['setOfficeDetails'],
+        ['mailNotificationToMmt'],
+      ],
       '&hook_civicrm_tabset' => 'institutionCollectionCampTabset',
     ];
   }
@@ -72,6 +76,95 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     ];
 
     self::generateQrCode($data, $id, $saveOptions);
+  }
+
+  /**
+   *
+   */
+  public static function mailNotificationToMmt($op, $groupID, $entityID, &$params) {
+    if ($op !== 'create') {
+      return;
+    }
+    if (!($goonjField = self::findOfficeId($params))) {
+      return;
+    }
+
+    $goonjFieldId = $goonjField['value'];
+    $vehicleDispatchId = $goonjField['entity_id'];
+
+    $collectionSourceVehicleDispatch = EckEntity::get('Collection_Source_Vehicle_Dispatch', FALSE)
+      ->addSelect('Camp_Vehicle_Dispatch.Collection_Camp')
+      ->addWhere('id', '=', $vehicleDispatchId)
+      ->execute()->first();
+
+    $collectionCampId = $collectionSourceVehicleDispatch['Camp_Vehicle_Dispatch.Collection_Camp'];
+
+    if (self::getEntitySubtypeName($collectionCampId) !== self::ENTITY_SUBTYPE_NAME) {
+      return;
+    }
+
+    $collectionCamp = EckEntity::get('Collection_Camp', FALSE)
+      ->addSelect('Institution_Collection_Camp_Intent.Collection_Camp_Address', 'title')
+      ->addWhere('id', '=', $collectionCampId)
+      ->execute()->single();
+
+    if (!$collectionCamp) {
+      return;
+    }
+
+    $campCode = $collectionCamp['title'];
+    $campAddress = $collectionCamp['Institution_Collection_Camp_Intent.Collection_Camp_Address'];
+
+    $coordinators = Relationship::get(FALSE)
+      ->addWhere('contact_id_b', '=', $goonjFieldId)
+      ->addWhere('relationship_type_id:name', '=', self::MATERIAL_RELATIONSHIP_TYPE_NAME)
+      ->addWhere('is_current', '=', TRUE)
+      ->execute()->first();
+
+    $mmtId = $coordinators['contact_id_a'];
+
+    if (empty($mmtId)) {
+      return;
+    }
+
+    $email = Email::get(FALSE)
+      ->addSelect('email')
+      ->addWhere('contact_id', '=', $mmtId)
+      ->execute()->single();
+
+    $mmtEmail = $email['email'];
+
+    $fromEmail = OptionValue::get(FALSE)
+      ->addSelect('label')
+      ->addWhere('option_group_id:name', '=', 'from_email_address')
+      ->addWhere('is_default', '=', TRUE)
+      ->execute()->single();
+
+    // Email to material management team member.
+    $mailParams = [
+      'subject' => 'Material Acknowledgement for Camp: ' . $campCode . ' at ' . $campAddress,
+      'from' => $fromEmail['label'],
+      'toEmail' => $mmtEmail,
+      'replyTo' => $fromEmail['label'],
+      'html' => self::sendEmailToMmt($collectionCampId, $campCode, $campAddress, $vehicleDispatchId),
+    ];
+    \CRM_Utils_Mail::send($mailParams);
+
+  }
+
+  /**
+   *
+   */
+  public static function sendEmailToMmt($collectionCampId, $campCode, $campAddress, $vehicleDispatchId) {
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+    $materialdispatchUrl = $homeUrl . 'acknowledgement-form-for-logistics/#?Eck_Collection_Source_Vehicle_Dispatch1=' . $vehicleDispatchId . '&Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&id=' . $vehicleDispatchId . '&Eck_Collection_Camp1=' . $collectionCampId;
+    $html = "
+    <p>Dear MMT team,</p>
+    <p>This is to inform you that a vehicle has been sent from camp <strong>$campCode</strong> at <strong>$campAddress</strong>.</p>
+    <p>Kindly acknowledge the details by clicking on this form <a href=\"$materialdispatchUrl\"> Link </a> when it is received at the center.</p>
+    <p>Warm regards,<br>Urban Relations Team</p>";
+
+    return $html;
   }
 
   /**
@@ -124,6 +217,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
       $logisticEmailSent = $collectionCamp['Institution_Collection_Camp_Logistics.Email_Sent'];
       $selfManagedBy = $collectionCamp['Institution_Collection_Camp_Logistics.Self_Managed_by_Institution'];
       $institutionPOCId = $collectionCamp['Institution_Collection_Camp_Intent.Institution_POC'];
+      $coordinatingPOCId = $collectionCamp['Institution_collection_camp_Review.Coordinating_POC'];
 
       $startDate = new \DateTime($collectionCamp['Institution_Collection_Camp_Intent.Collections_will_start_on_Date_']);
 
@@ -132,51 +226,150 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
       if (!$logisticEmailSent && $startDate <= $endOfToday) {
         if (!$selfManagedBy) {
+          // Send to the camp attended by POC.
           $recipient = Contact::get(FALSE)
             ->addSelect('email.email', 'display_name')
             ->addJoin('Email AS email', 'LEFT')
             ->addWhere('id', '=', $campAttendedById)
             ->execute()->single();
+
+          $recipientEmail = $recipient['email.email'];
+          $recipientName = $recipient['display_name'];
+
+          if (!$recipientEmail) {
+            throw new \Exception('Recipient email missing');
+          }
+          $from = HelperService::getDefaultFromEmail();
+          $mailParams = [
+            'subject' => 'Collection Camp Notification: ' . $campCode . ' at ' . $campAddress,
+            'from' => $from,
+            'toEmail' => $recipientEmail,
+            'replyTo' => $from,
+            'html' => self::getLogisticsEmailHtml($recipientName, $campId, $campAttendedById, $campOffice, $campCode, $campAddress),
+          ];
+
+          // Send logistics email.
+          $emailSendResult = \CRM_Utils_Mail::send($mailParams);
+
+          if ($emailSendResult) {
+            \Civi::log()->info("Logistics email sent for collection camp: $campId");
+            EckEntity::update('Collection_Camp', FALSE)
+              ->addValue('Institution_Collection_Camp_Logistics.Email_Sent', 1)
+              ->addWhere('id', '=', $campId)
+              ->execute();
+          }
         }
         else {
+          // Send dispatch email to Institution POC if self-managed.
           $recipient = Contact::get(FALSE)
             ->addSelect('email.email', 'display_name')
             ->addJoin('Email AS email', 'LEFT')
             ->addWhere('id', '=', $institutionPOCId)
             ->execute()->single();
-        }
-        $recipientEmail = $recipient['email.email'];
 
-        $recipientName = $recipient['display_name'];
+          $recipientEmail = $recipient['email.email'];
+          $recipientName = $recipient['display_name'];
 
-        if (!$recipientEmail) {
-          throw new \Exception('Recipient email missing');
-        }
-        $from = HelperService::getDefaultFromEmail();
-        // Prepare email parameters.
-        $mailParams = [
-          'subject' => 'Collection Camp Notification: ' . $campCode . ' at ' . $campAddress,
-          'from' => $from,
-          'toEmail' => $recipientEmail,
-          'replyTo' => $from,
-          'html' => self::getLogisticsEmailHtml($recipientName, $campId, $campAttendedById, $campOffice, $campCode, $campAddress),
-        ];
+          if (!$recipientEmail) {
+            \Civi::log()->info("Recipient email missing for institution POC: $campId");
+            return;
+          }
 
-        // Send email.
-        $emailSendResult = \CRM_Utils_Mail::send($mailParams);
+          $from = HelperService::getDefaultFromEmail();
+          // Prepare dummy dispatch email.
+          $mailParams = [
+            'subject' => 'Dummy Dispatch Notification for Self Managed Camp: ' . $campCode,
+            'from' => $from,
+            'toEmail' => $recipientEmail,
+            'replyTo' => $from,
+            'html' => self::getDummyDispatchEmailHtml($recipientName, $campId, $coordinatingPOCId, $campOffice, $campCode, $campAddress),
+          ];
 
-        if ($emailSendResult) {
-          \Civi::log()->info("Logistics email sent for collection camp: $campId");
-          EckEntity::update('Collection_Camp', FALSE)
-            ->addValue('Institution_Collection_Camp_Logistics.Email_Sent', 1)
-            ->addWhere('id', '=', $campId)
-            ->execute();
+          // Send dummy dispatch email.
+          $emailSendResult = \CRM_Utils_Mail::send($mailParams);
+          if ($emailSendResult) {
+            \Civi::log()->info("dispatch email sent for self-managed collection camp: $campId");
+          }
+
+          // Send dummy outcome email to Coordinating POC.
+          $recipient = Contact::get(FALSE)
+            ->addSelect('email.email', 'display_name')
+            ->addJoin('Email AS email', 'LEFT')
+            ->addWhere('id', '=', $coordinatingPOCId)
+            ->execute()->single();
+
+          $recipientEmail = $recipient['email.email'];
+          $recipientName = $recipient['display_name'];
+
+          if (!$recipientEmail) {
+            \Civi::log()->info("Recipient email missing for coordinating POC': $campId");
+            return;
+          }
+
+          // Prepare dummy outcome email.
+          $mailParams = [
+            'subject' => 'Dummy Outcome Notification for Self Managed Camp: ' . $campCode,
+            'from' => $from,
+            'toEmail' => $recipientEmail,
+            'replyTo' => $from,
+            'html' => self::sendOutcomeEmail($recipientName, $campId, $coordinatingPOCId, $campCode, $campAddress,),
+          ];
+
+          // Send dummy outcome email.
+          $emailSendResult = \CRM_Utils_Mail::send($mailParams);
+          if ($emailSendResult) {
+            \Civi::log()->info("outcome email sent for self-managed collection camp: $campId");
+          }
         }
       }
     }
     catch (\Exception $e) {
       \Civi::log()->error("Error in sendLogisticsEmail for $campId: " . $e->getMessage());
     }
+  }
+
+  /**
+   *
+   */
+  private static function sendDispatchEmail($contactName, $collectionCampId, $campAttendedById, $collectionCampGoonjOffice, $campCode, $campAddress) {
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+
+    $campVehicleDispatchFormUrl = $homeUrl . 'institution-camp-vehicle-dispatch-form/#?Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $campAttendedById . '&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent=' . $collectionCampGoonjOffice . '&Eck_Collection_Camp1=' . $collectionCampId;
+
+    $html = "
+  <p>Dear $contactName,</p>
+  <p>Thank you for attending the camp <strong>$campCode</strong> at <strong>$campAddress</strong>. There is a form that requires your attention during the camp:</p>
+  <ol>
+      <li><a href=\"$campVehicleDispatchFormUrl\">Dispatch Form</a><br>
+      Please complete this form from the camp location once the vehicle is being loaded and ready for dispatch to Goonj's processing center.</li>
+  </ol>
+  <p>We appreciate your cooperation.</p>
+  <p>Warm Regards,<br>Urban Relations Team</p>";
+
+    return $html;
+  }
+
+  /**
+   *
+   */
+  private static function sendOutcomeEmail($contactName, $collectionCampId, $coordinatingPOCId, $campCode, $campAddress) {
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+
+    // Construct URL for the outcome form.
+    $campOutcomeFormUrl = $homeUrl . '/institution-camp-outcome-form/#?Eck_Collection_Camp1=' . $collectionCampId . '&Camp_Outcome.Filled_By=' . $campAttendedById;
+
+    // Construct outcome email HTML.
+    $html = "
+  <p>Dear $contactName,</p>
+  <p>Thank you for attending the camp <strong>$campCode</strong> at <strong>$campAddress</strong>. There is one form that requires your attention after the camp:</p>
+  <ol>
+      <li><a href=\"$campOutcomeFormUrl\">Camp Outcome Form</a><br>
+      This feedback form should be filled out after the camp/drive ends, once you have an overview of the event's outcomes.</li>
+  </ol>
+  <p>We appreciate your cooperation.</p>
+  <p>Warm Regards,<br>Urban Relations Team</p>";
+
+    return $html;
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -226,7 +226,6 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
       if (!$logisticEmailSent && $startDate <= $endOfToday) {
         if (!$selfManagedBy) {
-          // Send to the camp attended by POC.
           $recipient = Contact::get(FALSE)
             ->addSelect('email.email', 'display_name')
             ->addJoin('Email AS email', 'LEFT')
@@ -237,7 +236,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
           $recipientName = $recipient['display_name'];
 
           if (!$recipientEmail) {
-            throw new \Exception('Recipient email missing');
+            \Civi::log()->info("Recipient email missing: $campId");
           }
           $from = HelperService::getDefaultFromEmail();
           $mailParams = [
@@ -260,7 +259,6 @@ class InstitutionCollectionCampService extends AutoSubscriber {
           }
         }
         else {
-          // Send dispatch email to Institution POC if self-managed.
           $recipient = Contact::get(FALSE)
             ->addSelect('email.email', 'display_name')
             ->addJoin('Email AS email', 'LEFT')
@@ -276,7 +274,6 @@ class InstitutionCollectionCampService extends AutoSubscriber {
           }
 
           $from = HelperService::getDefaultFromEmail();
-          // Prepare dummy dispatch email.
           $mailParams = [
             'subject' => 'Dummy Dispatch Notification for Self Managed Camp: ' . $campCode,
             'from' => $from,
@@ -285,13 +282,11 @@ class InstitutionCollectionCampService extends AutoSubscriber {
             'html' => self::getDummyDispatchEmailHtml($recipientName, $campId, $coordinatingPOCId, $campOffice, $campCode, $campAddress),
           ];
 
-          // Send dummy dispatch email.
           $emailSendResult = \CRM_Utils_Mail::send($mailParams);
           if ($emailSendResult) {
             \Civi::log()->info("dispatch email sent for self-managed collection camp: $campId");
           }
 
-          // Send dummy outcome email to Coordinating POC.
           $recipient = Contact::get(FALSE)
             ->addSelect('email.email', 'display_name')
             ->addJoin('Email AS email', 'LEFT')
@@ -306,7 +301,6 @@ class InstitutionCollectionCampService extends AutoSubscriber {
             return;
           }
 
-          // Prepare dummy outcome email.
           $mailParams = [
             'subject' => 'Dummy Outcome Notification for Self Managed Camp: ' . $campCode,
             'from' => $from,
@@ -315,7 +309,6 @@ class InstitutionCollectionCampService extends AutoSubscriber {
             'html' => self::sendOutcomeEmail($recipientName, $campId, $coordinatingPOCId, $campCode, $campAddress,),
           ];
 
-          // Send dummy outcome email.
           $emailSendResult = \CRM_Utils_Mail::send($mailParams);
           if ($emailSendResult) {
             \Civi::log()->info("outcome email sent for self-managed collection camp: $campId");
@@ -355,10 +348,8 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   private static function sendOutcomeEmail($contactName, $collectionCampId, $coordinatingPOCId, $campCode, $campAddress) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
 
-    // Construct URL for the outcome form.
     $campOutcomeFormUrl = $homeUrl . '/institution-camp-outcome-form/#?Eck_Collection_Camp1=' . $collectionCampId . '&Camp_Outcome.Filled_By=' . $campAttendedById;
 
-    // Construct outcome email HTML.
     $html = "
   <p>Dear $contactName,</p>
   <p>Thank you for attending the camp <strong>$campCode</strong> at <strong>$campAddress</strong>. There is one form that requires your attention after the camp:</p>
@@ -378,12 +369,10 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   private static function getLogisticsEmailHtml($contactName, $collectionCampId, $campAttendedById, $collectionCampGoonjOffice, $campCode, $campAddress) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
 
-    // Construct URLs for the dispatch and outcome forms.
     $campVehicleDispatchFormUrl = $homeUrl . 'institution-camp-vehicle-dispatch-form/#?Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $campAttendedById . '&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent=' . $collectionCampGoonjOffice . '&Eck_Collection_Camp1=' . $collectionCampId;
 
     $campOutcomeFormUrl = $homeUrl . '/institution-camp-outcome-form/#?Eck_Collection_Camp1=' . $collectionCampId . '&Camp_Outcome.Filled_By=' . $campAttendedById;
 
-    // Construct email HTML.
     $html = "
     <p>Dear $contactName,</p>
     <p>Thank you for attending the camp <strong>$campCode</strong> at <strong>$campAddress</strong>. There are two forms that require your attention during and after the camp:</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -111,6 +111,98 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
   }
 
+
+  public static function sendLogisticsEmail($collectionCamp) {
+    try {
+        $campId = $collectionCamp['id'];
+        $campCode = $collectionCamp['title'];
+        $campOffice = $collectionCamp['Institution_collection_camp_Review.Goonj_Office'];
+        $campAddress = $collectionCamp['Institution_Collection_Camp_Intent.Collection_Camp_Address'];
+        $campAttendedById = $collectionCamp['Institution_Collection_Camp_Logistics.Camp_to_be_attended_by'];
+        $logisticEmailSent = $collectionCamp['Institution_Collection_Camp_Logistics.Email_Sent'];
+        $selfManagedBy = $collectionCamp['Institution_Collection_Camp_Logistics.Self_Managed_by_Institution'];
+        $institutionPOCId = $collectionCamp['Institution_Collection_Camp_Intent.Institution_POC'];
+
+        $startDate = new \DateTime($collectionCamp['Institution_Collection_Camp_Intent.Collections_will_start_on_Date_']);
+
+        $today = new \DateTimeImmutable();
+        $endOfToday = $today->setTime(23, 59, 59);
+
+        if (!$logisticEmailSent && $startDate <= $endOfToday) {
+            if (!$selfManagedBy) {
+                $recipient = Contact::get(FALSE)
+                    ->addSelect('email.email', 'display_name')
+                    ->addJoin('Email AS email', 'LEFT')
+                    ->addWhere('id', '=', $campAttendedById)
+                    ->execute()->single();
+            } else {
+                $recipient = Contact::get(FALSE)
+                    ->addSelect('email.email', 'display_name')
+                    ->addJoin('Email AS email', 'LEFT')
+                    ->addWhere('id', '=', $institutionPOCId)
+                    ->execute()->single();
+            }
+            $recipientEmail = $recipient['email.email'];
+
+            $recipientName = $recipient['display_name'];
+
+            if (!$recipientEmail) {
+                throw new \Exception('Recipient email missing');
+            }
+            $from = HelperService::getDefaultFromEmail();
+            // Prepare email parameters
+            $mailParams = [
+                'subject' => 'Collection Camp Notification: ' . $campCode . ' at ' . $campAddress,
+                'from' => $from,
+                'toEmail' => $recipientEmail,
+                'replyTo' => $from,
+                'html' => self::getLogisticsEmailHtml($recipientName, $campId, $campAttendedById, $campOffice, $campCode, $campAddress),
+            ];
+
+            // Send email
+            $emailSendResult = \CRM_Utils_Mail::send($mailParams);
+
+            if ($emailSendResult) {
+                \Civi::log()->info("Logistics email sent for collection camp: $campId");
+                EckEntity::update('Collection_Camp', FALSE)
+                    ->addValue('Institution_Collection_Camp_Logistics.Email_Sent', 1)
+                    ->addWhere('id', '=', $campId)
+                    ->execute();
+            }
+        }
+    } catch (\Exception $e) {
+        \Civi::log()->error("Error in sendLogisticsEmail for $campId: " . $e->getMessage());
+    }
+}
+
+/**
+ * Generates the logistics email HTML content
+ */
+private static function getLogisticsEmailHtml($contactName, $collectionCampId, $campAttendedById, $collectionCampGoonjOffice, $campCode, $campAddress) {
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+
+    // Construct URLs for the dispatch and outcome forms
+    $campVehicleDispatchFormUrl = $homeUrl . 'camp-vehicle-dispatch-form/#?Camp_Vehicle_Dispatch.Collection_Camp=' . $collectionCampId . '&Camp_Vehicle_Dispatch.Filled_by=' . $campAttendedById . '&Camp_Vehicle_Dispatch.To_which_PU_Center_material_is_being_sent=' . $collectionCampGoonjOffice . '&Eck_Collection_Camp1=' . $collectionCampId;
+
+    $campOutcomeFormUrl = $homeUrl . '/camp-outcome-form/#?Eck_Collection_Camp1=' . $collectionCampId . '&Camp_Outcome.Filled_By=' . $campAttendedById;
+
+    // Construct email HTML
+    $html = "
+    <p>Dear $contactName,</p>
+    <p>Thank you for attending the camp <strong>$campCode</strong> at <strong>$campAddress</strong>. There are two forms that require your attention during and after the camp:</p>
+    <ol>
+        <li><a href=\"$campVehicleDispatchFormUrl\">Dispatch Form</a><br>
+        Please complete this form from the camp location once the vehicle is being loaded and ready for dispatch to Goonj's processing center.</li>
+        <li><a href=\"$campOutcomeFormUrl\">Camp Outcome Form</a><br>
+        This feedback form should be filled out after the camp/drive ends, once you have an overview of the event's outcomes.</li>
+    </ol>
+    <p>We appreciate your cooperation.</p>
+    <p>Warm Regards,<br>Urban Relations Team</p>";
+
+    return $html;
+}
+
+
   /**
    *
    */

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @file
+ */
+
+use Civi\Api4\EckEntity;
+use Civi\Api4\OptionValue;
+use Civi\InstitutionCollectionCampService;
+
+/**
+ * Goonjcustom.CollectionCampCron API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_institution_collection_camp_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.CollectionCampCron API.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
+  $returnValues = [];
+  $optionValues = OptionValue::get(FALSE)
+    ->addWhere('option_group_id:name', '=', 'eck_sub_types')
+    ->addWhere('name', '=', 'Institution_Collection_Camp')
+    ->addWhere('grouping', '=', 'Collection_Camp')
+    ->setLimit(1)
+    ->execute()->single();
+    error_log("optionValues: " . print_r($optionValues, TRUE));
+  $collectionCampSubtype = $optionValues['value'];
+  error_log("collectionCampSubtype: " . print_r($collectionCampSubtype, TRUE));
+//   $today = new DateTimeImmutable();
+//   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+
+  $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
+    ->addSelect(
+      'title',
+      'Institution_Collection_Camp_Logistics.Email_Sent',
+      'Institution_Collection_Camp_Logistics.Camp_to_be_attended_by',
+      'Institution_Collection_Camp_Intent.Collections_will_start_on_Date_',
+      'Institution_Collection_Camp_Intent.Collections_will_end_on_Date_',
+      'Institution_collection_camp_Review.Goonj_Office',
+      'Institution_Collection_Camp_Intent.Collection_Camp_Address',
+      'Institution_Collection_Camp_Intent.Institution_POC',
+      'Institution_Collection_Camp_Logistics.Self_Managed_by_Institution'
+    )
+    ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
+    ->addWhere('subtype', '=', $collectionCampSubtype)
+    // ->addWhere('Institution_Collection_Camp_Intent.Collections_will_start_on_Date', '<=', $endOfDay)
+    ->addWhere('Institution_Collection_Camp_Logistics.Camp_to_be_attended_by', 'IS NOT EMPTY')
+    ->addWhere('Institution_collection_camp_Review.Camp_Status', '!=', 'aborted')
+    ->addClause('OR',
+      ['Institution_Collection_Camp_Logistics.Email_Sent', 'IS NULL'],
+      ['Institution_Collection_Camp_Logistics.Email_Sent', '=', 0]
+    )
+    ->execute();
+
+  foreach ($collectionCamps as $camp) {
+    error_log("collectionCamps: " . print_r($collectionCamps, TRUE));
+    try {
+        InstitutionCollectionCampService::sendLogisticsEmail($camp);
+    //   CollectionCampService::updateContributorCount($camp);
+
+    }
+    catch (\Exception $e) {
+      \Civi::log()->info('Error processing camp', [
+        'id' => $camp['id'],
+        'error' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'institution_collection_camp_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -44,8 +44,7 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
   $collectionCampSubtype = $optionValues['value'];
   $today = new DateTimeImmutable();
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
-  error_log("endOfDay: " . print_r($endOfDay, TRUE));
-  error_log("endOfDay: " . print_r($endOfDay, TRUE));
+
   $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
     ->addSelect(
       'title',

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -44,7 +44,8 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
   $collectionCampSubtype = $optionValues['value'];
   $today = new DateTimeImmutable();
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
-
+  error_log("endOfDay: " . print_r($endOfDay, TRUE));
+  error_log("endOfDay: " . print_r($endOfDay, TRUE));
   $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
     ->addSelect(
       'title',
@@ -60,8 +61,8 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
     )
     ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
     ->addWhere('subtype', '=', $collectionCampSubtype)
-    ->addWhere('Institution_Collection_Camp_Intent.Collections_will_start_on_Date', '<=', $endOfDay)
-    ->addWhere('Institution_Collection_Camp_Logistics.Camp_to_be_attended_by', 'IS NOT EMPTY')
+    ->addWhere('Institution_Collection_Camp_Intent.Collections_will_start_on_Date_', '<=', $endOfDay)
+    ->addWhere('Institution_Collection_Camp_Logistics.Self_Managed_by_Institution', 'IS NOT EMPTY')
     ->addWhere('Institution_collection_camp_Review.Camp_Status', '!=', 'aborted')
     ->addClause('OR',
       ['Institution_Collection_Camp_Logistics.Email_Sent', 'IS NULL'],

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -55,7 +55,8 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
       'Institution_collection_camp_Review.Goonj_Office',
       'Institution_Collection_Camp_Intent.Collection_Camp_Address',
       'Institution_Collection_Camp_Intent.Institution_POC',
-      'Institution_Collection_Camp_Logistics.Self_Managed_by_Institution'
+      'Institution_Collection_Camp_Logistics.Self_Managed_by_Institution',
+      'Institution_collection_camp_Review.Coordinating_POC',
     )
     ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
     ->addWhere('subtype', '=', $collectionCampSubtype)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -41,6 +41,7 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
     ->addWhere('grouping', '=', 'Collection_Camp')
     ->setLimit(1)
     ->execute()->single();
+
   $collectionCampSubtype = $optionValues['value'];
   $today = new DateTimeImmutable();
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -41,11 +41,9 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
     ->addWhere('grouping', '=', 'Collection_Camp')
     ->setLimit(1)
     ->execute()->single();
-    error_log("optionValues: " . print_r($optionValues, TRUE));
   $collectionCampSubtype = $optionValues['value'];
-  error_log("collectionCampSubtype: " . print_r($collectionCampSubtype, TRUE));
-//   $today = new DateTimeImmutable();
-//   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+  $today = new DateTimeImmutable();
+  $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
   $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
     ->addSelect(
@@ -61,7 +59,7 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
     )
     ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
     ->addWhere('subtype', '=', $collectionCampSubtype)
-    // ->addWhere('Institution_Collection_Camp_Intent.Collections_will_start_on_Date', '<=', $endOfDay)
+    ->addWhere('Institution_Collection_Camp_Intent.Collections_will_start_on_Date', '<=', $endOfDay)
     ->addWhere('Institution_Collection_Camp_Logistics.Camp_to_be_attended_by', 'IS NOT EMPTY')
     ->addWhere('Institution_collection_camp_Review.Camp_Status', '!=', 'aborted')
     ->addClause('OR',
@@ -71,11 +69,8 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
     ->execute();
 
   foreach ($collectionCamps as $camp) {
-    error_log("collectionCamps: " . print_r($collectionCamps, TRUE));
     try {
-        InstitutionCollectionCampService::sendLogisticsEmail($camp);
-    //   CollectionCampService::updateContributorCount($camp);
-
+      InstitutionCollectionCampService::sendLogisticsEmail($camp);
     }
     catch (\Exception $e) {
       \Civi::log()->info('Error processing camp', [

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -9,7 +9,7 @@ use Civi\Api4\OptionValue;
 use Civi\InstitutionCollectionCampService;
 
 /**
- * Goonjcustom.CollectionCampCron API specification (optional)
+ * Goonjcustom.InstitutionCollectionCampCron API specification (optional)
  * This is used for documentation and validation.
  *
  * @param array $spec


### PR DESCRIPTION
### Description
1- Send the dispatch email to the institution's POC and outcome email to coordinating POC if it is self-managed. If it is not self-managed, send the dispatch email and along with outcome to the camp attended by.
2. Send the ack. email to mmt once user fill the dispatch form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for sending logistics emails related to collection camps, including detailed error handling and email content generation.
	- Added a new API endpoint for handling cron jobs associated with institution collection camps, enabling automated logistics email dispatch.
	- Implemented notifications to the Material Management Team upon the creation of new entities.
	- Expanded tab functionality to include a new 'campOutcome' tab.

- **Bug Fixes**
	- Improved error logging during the logistics email sending process to enhance debugging capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->