### PR TITLE
Assign Goonj Chapter To Contact

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -35,7 +35,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
       '&hook_civicrm_pre' => [
         ['assignChapterGroupToIndividual'],
       ],
-      // '&hook_civicrm_pre' => 'generateInstitutionCollectionCampQr',
+      '&hook_civicrm_pre' => 'generateInstitutionCollectionCampQr',
       '&hook_civicrm_custom' => [
         ['setOfficeDetails'],
         ['mailNotificationToMmt'],

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -34,8 +34,8 @@ class InstitutionCollectionCampService extends AutoSubscriber {
       '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       '&hook_civicrm_pre' => [
         ['assignChapterGroupToIndividual'],
+        ['generateInstitutionCollectionCampQr'],
       ],
-      '&hook_civicrm_pre' => 'generateInstitutionCollectionCampQr',
       '&hook_civicrm_custom' => [
         ['setOfficeDetails'],
         ['mailNotificationToMmt'],

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -58,6 +58,7 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
       'Institution_Collection_Camp_Intent.Institution_POC',
       'Institution_Collection_Camp_Logistics.Self_Managed_by_Institution',
       'Institution_collection_camp_Review.Coordinating_POC',
+      'Institution_Collection_Camp_Intent.Organization_Name',
     )
     ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
     ->addWhere('subtype', '=', $collectionCampSubtype)


### PR DESCRIPTION
Assign the Goonj Chapter to both the organization and the individual contact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced event handling for chapter group assignments.
	- Added methods for retrieving and assigning contact groups based on state ID.
	- Improved logic for adding contacts to groups.
	- Expanded data retrieval in the collection camp cron function.

- **Bug Fixes**
	- Updated logging for scenarios where no contact group is found.
	- Enhanced logging for missing IDs during group assignments.

- **Documentation**
	- Clarified method functionalities and logging details for better understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->