### PR TITLE
Add Outcome email for visit

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Civi;
+
+use Civi\Core\Service\AutoSubscriber;
+use Civi\Api4\Contact;
+
+
+/**
+ *
+ */
+class UrbanPlannedVisitService extends AutoSubscriber {
+  private static $individualId = NULL;
+
+  /**
+   *
+   */
+  public static function getSubscribedEvents() {
+    return [
+    // @todo
+    //   '&hook_civicrm_post' => [
+    //     ['assignChapterGroupToIndividualForUrbanPlannedVisit'],
+    //   ],.
+    ];
+  }
+
+  /**
+   *
+   */
+  public static function sendOutcomeEmail($visit) {
+    $coordinatingGoonjPOCId = $visit['Urban_Planned_Visit.Coordinating_Goonj_POC'];
+
+    $coordinatingGoonjPOC = Contact::get(FALSE)
+      ->addSelect('email.email', 'display_name')
+      ->addJoin('Email AS email', 'LEFT')
+      ->addWhere('id', '=', $coordinatingGoonjPOCId)
+      ->execute()->single();
+
+    $coordinatingGoonjPOCEmail = $coordinatingGoonjPOC['email.email'];
+    $coordinatingGoonjPOCName = $coordinatingGoonjPOC['display_name'];
+    error_log("coordinatingGoonjPOCEmail: " . print_r($coordinatingGoonjPOCEmail, TRUE));
+    error_log("coordinatingGoonjPOCName: " . print_r($coordinatingGoonjPOCName, TRUE));
+
+    if (!$coordinatingGoonjPOCEmail) {
+      throw new \Exception('POC email missing');
+    }
+
+    $from = HelperService::getDefaultFromEmail();
+
+    $mailParams = [
+      'subject' => 'Urban Planned Visit',
+      'from' => $from,
+      'toEmail' => $coordinatingGoonjPOCEmail,
+      'replyTo' => $from,
+      'html' => self::getOutcomeEmailHtml($coordinatingGoonjPOCName),
+    ];
+    \CRM_Utils_Mail::send($mailParams);
+  }
+
+  /**
+   *
+   */
+  private static function getOutcomeEmailHtml($coordinatingGoonjPOCName) {
+    $homeUrl = \CRM_Utils_System::baseCMSURL();
+    $visitOutcomeFormUrl = $homeUrl . '/visit-outcome-form/';
+
+    $html = "
+    <p>Dear $coordinatingGoonjPOCName,</p>
+    <p>Thank you for attending the visit. Please fills out the below form:</p>
+    <ol>
+        <li><a href=\"$visitOutcomeFormUrl\">Camp Outcome Form</a><br>
+        This feedback form should be filled out after the camp/drive ends, once you have an overview of the event's outcomes.</li>
+    </ol>
+    <p>We appreciate your cooperation.</p>
+    <p>Warm Regards,<br>Urban Relations Team</p>";
+
+    return $html;
+  }
+
+}

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -66,10 +66,9 @@ class UrbanPlannedVisitService extends AutoSubscriber {
 
     $html = "
     <p>Dear $coordinatingGoonjPOCName,</p>
-    <p>Thank you for attending the visit. Please fills out the below form:</p>
+    <p>. Please fills out the below form:</p>
     <ol>
         <li><a href=\"$visitOutcomeFormUrl\">Camp Outcome Form</a><br>
-        This feedback form should be filled out after the camp/drive ends, once you have an overview of the event's outcomes.</li>
     </ol>
     <p>We appreciate your cooperation.</p>
     <p>Warm Regards,<br>Urban Relations Team</p>";

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -28,6 +28,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
    *
    */
   public static function sendOutcomeEmail($visit) {
+    $visitId = $visit['id'];
     $coordinatingGoonjPOCId = $visit['Urban_Planned_Visit.Coordinating_Goonj_POC'];
 
     $coordinatingGoonjPOC = Contact::get(FALSE)
@@ -52,7 +53,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       'from' => $from,
       'toEmail' => $coordinatingGoonjPOCEmail,
       'replyTo' => $from,
-      'html' => self::getOutcomeEmailHtml($coordinatingGoonjPOCName),
+      'html' => self::getOutcomeEmailHtml($coordinatingGoonjPOCName, $visitId),
     ];
     \CRM_Utils_Mail::send($mailParams);
   }
