### PR TITLE
Add landmark token to dropping center poster

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
@@ -27,6 +27,7 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
       'coordinator' => \CRM_Goonjcustom_ExtensionUtil::ts('Coordinator (Goonj)'),
       'remarks' => \CRM_Goonjcustom_ExtensionUtil::ts('Remarks'),
       'address_city' => \CRM_Goonjcustom_ExtensionUtil::ts('City'),
+      'landmark' => \CRM_Goonjcustom_ExtensionUtil::ts('Landmark or Nearby Area'),
     ]);
   }
 
@@ -80,6 +81,17 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
 
       case 'address_city':
         $value = $collectionSource['Dropping_Centre.District_City'];
+        break;
+
+      case 'landmark':
+        $landmarkOrNearbyArea = $collectionSource['Dropping_Centre.Landmark_or_Near_by_area'];
+
+        if (!empty($landmarkOrNearbyArea)) {
+          $value = "(" . $landmarkOrNearbyArea . ")";
+        }
+        else {
+          $value = '';
+        }
         break;
 
       default:

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
@@ -84,7 +84,14 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
         break;
 
       case 'landmark':
-        $value = $collectionSource['Dropping_Centre.Landmark_or_Near_by_area'];
+        $landmarkOrNearbyArea = $collectionSource['Dropping_Centre.Landmark_or_Near_by_area'];
+
+        if (!empty($landmarkOrNearbyArea)) {
+          $value = "(" . $landmarkOrNearbyArea . ")";
+        }
+        else {
+          $value = '';
+        }
         break;
 
       default:

--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/DroppingCenter.php
@@ -84,14 +84,7 @@ class CRM_Goonjcustom_Token_DroppingCenter extends AbstractTokenSubscriber {
         break;
 
       case 'landmark':
-        $landmarkOrNearbyArea = $collectionSource['Dropping_Centre.Landmark_or_Near_by_area'];
-
-        if (!empty($landmarkOrNearbyArea)) {
-          $value = "(" . $landmarkOrNearbyArea . ")";
-        }
-        else {
-          $value = '';
-        }
+        $value = $collectionSource['Dropping_Centre.Landmark_or_Near_by_area'];
         break;
 
       default:

--- a/wp-content/civi-extensions/goonjcustom/js/puppeteer.js
+++ b/wp-content/civi-extensions/goonjcustom/js/puppeteer.js
@@ -1,12 +1,8 @@
 const puppeteer = require('puppeteer');
 
-require('dotenv').config();
-
 (async () => {
-    const executablePath = process.env.NODE_ENV === 'production' ? process.env.EXECUTABLE_PATH : '';
-    console.log(executablePath,'executablePath')
     const browser = await puppeteer.launch({
-        executablePath: executablePath
+        executablePath: '/home/apache/.cache/puppeteer/chrome/linux-129.0.6668.89/chrome-linux64/chrome',
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
 

--- a/wp-content/civi-extensions/goonjcustom/js/puppeteer.js
+++ b/wp-content/civi-extensions/goonjcustom/js/puppeteer.js
@@ -1,8 +1,12 @@
 const puppeteer = require('puppeteer');
 
+require('dotenv').config();
+
 (async () => {
+    const executablePath = process.env.NODE_ENV === 'production' ? process.env.EXECUTABLE_PATH : '';
+    console.log(executablePath,'executablePath')
     const browser = await puppeteer.launch({
-        executablePath: '/home/apache/.cache/puppeteer/chrome/linux-129.0.6668.89/chrome-linux64/chrome',
+        executablePath: executablePath
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
 


### PR DESCRIPTION
**Description:**
1. Updated the evaluateToken() function to include the landmark in the format (Landmark) if the field is not empty.
2. Added a new token for "Landmark or Nearby Area" to be displayed in parentheses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new 'landmark' field for improved token processing in the Dropping Center functionality.
	- Enhanced token evaluation to include 'landmark' for better output formatting. 

- **Bug Fixes**
	- Improved error handling for missing collection source IDs, ensuring better debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->