### PR TITLE
Handle Razorpay Subscription Cancellation Webhook in CiviCRM Extension

### DIFF
--- a/wp-content/civi-extensions/civirazorpay/CRM/Core/Civirazorpay/Payment/Razorpay.php
+++ b/wp-content/civi-extensions/civirazorpay/CRM/Core/Civirazorpay/Payment/Razorpay.php
@@ -454,6 +454,10 @@ class CRM_Core_Civirazorpay_Payment_Razorpay extends CRM_Core_Payment {
   private function processSubscriptionCancelled(array $event): void {
     $subscriptionData = $event['payload']['subscription']['entity'] ?? [];
 
+    \Civi::log()->debug(__METHOD__, [
+      'subscriptionData' => $subscriptionData
+    ]);
+
     if (empty($subscriptionData['id']) || empty($subscriptionData['status']) || $subscriptionData['status'] !== 'cancelled') {
       \Civi::log()->error('Invalid or incomplete Razorpay subscription cancellation event', [
         'event' => $event,


### PR DESCRIPTION
## Description

This PR introduces support for handling the `subscription.cancelled` webhook event from Razorpay in the CiviCRM Razorpay payment processor extension.

## Key Changes

- Added a new method `processSubscriptionCancelled` to handle the Razorpay `subscription.cancelled` webhook event.
- Updates the corresponding `ContributionRecur` record in CiviCRM:
- Marks the recurring contribution status as Cancelled.
- Sets the accurate `cancel_date` using the ended_at timestamp from Razorpay.
- Adds a `cancel_reason` indicating it was cancelled from the Razorpay Dashboard.
- Logs appropriate messages for successful updates and error scenarios for better traceability.

These changes ensure that cancellations initiated from the Razorpay Dashboard are accurately reflected in CiviCRM, maintaining consistency between both systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced handling for subscription cancellations from Razorpay, updating records accordingly.
  
- **Bug Fixes**
	- Enhanced webhook event handling to appropriately respond to subscription cancellation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->