### PR TITLE
Created Institution Dropping Center activity to Contact

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -96,7 +96,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
 
     }
     catch (\CiviCRM_API4_Exception $ex) {
-      \Civi::log()->debug("Exception while creating Organize Collection Camp activity: " . $ex->getMessage());
+      \Civi::log()->debug("Exception while creating Organize Institution Collection Camp activity: " . $ex->getMessage());
     }
   }
 
@@ -106,7 +106,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   private static function createActivity($contactId, $collectionCampTitle, $collectionCampId) {
     Activity::create(FALSE)
       ->addValue('subject', $collectionCampTitle)
-      ->addValue('activity_type_id:name', 'Organize Collection Camp')
+      ->addValue('activity_type_id:name', 'Organize Institution Collection Camp')
       ->addValue('status_id:name', 'Authorized')
       ->addValue('activity_date_time', date('Y-m-d H:i:s'))
       ->addValue('source_contact_id', $contactId)

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
@@ -44,8 +44,9 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
     ];
   }
 
-
-
+  /**
+   *
+   */
   public static function linkInstitutionDroppingCenterToContact(string $op, string $objectName, $objectId, &$objectRef) {
     if ($objectName !== 'Eck_Collection_Camp' || !$objectId) {
       return;
@@ -98,6 +99,9 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
     }
   }
 
+  /**
+   *
+   */
   private static function createActivity($contactId, $droppingCenterCode, $droppingCenterId) {
     Activity::create(FALSE)
       ->addValue('subject', $droppingCenterCode)
@@ -111,7 +115,6 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
 
     \Civi::log()->info("Activity created for contact {$contactId} for Institution Dropping Center {$droppingCenterCode}");
   }
-
 
   /**
    *

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
@@ -105,7 +105,7 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
   private static function createActivity($contactId, $droppingCenterCode, $droppingCenterId) {
     Activity::create(FALSE)
       ->addValue('subject', $droppingCenterCode)
-      ->addValue('activity_type_id:name', 'Organize Dropping Center')
+      ->addValue('activity_type_id:name', 'Organize Institution Dropping Center')
       ->addValue('status_id:name', 'Authorized')
       ->addValue('activity_date_time', date('Y-m-d H:i:s'))
       ->addValue('source_contact_id', $contactId)

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
@@ -37,9 +37,81 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
         ['mailNotificationToMmt'],
       ],
       '&hook_civicrm_post' => 'processDispatchEmail',
-      '&hook_civicrm_pre' => 'generateInstitutionDroppingCenterQr',
+      '&hook_civicrm_pre' => [
+        ['generateInstitutionDroppingCenterQr'],
+        ['linkInstitutionDroppingCenterToContact'],
+      ],
     ];
   }
+
+
+
+  public static function linkInstitutionDroppingCenterToContact(string $op, string $objectName, $objectId, &$objectRef) {
+    if ($objectName !== 'Eck_Collection_Camp' || !$objectId) {
+      return;
+    }
+
+    $newStatus = $objectRef['Collection_Camp_Core_Details.Status'] ?? '';
+    if (!$newStatus) {
+      return;
+    }
+
+    $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
+      ->addSelect('Collection_Camp_Core_Details.Status', 'Institution_Dropping_Center_Intent.Organization_Name', 'title', 'Institution_Dropping_Center_Intent.Institution_POC')
+      ->addWhere('id', '=', $objectId)
+      ->execute();
+
+    $currentDroppingCenter = $collectionCamps->first();
+    $currentStatus = $currentDroppingCenter['Collection_Camp_Core_Details.Status'];
+    $PocId = $currentDroppingCenter['Institution_Dropping_Center_Intent.Institution_POC'];
+    $organizationId = $currentDroppingCenter['Institution_Dropping_Center_Intent.Organization_Name'];
+
+    if (!$PocId && !$organizationId) {
+      return;
+    }
+
+    $droppingCenterCode = $currentDroppingCenter['title'];
+    $droppingCenterId = $currentDroppingCenter['id'];
+
+    if ($currentStatus !== $newStatus && $newStatus === 'authorized') {
+      self::createDroppingCenterOrganizeActivity($PocId, $organizationId, $droppingCenterCode, $droppingCenterId);
+    }
+  }
+
+  /**
+   *
+   */
+  private static function createDroppingCenterOrganizeActivity($PocId, $organizationId, $droppingCenterCode, $droppingCenterId) {
+    try {
+
+      // Create activity for PocId.
+      self::createActivity($PocId, $droppingCenterCode, $droppingCenterId);
+
+      // Create activity for organizationId, only if it's different from PocId.
+      if ($organizationId !== $PocId) {
+        self::createActivity($organizationId, $droppingCenterCode, $droppingCenterId);
+      }
+
+    }
+    catch (\CiviCRM_API4_Exception $ex) {
+      \Civi::log()->debug("Exception while creating Organize Dropping Center activity: " . $ex->getMessage());
+    }
+  }
+
+  private static function createActivity($contactId, $droppingCenterCode, $droppingCenterId) {
+    Activity::create(FALSE)
+      ->addValue('subject', $droppingCenterCode)
+      ->addValue('activity_type_id:name', 'Organize Dropping Center')
+      ->addValue('status_id:name', 'Authorized')
+      ->addValue('activity_date_time', date('Y-m-d H:i:s'))
+      ->addValue('source_contact_id', $contactId)
+      ->addValue('target_contact_id', $contactId)
+      ->addValue('Collection_Camp_Data.Collection_Camp_ID', $droppingCenterId)
+      ->execute();
+
+    \Civi::log()->info("Activity created for contact {$contactId} for Institution Dropping Center {$droppingCenterCode}");
+  }
+
 
   /**
    *
@@ -238,13 +310,13 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
       ->addWhere('id', '=', $objectId)
       ->execute();
 
-    $currentCollectionCamp = $collectionCamps->first();
-    $currentStatus = $currentCollectionCamp['Collection_Camp_Core_Details.Status'];
-    $collectionCampId = $currentCollectionCamp['id'];
+    $currentDroppingCenter = $collectionCamps->first();
+    $currentStatus = $currentDroppingCenter['Collection_Camp_Core_Details.Status'];
+    $droppingCenterId = $currentDroppingCenter['id'];
 
     // Check for status change.
     if ($currentStatus !== $newStatus && $newStatus === 'authorized') {
-      self::generateInstitutionDroppingCenterQrCode($collectionCampId);
+      self::generateInstitutionDroppingCenterQrCode($droppingCenterId);
     }
   }
 


### PR DESCRIPTION
Once the institution is authorized as a dropping center, the activity should be created on the contact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event handler for linking institution dropping centers to contacts.
	- Added functionality to create activities based on the status of collection camps.
- **Improvements**
	- Enhanced clarity of variable names in existing methods related to QR code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->