### PR TITLE
Add `setIndianStateOptions` Hook for Dynamic State Options in `CollectionBaseService`

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -16,7 +16,6 @@ use Civi\Api4\Group;
 use Civi\Api4\GroupContact;
 use Civi\Api4\OptionValue;
 use Civi\Api4\Relationship;
-use Civi\Api4\StateProvince;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Service\AutoSubscriber;
 use CRM_Core_Action;
@@ -65,7 +64,6 @@ class CollectionCampService extends AutoSubscriber {
       ['linkInductionWithCollectionCamp'],
       ['mailNotificationToMmt'],
       ],
-      '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       'civi.afform.submit' => [
       ['setCollectionCampAddress', 9],
       ['setEventVolunteersAddress', 8],
@@ -765,43 +763,6 @@ class CollectionCampService extends AutoSubscriber {
     $coordinator = $fallbackCoordinators->itemAt($randomIndex);
 
     return $coordinator;
-  }
-
-  /**
-   *
-   */
-  public static function setIndianStateOptions(string $entity, string $field, array &$options, array $params) {
-    if ($entity !== 'Eck_Collection_Camp') {
-      return;
-    }
-
-    $intentStateFields = CustomField::get(FALSE)
-      ->addWhere('custom_group_id:name', '=', 'Collection_Camp_Intent_Details')
-      ->addWhere('name', '=', 'State')
-      ->execute();
-
-    $stateField = $intentStateFields->first();
-
-    $statefieldId = $stateField['id'];
-
-    if ($field !== "custom_$statefieldId") {
-      return;
-    }
-
-    $indianStates = StateProvince::get(FALSE)
-      ->addWhere('country_id.iso_code', '=', 'IN')
-      ->addOrderBy('name', 'ASC')
-      ->execute();
-
-    $stateOptions = [];
-    foreach ($indianStates as $state) {
-      if ($state['is_active']) {
-        $stateOptions[$state['id']] = $state['name'];
-      }
-    }
-
-    $options = $stateOptions;
-
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -7,7 +7,6 @@ use Civi\Api4\CustomField;
 use Civi\Api4\EckEntity;
 use Civi\Api4\Email;
 use Civi\Api4\Relationship;
-use Civi\Api4\StateProvince;
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Traits\CollectionSource;
 use Civi\Traits\QrCodeable;
@@ -36,7 +35,6 @@ class DroppingCenterService extends AutoSubscriber {
         ['setOfficeDetails'],
         ['mailNotificationToMmt'],
       ],
-      '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       '&hook_civicrm_post' => 'processDispatchEmail',
     ];
   }
@@ -418,43 +416,6 @@ class DroppingCenterService extends AutoSubscriber {
     ];
 
     \CRM_Utils_Mail::send($mailParams);
