### PR TITLE
Assign Campaign to Contribution Pages for collection source

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1356,16 +1356,7 @@ class CollectionCampService extends AutoSubscriber {
   }
 
   /**
-   * This hook is called after a db write on entities.
    *
-   * @param string $op
-   *   The type of operation being performed.
-   * @param string $objectName
-   *   The name of the object.
-   * @param int $objectId
-   *   The unique identifier for the object.
-   * @param object $objectRef
-   *   The reference to the object.
    */
   public static function updateCampaignForCollectionSourceContribution(string $op, string $objectName, $objectId, &$objectRef) {
     if ($objectName != 'Contribution' || $objectId === NULL) {

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1359,7 +1359,7 @@ class CollectionCampService extends AutoSubscriber {
    *
    */
   public static function updateCampaignForCollectionSourceContribution(string $op, string $objectName, $objectId, &$objectRef) {
-    if ($objectName != 'Contribution' || !$objectId) {
+    if ($objectName != 'Contribution' || !$objectId || $op !== 'edit') {
       return;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1359,7 +1359,7 @@ class CollectionCampService extends AutoSubscriber {
    *
    */
   public static function updateCampaignForCollectionSourceContribution(string $op, string $objectName, $objectId, &$objectRef) {
-    if ($objectName != 'Contribution' || $objectId === NULL) {
+    if ($objectName != 'Contribution' || !$objectId) {
       return;
     }
 


### PR DESCRIPTION
Assign Campaign to Contribution Pages for collection source
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to automatically update contributions with the correct campaign ID based on their collection source.

- **Bug Fixes**
	- Improved tracking of contributions to ensure they are linked to the appropriate campaigns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->