### PR TITLE
fix(*) send physical induction slot for mulitiple city

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -835,7 +835,7 @@ class InductionService extends AutoSubscriber {
       // Check if the result has any rows
     if ($officeContact->count() > 0) {
         // Extract the first row (assuming one result, based on rowCount => 1)
-        $officeContactData = $officeContact[0];
+        $officeContactData = $officeContact->first();
     
         // Add the primary city to the array
         if (!empty($officeContactData['address_primary.city'])) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -825,11 +825,35 @@ class InductionService extends AutoSubscriber {
 
     // Check if a Goonj office exists in the contact's state.
     $officeContact = Contact::get(FALSE)
-      ->addSelect('id', 'display_name')
+      ->addSelect('id', 'display_name', 'Goonj_Office_Details.Other_Induction_Cities', 'address_primary.city')
       ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
       ->addWhere('address_primary.state_province_id', '=', $contactStateId)
-      ->addWhere('address_primary.city', 'LIKE', $contactCityFormatted . '%')
       ->execute();
+
+    $officeContactInductionCities = [];
+
+      // Check if the result has any rows
+    if ($officeContact->count() > 0) {
+        // Extract the first row (assuming one result, based on rowCount => 1)
+        $officeContactData = $officeContact[0];
+    
+        // Add the primary city to the array
+        if (!empty($officeContactData['address_primary.city'])) {
+            $officeContactInductionCities[] = $officeContactData['address_primary.city'];
+        }
+    
+        // Add the other induction cities to the array
+        if (!empty($officeContactData['Goonj_Office_Details.Other_Induction_Cities'])) {
+            // Split the string into an array and merge it
+            $otherCities = array_map('trim', explode(',', $officeContactData['Goonj_Office_Details.Other_Induction_Cities']));
+            $officeContactInductionCities = array_merge($officeContactInductionCities, $otherCities);
+        }
+    
+        // Convert all cities to lowercase, remove duplicates, and re-index the array
+        $officeContactInductionCities = array_map('strtolower', $officeContactInductionCities);
+        $officeContactInductionCities = array_unique($officeContactInductionCities);
+        $officeContactInductionCities = array_values($officeContactInductionCities);
+    }
 
     // If no Goonj office exists, induction is online.
     if ($officeContact->count() === 0) {
@@ -837,7 +861,12 @@ class InductionService extends AutoSubscriber {
       return $inductionType;
     }
 
-    return $inductionType;
+    if (in_array(strtolower($contactCityFormatted), $officeContactInductionCities)) {
+      return $inductionType;
+    } else {
+      $inductionType = 'Online';
+      return $inductionType;
+    }
   }
 
 }

--- a/wp-content/plugins/goonj-blocks/build/functions.php
+++ b/wp-content/plugins/goonj-blocks/build/functions.php
@@ -102,13 +102,9 @@ function generate_induction_slots($contactId = null, $days = 30) {
             ->addSelect('id', 'display_name', 'Goonj_Office_Details.Other_Induction_Cities', 'address_primary.city')
             ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
             ->addWhere('address_primary.state_province_id', '=', $contactStateId)
-            // ->addWhere('address_primary.city', 'LIKE', $contactCityFormatted . '%')
             ->execute();
-        \Civi::log()->info('officeContact', ['officeContact'=>$officeContact]);
-        $officeContactInductionCities = [];
 
         $officeContactInductionCities = [];
-
         // Check if the result has any rows
         if ($officeContact->count() > 0) {
             // Extract the first row (assuming one result, based on rowCount => 1)
@@ -132,22 +128,16 @@ function generate_induction_slots($contactId = null, $days = 30) {
             $officeContactInductionCities = array_values($officeContactInductionCities);
         }
         
-        // Log the result for debugging
-        \Civi::log()->info('officeContactInductionCities', ['officeContactInductionCities' => $officeContactInductionCities, 'contactCityFormatted'=>$contactCityFormatted]);
-        
-        
-
-        if ($officeContact->count() === 0 ) {
-            // generate online induction slots for state having no office
+        if ($officeContact->count() === 0) {
+            // Generate online induction slots for state having no office
             return generate_slots($assignedOfficeId, $defaultMaxSlot, $onlineInductionType, $inductionSlotStartDate);
         }
+        
         if (in_array(strtolower($contactCityFormatted), $officeContactInductionCities)) {
             return generate_slots($assignedOfficeId, $defaultMaxSlot, $physicalInductionType, $inductionSlotStartDate);
-        }else{
+        } else {
             return generate_slots($assignedOfficeId, $defaultMaxSlot, $onlineInductionType, $inductionSlotStartDate);
-        }
-        // generate physical induction slots having office in their states
-        // return generate_slots($assignedOfficeId, $defaultMaxSlot, $physicalInductionType, $inductionSlotStartDate);
+        }        
     } catch (\Exception $e) {
         \Civi::log()->error('Error generating induction slots', [
             'contactId' => $contactId,

--- a/wp-content/plugins/goonj-blocks/build/functions.php
+++ b/wp-content/plugins/goonj-blocks/build/functions.php
@@ -108,7 +108,7 @@ function generate_induction_slots($contactId = null, $days = 30) {
         // Check if the result has any rows
         if ($officeContact->count() > 0) {
             // Extract the first row (assuming one result, based on rowCount => 1)
-            $officeContactData = $officeContact[0];
+            $officeContactData = $officeContact->first();
         
             // Add the primary city to the array
             if (!empty($officeContactData['address_primary.city'])) {

--- a/wp-content/plugins/goonj-blocks/build/functions.php
+++ b/wp-content/plugins/goonj-blocks/build/functions.php
@@ -99,18 +99,55 @@ function generate_induction_slots($contactId = null, $days = 30) {
 
         // Determine if a Goonj office exists in the contact's state and schedule accordingly
         $officeContact = \Civi\Api4\Contact::get(FALSE)
-            ->addSelect('id', 'display_name')
+            ->addSelect('id', 'display_name', 'Goonj_Office_Details.Other_Induction_Cities', 'address_primary.city')
             ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
             ->addWhere('address_primary.state_province_id', '=', $contactStateId)
-            ->addWhere('address_primary.city', 'LIKE', $contactCityFormatted . '%')
+            // ->addWhere('address_primary.city', 'LIKE', $contactCityFormatted . '%')
             ->execute();
+        \Civi::log()->info('officeContact', ['officeContact'=>$officeContact]);
+        $officeContactInductionCities = [];
 
-        if ($officeContact->count() === 0) {
+        $officeContactInductionCities = [];
+
+        // Check if the result has any rows
+        if ($officeContact->count() > 0) {
+            // Extract the first row (assuming one result, based on rowCount => 1)
+            $officeContactData = $officeContact[0];
+        
+            // Add the primary city to the array
+            if (!empty($officeContactData['address_primary.city'])) {
+                $officeContactInductionCities[] = $officeContactData['address_primary.city'];
+            }
+        
+            // Add the other induction cities to the array
+            if (!empty($officeContactData['Goonj_Office_Details.Other_Induction_Cities'])) {
+                // Split the string into an array and merge it
+                $otherCities = array_map('trim', explode(',', $officeContactData['Goonj_Office_Details.Other_Induction_Cities']));
+                $officeContactInductionCities = array_merge($officeContactInductionCities, $otherCities);
+            }
+        
+            // Convert all cities to lowercase, remove duplicates, and re-index the array
+            $officeContactInductionCities = array_map('strtolower', $officeContactInductionCities);
+            $officeContactInductionCities = array_unique($officeContactInductionCities);
+            $officeContactInductionCities = array_values($officeContactInductionCities);
+        }
+        
+        // Log the result for debugging
+        \Civi::log()->info('officeContactInductionCities', ['officeContactInductionCities' => $officeContactInductionCities, 'contactCityFormatted'=>$contactCityFormatted]);
+        
+        
+
+        if ($officeContact->count() === 0 ) {
             // generate online induction slots for state having no office
             return generate_slots($assignedOfficeId, $defaultMaxSlot, $onlineInductionType, $inductionSlotStartDate);
         }
+        if (in_array(strtolower($contactCityFormatted), $officeContactInductionCities)) {
+            return generate_slots($assignedOfficeId, $defaultMaxSlot, $physicalInductionType, $inductionSlotStartDate);
+        }else{
+            return generate_slots($assignedOfficeId, $defaultMaxSlot, $onlineInductionType, $inductionSlotStartDate);
+        }
         // generate physical induction slots having office in their states
-        return generate_slots($assignedOfficeId, $defaultMaxSlot, $physicalInductionType, $inductionSlotStartDate);
+        // return generate_slots($assignedOfficeId, $defaultMaxSlot, $physicalInductionType, $inductionSlotStartDate);
     } catch (\Exception $e) {
         \Civi::log()->error('Error generating induction slots', [
             'contactId' => $contactId,

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -166,7 +166,6 @@ $target_data = [
     'should_include_attendee_feedback'=> $action_target['Goonj_Activities.Include_Attendee_Feedback_Form']
   ],
 ];
-\Civi::log()->info('target_data', ['target_data'=>$target_data]);
 
 if (in_array($target, ['collection-camp','institution-collection-camp', 'dropping-center', 'goonj-activities'])) :
   $target_info = $target_data[$target];

--- a/wp-content/plugins/goonj-blocks/src/functions.php
+++ b/wp-content/plugins/goonj-blocks/src/functions.php
@@ -108,7 +108,7 @@ function generate_induction_slots($contactId = null, $days = 30) {
         // Check if the result has any rows
         if ($officeContact->count() > 0) {
             // Extract the first row (assuming one result, based on rowCount => 1)
-            $officeContactData = $officeContact[0];
+            $officeContactData = $officeContact->first();
         
             // Add the primary city to the array
             if (!empty($officeContactData['address_primary.city'])) {


### PR DESCRIPTION
- Added changes to check contact city and pu mulitiple induction city for physical induction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced logic for determining induction types based on volunteer cities.
	- Improved handling of email notifications to prevent duplicates.
	- Consolidated registration links for various volunteer activities.
	- Enhanced display of induction slots and statuses for better user experience.

- **Bug Fixes**
	- Enhanced error handling and logging for induction slot generation and office contact retrieval.
	- Improved clarity in the display of induction schedules and availability.

- **Documentation**
	- Updated comments and logging for better traceability in induction processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->