### PR TITLE
Rename tab

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -476,8 +476,8 @@ class DroppingCenterService extends AutoSubscriber {
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
         'permissions' => ['goonj_chapter_admin', 'urbanops'],
       ],
-      'donation' => [
-        'title' => ts('Donation'),
+      'donationBox' => [
+        'title' => ts('Donation Box'),
         'module' => 'afsearchDonation',
         'directive' => 'afsearch-donation',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',


### PR DESCRIPTION
Rename Tab `Donation` to `Donation Box`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The 'donation' tab has been renamed to 'donationBox' for improved clarity in the user interface.
	- The title associated with the donation tab has been updated to 'Donation Box'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->