### PR TITLE
Remove Contact Tab For MMT Role

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/ContactSummaryViewService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/ContactSummaryViewService.php
@@ -30,6 +30,7 @@ class ContactSummaryViewService extends AutoSubscriber {
 
     $permissionsToHideTabs = [
       'account_team' => ['participant', 'activity', 'group', 'log', 'rel'],
+      'mmt' => ['participant', 'activity', 'group', 'log', 'rel', 'contribute'],
     ];
 
     $newTabs = $tabs;


### PR DESCRIPTION
removed all tabs under the Contact section, except for the Summary tab, for the MMT Role.