### PR TITLE
Refactor Institution Material Contribution Service

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionMaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionMaterialContributionService.php
@@ -33,17 +33,14 @@ class InstitutionMaterialContributionService extends AutoSubscriber {
     if (!$data) {
       return;
     }
-
     $activityData = $data['Activity1'][0]['fields'] ?? [];
-    $activityDate = $activityData['activity_date_time'];
-    $brandingCampaignId = $activityData['Institution_Material_Contribution.Co_branding_Campaign'] ?? NULL;
-    $campaignId = $activityData['Institution_Material_Contribution.Campaign'] ?? NULL;
+    $activityDate = $activityData['Institution_Material_Contribution.Contribution_Date'];
+    $campaignId = $activityData['campaign_id'] ?? NULL;
     $description = $activityData['Institution_Material_Contribution.Description_of_Material_No_of_Bags_Material_'] ?? '';
     $deliveredBy = $activityData['Institution_Material_Contribution.Delivered_By_Name'] ?? '';
     $deliveredByContact = $activityData['Institution_Material_Contribution.Delivered_By_Contact'] ?? '';
     $organizationId = $data['Organization1'][0]['fields']['id'] ?? NULL;
-
-    $contacts = self::fetchContributionContacts($brandingCampaignId, $campaignId, $organizationId);
+    $contacts = self::fetchContributionContacts($campaignId, $organizationId);
 
     if (!empty($contacts)) {
       self::sendInstitutionMaterialContributionEmails($contacts, $description, $deliveredBy, $deliveredByContact, $activityDate);
@@ -53,43 +50,18 @@ class InstitutionMaterialContributionService extends AutoSubscriber {
   /**
    *
    */
-  private static function fetchContributionContacts($brandingCampaignId, $campaignId, $organizationId) {
+  private static function fetchContributionContacts($campaignId, $organizationId) {
     $contacts = [];
 
-    // Case 1: Co-Branding Campaign Contacts.
-    if ($brandingCampaignId) {
-      $contacts = self::getBranchWisePOCs($brandingCampaignId);
-    }
-    // Case 2: Campaign Institution POC.
-    elseif ($campaignId) {
+    // Case 1: Campaign Institution POC.
+    if ($campaignId) {
       $contacts = self::getCampaignInstitutionPOC($campaignId);
     }
-    // Case 3: Institution POC.
+    // Case 2: Institution POC.
     elseif ($organizationId) {
       $contacts = self::getInstitutionRelationships($organizationId);
     }
 
-    return $contacts;
-  }
-
-  /**
-   *
-   */
-  private static function getBranchWisePOCs($campaignId) {
-    $contacts = [];
-    $campaign = Campaign::get(TRUE)
-      ->addSelect('Additional_Details.Branch_Wise_POCs')
-      ->addWhere('id', '=', $campaignId)
-      ->execute()
-      ->first();
-
-    $branchWisePOCs = $campaign['Additional_Details.Branch_Wise_POCs'] ?? [];
-    foreach ($branchWisePOCs as $contactId) {
-      $contact = self::getContactDetails($contactId);
-      if ($contact) {
-        $contacts[$contact['email']] = $contact;
-      }
-    }
     return $contacts;
   }
 


### PR DESCRIPTION
We have removed the co-branded campaign and are now exclusively using the standard campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined handling of material contribution activity data.
	- Simplified method for fetching contribution contacts.

- **Bug Fixes**
	- Improved retrieval of campaign ID and contribution date from data sources.

- **Refactor**
	- Removed unnecessary complexity related to branding campaign ID.
	- Eliminated the `getBranchWisePOCs` method for clearer data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->