-  }
-
-  /**
-   *
-   */
-  public static function setIndianStateOptions(string $entity, string $field, array &$options, array $params) {
-    if ($entity !== 'Eck_Collection_Camp') {
-      return;
-    }
-
-    $customStateFields = CustomField::get(FALSE)
-      ->addWhere('custom_group_id:name', '=', 'Dropping_Centre')
-      ->addWhere('name', '=', 'State')
-      ->execute();
-
-    $stateField = $customStateFields->first();
-
-    $stateFieldId = $stateField['id'];
-
-    if ($field !== "custom_$stateFieldId") {
-      return;
-    }
-
-    $activeIndianStates = StateProvince::get(FALSE)
-      ->addWhere('country_id.iso_code', '=', 'IN')
-      ->addOrderBy('name', 'ASC')
-      ->execute();
-
-    $stateOptions = [];
-    foreach ($activeIndianStates as $state) {
-      if ($state['is_active']) {
-        $stateOptions[$state['id']] = $state['name'];
-      }
-    }
-
-    $options = $stateOptions;
-
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/GoonjActivitiesService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/GoonjActivitiesService.php
@@ -9,7 +9,6 @@ use Civi\Api4\CustomField;
 use Civi\Api4\EckEntity;
 use Civi\Api4\OptionValue;
 use Civi\Api4\Relationship;
-use Civi\Api4\StateProvince;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Traits\CollectionSource;
@@ -34,7 +33,6 @@ class GoonjActivitiesService extends AutoSubscriber {
    */
   public static function getSubscribedEvents() {
     return [
-      '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       'civi.afform.submit' => [
         ['setGoonjActivitiesAddress', 9],
         ['setActivitiesVolunteersAddress', 8],
@@ -50,43 +48,6 @@ class GoonjActivitiesService extends AutoSubscriber {
         ['createActivityForGoonjActivityCollectionCamp'],
       ],
     ];
-  }
-
-  /**
-   *
-   */
-  public static function setIndianStateOptions(string $entity, string $field, array &$options, array $params) {
-    if ($entity !== 'Eck_Collection_Camp') {
-      return;
-    }
-
-    $customStateFields = CustomField::get(FALSE)
-      ->addWhere('custom_group_id:name', '=', 'Goonj_Activities')
-      ->addWhere('name', '=', 'State')
-      ->execute();
-
-    $stateField = $customStateFields->first();
-
-    $stateFieldId = $stateField['id'];
-
-    if ($field !== "custom_$stateFieldId") {
-      return;
-    }
-
-    $activeIndianStates = StateProvince::get(FALSE)
-      ->addWhere('country_id.iso_code', '=', 'IN')
-      ->addOrderBy('name', 'ASC')
-      ->execute();
-
-    $stateOptions = [];
-    foreach ($activeIndianStates as $state) {
-      if ($state['is_active']) {
-        $stateOptions[$state['id']] = $state['name'];
-      }
-    }
-
-    $options = $stateOptions;
-
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InductionService.php
@@ -823,7 +823,7 @@ class InductionService extends AutoSubscriber {
       return $inductionType;
     }
 
-    $officeContact = \Civi\Api4\Contact::get(FALSE)
+    $officeContact = Contact::get(FALSE)
       ->addWhere('contact_sub_type', 'CONTAINS', 'Goonj_Office')
       ->addClause('OR', ['Goonj_Office_Details.Other_Induction_Cities', 'CONTAINS', $contactCityFormatted], ['address_primary.city', 'CONTAINS', $contactCityFormatted])
       ->execute();
@@ -837,7 +837,8 @@ class InductionService extends AutoSubscriber {
 
     if (!empty($officeDetails)) {
       return $inductionType;
-    } else {
+    }
+    else {
       $inductionType = 'Online';
       return $inductionType;
     }

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -12,7 +12,6 @@ use Civi\Api4\Group;
 use Civi\Api4\GroupContact;
 use Civi\Api4\OptionValue;
 use Civi\Api4\Relationship;
-use Civi\Api4\StateProvince;
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Traits\CollectionSource;
 use Civi\Traits\QrCodeable;
@@ -33,7 +32,6 @@ class InstitutionCollectionCampService extends AutoSubscriber {
    */
   public static function getSubscribedEvents() {
     return [
-      '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       '&hook_civicrm_pre' => [
         ['assignChapterGroupToIndividual'],
         ['generateInstitutionCollectionCampQr'],
@@ -270,43 +268,6 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     <p>Warm regards,<br>Urban Relations Team</p>";
 
     return $html;
-  }
-
-  /**
-   *
-   */
-  public static function setIndianStateOptions(string $entity, string $field, array &$options, array $params) {
-    if ($entity !== 'Eck_Collection_Camp') {
-      return;
-    }
-
-    $intentStateFields = CustomField::get(FALSE)
-      ->addWhere('custom_group_id:name', '=', 'Institution_Collection_Camp_Intent')
-      ->addWhere('name', '=', 'State')
-      ->execute();
-
-    $stateField = $intentStateFields->first();
-
-    $statefieldId = $stateField['id'];
-
-    if ($field !== "custom_$statefieldId") {
-      return;
-    }
-
-    $indianStates = StateProvince::get(FALSE)
-      ->addWhere('country_id.iso_code', '=', 'IN')
-      ->addOrderBy('name', 'ASC')
-      ->execute();
-
-    $stateOptions = [];
-    foreach ($indianStates as $state) {
-      if ($state['is_active']) {
-        $stateOptions[$state['id']] = $state['name'];
-      }
-    }
-
-    $options = $stateOptions;
-
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
@@ -5,7 +5,6 @@ namespace Civi;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
 use Civi\Api4\EckEntity;
-use Civi\Api4\StateProvince;
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Traits\CollectionSource;
 use Civi\Traits\QrCodeable;
@@ -29,49 +28,11 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
    */
   public static function getSubscribedEvents() {
     return [
-      '&hook_civicrm_fieldOptions' => 'setIndianStateOptions',
       '&hook_civicrm_custom' => [
         ['setOfficeDetails'],
       ],
       '&hook_civicrm_pre' => 'generateInstitutionDroppingCenterQr',
     ];
-  }
-
-  /**
-   *
-   */
-  public static function setIndianStateOptions(string $entity, string $field, array &$options, array $params) {
-    if ($entity !== 'Eck_Collection_Camp') {
-      return;
-    }
-
-    $intentStateFields = CustomField::get(FALSE)
-      ->addWhere('custom_group_id:name', '=', 'Institution_Dropping_Center_Intent')
-      ->addWhere('name', '=', 'State')
-      ->execute();
-
-    $stateField = $intentStateFields->first();
-
-    $statefieldId = $stateField['id'];
-
-    if ($field !== "custom_$statefieldId") {
-      return;
-    }
-
-    $indianStates = StateProvince::get(FALSE)
-      ->addWhere('country_id.iso_code', '=', 'IN')
-      ->addOrderBy('name', 'ASC')
-      ->execute();
-
-    $stateOptions = [];
-    foreach ($indianStates as $state) {
-      if ($state['is_active']) {
-        $stateOptions[$state['id']] = $state['name'];
-      }
-    }
-
-    $options = $stateOptions;
-
   }
 
   /**


### PR DESCRIPTION
This pull request introduces a new `hook_civicrm_fieldOptions` in the `CollectionBaseService` class to dynamically populate Indian state options for specific fields. The refactoring adds extensibility and scalability to the handling of state-related options, making future development more modular and maintainable.


### Why Refactored?

- Centralized and dynamic handling of state options removes hardcoded values, improving maintainability.
- The hook-based implementation allows for easy integration with existing and future features without invasive changes to the core logic.
- Adopting the StateProvince API ensures consistent and reliable data fetching while adhering to best practices in CiviCRM.

### How to Extend in the Future

- **Add Support for Other Countries:** Modify the setIndianStateOptions method to include additional country filters or add a method for other entities.
- **Extend Field Handling:** Expand the `getStateFieldNames()` utility to include more fields requiring dynamic options.
- **Additional Data Options:** Leverage the hook for other data sources like city or district fields by introducing similar methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a method to provide options for Indian states specifically for the `Eck_Collection_Camp` entity.
  
- **Bug Fixes**
	- Enhanced error handling and logging in the office assignment process.
	- Improved checks and logging for email notifications.

- **Refactor**
	- Cleaned up the `fetchTypeOfInduction` method for better readability.

- **Chores**
	- Removed outdated methods related to Indian state options across multiple services, streamlining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->