### PR TITLE
Add Activity In Institution related to institution Campaign

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCampaignService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCampaignService.php
@@ -17,7 +17,7 @@ class InstitutionCampaignService extends AutoSubscriber {
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_post' => [
-        ['linkCollectionCampToContact'],
+        ['linkCampaignToOrganization'],
       ],
     ];
   }
@@ -25,7 +25,7 @@ class InstitutionCampaignService extends AutoSubscriber {
   /**
    *
    */
-  public static function linkCollectionCampToContact(string $op, string $objectName, int $objectId, &$objectRef) {
+  public static function linkCampaignToOrganization(string $op, string $objectName, int $objectId, &$objectRef) {
 
     if ($objectName != 'Campaign' || !$objectId) {
       return;

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCampaignService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCampaignService.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Civi;
+
+use Civi\Api4\Activity;
+use Civi\Api4\Campaign;
+use Civi\Core\Service\AutoSubscriber;
+
+/**
+ *
+ */
+class InstitutionCampaignService extends AutoSubscriber {
+
+  /**
+   *
+   */
+  public static function getSubscribedEvents() {
+    return [
+      '&hook_civicrm_post' => [
+        ['linkCollectionCampToContact'],
+      ],
+    ];
+  }
+
+  /**
+   *
+   */
+  public static function linkCollectionCampToContact(string $op, string $objectName, int $objectId, &$objectRef) {
+
+    if ($objectName != 'Campaign' || !$objectId) {
+      return;
+    }
+
+    $institutionCampaign = Campaign::get(TRUE)
+      ->addSelect(
+          'id',
+          'Additional_Details.Institution',
+          'title'
+      )
+      ->addWhere('id', '=', $objectId)
+      ->execute();
+
+    $currentInstitutionCampaign = $institutionCampaign->first();
+    $currentInstitutionId = $currentInstitutionCampaign['Additional_Details.Institution'];
+    if (!$currentInstitutionId) {
+      return;
+    }
+    $campaignTitle = $currentInstitutionCampaign['title'];
+    $campaignId = $currentInstitutionCampaign['id'];
+
+    // Check for status change.
+    if ($currentInstitutionId) {
+      self::createCollectionCampOrganizeActivity($currentInstitutionId, $campaignTitle, $campaignId);
+    }
+  }
+
+  /**
+   * Log an activity in CiviCRM.
+   */
+  private static function createCollectionCampOrganizeActivity($currentInstitutionId, $campaignTitle, $campaignId) {
+    try {
+      $results = Activity::create(FALSE)
+        ->addValue('subject', $campaignTitle)
+        ->addValue('activity_type_id:name', 'Institution Campaign')
+        ->addValue('status_id:name', 'Completed')
+        ->addValue('activity_date_time', date('Y-m-d H:i:s'))
+        ->addValue('source_contact_id', $currentInstitutionId)
+        ->addValue('target_contact_id', $currentInstitutionId)
+        ->execute();
+
+    }
+    catch (\CiviCRM_API4_Exception $ex) {
+      \Civi::log()->debug("Exception while creating Organize Collection Camp activity: " . $ex->getMessage());
+    }
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCampaignService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCampaignService.php
@@ -50,14 +50,14 @@ class InstitutionCampaignService extends AutoSubscriber {
 
     // Check for status change.
     if ($currentInstitutionId) {
-      self::createCollectionCampOrganizeActivity($currentInstitutionId, $campaignTitle, $campaignId);
+      self::createInstitutionCampaignActivity($currentInstitutionId, $campaignTitle, $campaignId);
     }
   }
 
   /**
    * Log an activity in CiviCRM.
    */
-  private static function createCollectionCampOrganizeActivity($currentInstitutionId, $campaignTitle, $campaignId) {
+  private static function createInstitutionCampaignActivity($currentInstitutionId, $campaignTitle, $campaignId) {
     try {
       $results = Activity::create(FALSE)
         ->addValue('subject', $campaignTitle)
@@ -70,7 +70,7 @@ class InstitutionCampaignService extends AutoSubscriber {
 
     }
     catch (\CiviCRM_API4_Exception $ex) {
-      \Civi::log()->debug("Exception while creating Organize Collection Camp activity: " . $ex->getMessage());
+      \Civi::log()->debug("Exception while creating Institution Campaign activity: " . $ex->getMessage());
     }
   }
 


### PR DESCRIPTION
Add functionality to log an "Institution Campaign" activity in CiviCRM when a campaign is linked to an institution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to link campaigns to institutions within the CiviCRM system.
	- Added automated logging of activities related to campaigns.

- **Bug Fixes**
	- Implemented error handling for activity creation to ensure robust API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->