### PR TITLE
Refactor Code : Assign Goonj Office

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -145,10 +145,6 @@ class InstitutionService extends AutoSubscriber {
       return FALSE;
     }
 
-    \Civi::log()->info('Organization created: ', [
-      'id' => $objectId,
-      'subtypes' => $objectRef->contact_sub_type,
-    ]);
     $subTypes = $objectRef->contact_sub_type;
 
     if (empty($subTypes)) {
@@ -165,10 +161,6 @@ class InstitutionService extends AutoSubscriber {
     }
 
     self::$organizationId = $objectId;
-
-    \Civi::log()->info('Organization set: ', [
-      'id' => self::$organizationId,
-    ]);
   }
 
   /**
@@ -203,7 +195,6 @@ class InstitutionService extends AutoSubscriber {
       ->execute();
 
     if (!$stateId) {
-      \Civi::log()->info('state not found', ['organizationId' => self::$organizationId, 'stateId' => $stateId]);
       return FALSE;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionService.php
@@ -24,7 +24,7 @@ class InstitutionService extends AutoSubscriber {
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_post' => [
-        ['organisationCreated'],
+        ['organizationCreated'],
         ['setOfficeDetails'],
         ['assignChapterGroupToIndividual'],
       ],
@@ -139,13 +139,13 @@ class InstitutionService extends AutoSubscriber {
    * @param object $objectRef
    *   The parameters that were sent into the calling function.
    */
-  public static function organisationCreated(string $op, string $objectName, int $objectId, &$objectRef) {
+  public static function organizationCreated(string $op, string $objectName, int $objectId, &$objectRef) {
 
     if ($op !== 'create' || $objectName !== 'Organization') {
       return FALSE;
     }
 
-    \Civi::log()->info('Organisation created: ', [
+    \Civi::log()->info('Organization created: ', [
       'id' => $objectId,
       'subtypes' => $objectRef->contact_sub_type,
     ]);
@@ -166,7 +166,7 @@ class InstitutionService extends AutoSubscriber {
 
     self::$organizationId = $objectId;
 
-    \Civi::log()->info('Organisation set: ', [
+    \Civi::log()->info('Organization set: ', [
       'id' => self::$organizationId,
     ]);
   }


### PR DESCRIPTION
**Organization Creation (organisationCreated):**
1. When a new organization is created, the system checks if it is an "Institute" subtype.
2. If it's an "Institute," the organization's ID is logged and stored for further processing.

**Assigning Office and Coordinator (setOfficeDetails):**
1. When a primary address is added to the organization, the system looks for a corresponding Goonj office based on the organization's state.
2. If no office is found for the state, a fallback office is assigned.
3. The system then identifies and assigns a relevant coordinator from the state office to manage the organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new event handler for organization creation.
	- Added logging for organization details during creation.

- **Improvements**
	- Enhanced validation and logging in the office details setting process.
	- Streamlined chapter group assignment logic with improved checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->