@@ -60,9 +61,9 @@ class UrbanPlannedVisitService extends AutoSubscriber {
   /**
    *
    */
-  private static function getOutcomeEmailHtml($coordinatingGoonjPOCName) {
+  private static function getOutcomeEmailHtml($coordinatingGoonjPOCName, $visitId) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
-    $visitOutcomeFormUrl = $homeUrl . '/visit-outcome-form/';
+    $visitOutcomeFormUrl = $homeUrl . '/visit-outcome/#?Eck_Institution_Visit1=' . $visitId;
 
     $html = "
     <p>Dear $coordinatingGoonjPOCName,</p>

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -4,6 +4,7 @@ namespace Civi;
 
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Api4\Contact;
+use Civi\Api4\EckEntity;
 
 
 /**
@@ -55,7 +56,15 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       'replyTo' => $from,
       'html' => self::getOutcomeEmailHtml($coordinatingGoonjPOCName, $visitId),
     ];
-    \CRM_Utils_Mail::send($mailParams);
+    $emailSendResult = \CRM_Utils_Mail::send($mailParams);
+
+    if ($emailSendResult) {
+      error_log("emailSendResult is gone or not: " . print_r($emailSendResult, TRUE));
+      EckEntity::update('Institution_Visit', FALSE)
+        ->addValue('Visit_Outcome.Outcome_Email_Sent', 1)
+        ->addWhere('id', '=', $visitId)
+        ->execute();
+    }
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -40,8 +40,6 @@ class UrbanPlannedVisitService extends AutoSubscriber {
 
     $coordinatingGoonjPOCEmail = $coordinatingGoonjPOC['email.email'];
     $coordinatingGoonjPOCName = $coordinatingGoonjPOC['display_name'];
-    error_log("coordinatingGoonjPOCEmail: " . print_r($coordinatingGoonjPOCEmail, TRUE));
-    error_log("coordinatingGoonjPOCName: " . print_r($coordinatingGoonjPOCName, TRUE));
 
     if (!$coordinatingGoonjPOCEmail) {
       throw new \Exception('POC email missing');
@@ -59,7 +57,6 @@ class UrbanPlannedVisitService extends AutoSubscriber {
     $emailSendResult = \CRM_Utils_Mail::send($mailParams);
 
     if ($emailSendResult) {
-      error_log("emailSendResult is gone or not: " . print_r($emailSendResult, TRUE));
       EckEntity::update('Institution_Visit', FALSE)
         ->addValue('Visit_Outcome.Outcome_Email_Sent', 1)
         ->addWhere('id', '=', $visitId)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
@@ -42,6 +42,10 @@ function civicrm_api3_goonjcustom_urban_planned_visit_outcome_cron($params) {
     ->addSelect('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', 'Urban_Planned_Visit.Coordinating_Goonj_POC')
     ->addWhere('Urban_Planned_Visit.Coordinating_Goonj_POC', 'IS NOT NULL')
     ->addWhere('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', '<=', $endOfDay)
+    ->addClause('OR',
+    ['Visit_Outcome.Outcome_Email_Sent', 'IS NULL'],
+    ['Visit_Outcome.Outcome_Email_Sent', '=', 0]
+    )
     ->execute();
 
   error_log("institutionVisit: " . print_r($institutionVisit, TRUE));

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
@@ -55,6 +55,7 @@ function civicrm_api3_goonjcustom_urban_planned_visit_outcome_cron($params) {
     catch (\Exception $e) {
       \Civi::log()->info('Error processing visit', [
         'error' => $e->getMessage(),
+        'visit_id' => $visit['id'],
       ]);
     }
   }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
@@ -48,8 +48,6 @@ function civicrm_api3_goonjcustom_urban_planned_visit_outcome_cron($params) {
     )
     ->execute();
 
-  error_log("institutionVisit: " . print_r($institutionVisit, TRUE));
-
   foreach ($institutionVisit as $visit) {
     try {
       UrbanPlannedVisitService::sendOutcomeEmail($visit);

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanPlannedVisitOutcomeCron.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ */
+
+use Civi\Api4\EckEntity;
+use Civi\UrbanPlannedVisitService;
+
+/**
+ * Goonjcustom.UrbanPlannedVisitOutcomeCron API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_urban_planned_visit_outcome_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.UrbanPlannedVisit API.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_urban_planned_visit_outcome_cron($params) {
+  $returnValues = [];
+
+  $today = new DateTimeImmutable();
+  $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+
+  $institutionVisit = EckEntity::get('Institution_Visit', FALSE)
+    ->addSelect('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', 'Urban_Planned_Visit.Coordinating_Goonj_POC')
+    ->addWhere('Urban_Planned_Visit.Coordinating_Goonj_POC', 'IS NOT NULL')
+    ->addWhere('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', '<=', $endOfDay)
+    ->execute();
+
+  error_log("institutionVisit: " . print_r($institutionVisit, TRUE));
+
+  foreach ($institutionVisit as $visit) {
+    try {
+      UrbanPlannedVisitService::sendOutcomeEmail($visit);
+    }
+    catch (\Exception $e) {
+      \Civi::log()->info('Error processing visit', [
+        'error' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'urban_planned_visit_outcome_cron');
+}


### PR DESCRIPTION
Add Outcome email for visit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a service for sending outcome emails related to urban planned visits.
	- Added an API endpoint for processing urban planned visit outcomes.

- **Bug Fixes**
	- Implemented error handling for missing email addresses when sending outcome emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->