### PR TITLE
Use institutionCampId instead of campId in status update logic

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -62,7 +62,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
     if ($currentStatus !== $newStatus) {
       if ($newStatus === 'authorized') {
         $institutionCampId = $objectRef['id'] ?? NULL;
-        if ($campId === NULL) {
+        if ($institutionCampId === NULL) {
           return;
         }
 


### PR DESCRIPTION
Replaced the use of campId with institutionCampId in the updateInstitutionCampStatusAfterAuth method to ensure accurate status updates for institution collection camps.