### PR TITLE
Send the email for the visit guide and poc after authorization

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -70,7 +70,6 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       $visitTime = $visitData['Urban_Planned_Visit.What_time_do_you_wish_to_visit_'];
       $visitParticipation = $visitData['Urban_Planned_Visit.Number_of_people_accompanying_you'];
       $institutionName = $visitData['Urban_Planned_Visit.Institution_Name'];
-      error_log("institutionName: " . print_r($institutionName, TRUE));
 
       $goonjVisitGuideId = $objectRef['Urban_Planned_Visit.Visit_Guide'] ?? '';
 
@@ -95,7 +94,6 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       $coordinatingGoonjPocName = $coordinatingGoonjPoc['display_name'];
 
       $from = HelperService::getDefaultFromEmail();
-      error_log("from: " . print_r($from, TRUE));
 
       $activity = Activity::get(FALSE)
         ->addSelect('contact.display_name')
@@ -131,7 +129,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       'from' => $from,
       'toEmail' => $goonjVisitGuideEmail,
       'replyTo' => $from,
-      'html' => self::getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName, $institutionName),
+      'html' => self::getGoonjCoordPocAndVisitEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName, $institutionName),
       'cc' => $coordinatingGoonjPocEmail,
     ];
 
@@ -148,7 +146,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
   /**
    * Generate the email HTML content for Goonj Coordinating POC.
    */
-  private static function getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName, $institutionName) {
+  private static function getGoonjCoordPocAndVisitEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName, $institutionName) {
     $date = new \DateTime($visitDate);
     $dayOfWeek = $date->format('l');
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -89,47 +89,12 @@ class UrbanPlannedVisitService extends AutoSubscriber {
         ->execute()->single();
   
       $goonjCoordinatingGoonjPocEmail = $goonjCoordinatingGoonjPoc['email.email'];
-      $goonjCoordinatingGoonjPocName = $goonjCoordinatingGoonjPoc['display_name'];
+      $coordinatingGoonjPocName = $goonjCoordinatingGoonjPoc['display_name'];
   
       $from = HelperService::getDefaultFromEmail();
 
-      self::sendEmailToCoordinatingPoc($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjCoordinatingGoonjPocEmail, $coordinatingGoonjPocName, $from);
       self::sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail);
     }
-  }
-
-  /**
-   *
-   */
-  private static function sendEmailToCoordinatingPoc($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjCoordinatingGoonjPocEmail, $coordinatingGoonjPocName, $from) {
-    $emailToGoonjCoordPoc = EckEntity::get('Institution_Visit', FALSE)
-      ->addSelect('Urban_Planned_Visit.Email_To_Goonj_Coord_Poc')
-      ->addWhere('id', '=', $visitId)
-      ->execute()->single();
-
-    $isEmailSendToGoonjCoordPoc = $emailToGoonjCoordPoc['Urban_Planned_Visit.Email_To_Goonj_Coord_Poc'];
-
-    if ($isEmailSendToGoonjCoordPoc !== NULL) {
-      return;
-    }
-
-
-    $mailParamsExternalPoc = [
-      'subject' => 'You have been assigned for a Learning Journey at GCoC',
-      'from' => $from,
-      'toEmail' => $goonjCoordinatingGoonjPocEmail,
-      'replyTo' => $from,
-      'html' => self::getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName),
-    ];
-
-    $emailSendResultToCoordinatingGoonjPoc = \CRM_Utils_Mail::send($mailParamsExternalPoc);
-
-    // If ($emailSendResultToCoordinatingGoonjPoc) {
-    //   EckEntity::update('Institution_Visit', FALSE)
-    //     ->addValue('Urban_Planned_Visit.Email_To_Goonj_Coord_Poc', 1)
-    //     ->addWhere('id', '=', $visitId)
-    //     ->execute();
-    // }
   }
 
    /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -62,13 +62,14 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       }
 
       $visitData = EckEntity::get('Institution_Visit', FALSE)
-        ->addSelect('Urban_Planned_Visit.Number_of_people_accompanying_you', 'Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_')
+        ->addSelect('Urban_Planned_Visit.Number_of_people_accompanying_you', 'Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Institution_Name')
         ->addWhere('id', '=', $visitId)
         ->execute()->single();
 
       $visitDate = $visitData['Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj'];
       $visitTime = $visitData['Urban_Planned_Visit.What_time_do_you_wish_to_visit_'];
       $visitParticipation = $visitData['Urban_Planned_Visit.Number_of_people_accompanying_you'];
+      $institutionName = $visitData['Urban_Planned_Visit.Institution_Name'];
 
       $goonjVisitGuideId = $objectRef['Urban_Planned_Visit.Visit_Guide'] ?? '';
 
@@ -105,14 +106,14 @@ class UrbanPlannedVisitService extends AutoSubscriber {
 
       $individualName = $activity['contact.display_name'];
 
-      self::sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail, $coordinatingGoonjPocEmail, $individualName);
+      self::sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail, $coordinatingGoonjPocEmail, $individualName, $institutionName);
     }
   }
 
   /**
    *
    */
-  private static function sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail, $coordinatingGoonjPocEmail, $individualName) {
+  private static function sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail, $coordinatingGoonjPocEmail, $individualName, $institutionName) {
     $emailToGoonjVisitGuide = EckEntity::get('Institution_Visit', FALSE)
       ->addSelect('Urban_Planned_Visit.Email_To_Goonj_Visit_Guide',)
       ->addWhere('id', '=', $visitId)
@@ -129,7 +130,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       'from' => $from,
       'toEmail' => $goonjVisitGuideEmail,
       'replyTo' => $from,
-      'html' => self::getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName),
+      'html' => self::getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName, $institutionName),
       'cc' => $coordinatingGoonjPocEmail,
     ];
 
@@ -146,7 +147,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
   /**
    * Generate the email HTML content for Goonj Coordinating POC.
    */
-  private static function getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName) {
+  private static function getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $individualName, $institutionName) {
     $date = new \DateTime($visitDate);
     $dayOfWeek = $date->format('l');
 
@@ -158,7 +159,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
   <ul>
       <li><strong>Date:</strong> $visitDate, $dayOfWeek</li>
       <li><strong>Time:</strong> $visitTime</li>
-      <li><strong>Individual/Institute Name:</strong> [$individualName/Institute]</li>
+      <li><strong>Individual/Institute Name:</strong> [$individualName/$institutionName]</li>
       <li><strong>Number of Participants:</strong> $visitParticipation</li>
   </ul>
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -93,14 +93,14 @@ class UrbanPlannedVisitService extends AutoSubscriber {
   
       $from = HelperService::getDefaultFromEmail();
 
-      self::sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail);
+      self::sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail, $coordinatingGoonjPocEmail);
     }
   }
 
    /**
    *
    */
-  private static function sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail) {
+  private static function sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail, $coordinatingGoonjPocEmail) {
     $emailToGoonjVisitGuide = EckEntity::get('Institution_Visit', FALSE)
       ->addSelect('Urban_Planned_Visit.Email_To_Goonj_Visit_Guide',)
       ->addWhere('id', '=', $visitId)
@@ -118,6 +118,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       'toEmail' => $goonjVisitGuideEmail,
       'replyTo' => $from,
       'html' => self::getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName),
+      'cc' => $coordinatingGoonjPocEmail,
     ];
 
     $emailSendResultToVisitGuide = \CRM_Utils_Mail::send($mailParamsVisitGuide);

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -154,9 +154,11 @@ class UrbanPlannedVisitService extends AutoSubscriber {
 
   <p>Let’s work together to create a meaningful and enriching experience for our visitors!</p>
 
-  <p>Warm regards,</p>
-  <p>$coordinatingGoonjPocName</p>
-  <p>Team Goonj</p>
+  <p>
+    Warm regards,<br>
+    $coordinatingGoonjPocName<br>
+    Team Goonj
+  </p>
   ";
 
     return $html;

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -137,12 +137,12 @@ class UrbanPlannedVisitService extends AutoSubscriber {
 
     $emailSendResultToVisitGuide = \CRM_Utils_Mail::send($mailParamsVisitGuide);
 
-    // If ($emailSendResultToVisitGuide) {
-    //   EckEntity::update('Institution_Visit', FALSE)
-    //     ->addValue('Urban_Planned_Visit.Email_To_Goonj_Visit_Guide', 1)
-    //     ->addWhere('id', '=', $visitId)
-    //     ->execute();
-    // }
+    If ($emailSendResultToVisitGuide) {
+      EckEntity::update('Institution_Visit', FALSE)
+        ->addValue('Urban_Planned_Visit.Email_To_Goonj_Visit_Guide', 1)
+        ->addWhere('id', '=', $visitId)
+        ->execute();
+    }
   }
 
   /**

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -62,7 +62,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       }
 
       $visitData = EckEntity::get('Institution_Visit', FALSE)
-        ->addSelect('Urban_Planned_Visit.Number_of_people_accompanying_you', 'Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Institution_Name')
+        ->addSelect('Urban_Planned_Visit.Number_of_people_accompanying_you', 'Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Institution_Name')
         ->addWhere('id', '=', $visitId)
         ->execute()->single();
 
@@ -70,6 +70,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       $visitTime = $visitData['Urban_Planned_Visit.What_time_do_you_wish_to_visit_'];
       $visitParticipation = $visitData['Urban_Planned_Visit.Number_of_people_accompanying_you'];
       $institutionName = $visitData['Urban_Planned_Visit.Institution_Name'];
+      error_log("institutionName: " . print_r($institutionName, TRUE));
 
       $goonjVisitGuideId = $objectRef['Urban_Planned_Visit.Visit_Guide'] ?? '';
 
@@ -151,28 +152,36 @@ class UrbanPlannedVisitService extends AutoSubscriber {
     $date = new \DateTime($visitDate);
     $dayOfWeek = $date->format('l');
 
+    // Conditionally construct the Individual/Institute Name string.
+    $individualOrInstitute = $individualName;
+    error_log("individualOrInstitute: " . print_r($individualOrInstitute, TRUE));
+
+    if (!empty($institutionName)) {
+      $individualOrInstitute .= " / $institutionName";
+    }
+
     $html = "
-  <p>Dear $goonjVisitGuideName,</p>
+<p>Dear $goonjVisitGuideName,</p>
 
-  <p>A Learning Journey at our Goonj Center of Circularity (GCoC) has been confirmed, and you have been assigned for this visit as per the roster/availability. Details below:</p>
+<p>A Learning Journey at our Goonj Center of Circularity (GCoC) has been confirmed, and you have been assigned for this visit as per the roster/availability. Details below:</p>
 
-  <ul>
-      <li><strong>Date:</strong> $visitDate, $dayOfWeek</li>
-      <li><strong>Time:</strong> $visitTime</li>
-      <li><strong>Individual/Institute Name:</strong> [$individualName/$institutionName]</li>
-      <li><strong>Number of Participants:</strong> $visitParticipation</li>
-  </ul>
+<ul>
+    <li><strong>Date:</strong> $visitDate, $dayOfWeek</li>
+    <li><strong>Time:</strong> $visitTime</li>
+    <li><strong>Individual/Institute Name:</strong> $individualOrInstitute</li>
+    <li><strong>Number of Participants:</strong> $visitParticipation</li>
+</ul>
 
-  <p>Kindly ensure your presence during the above time slot. If you need to make any changes, please write back to me asap so we can adjust the schedule accordingly.</p>
+<p>Kindly ensure your presence during the above time slot. If you need to make any changes, please write back to me asap so we can adjust the schedule accordingly.</p>
 
-  <p>Let’s work together to create a meaningful and enriching experience for our visitors!</p>
+<p>Let’s work together to create a meaningful and enriching experience for our visitors!</p>
 
-  <p>
-    Warm regards,<br>
-    $coordinatingGoonjPocName<br>
-    Team Goonj
-  </p>
-  ";
+<p>
+  Warm regards,<br>
+  $coordinatingGoonjPocName<br>
+  Team Goonj
+</p>
+";
 
     return $html;
   }

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -82,14 +82,14 @@ class UrbanPlannedVisitService extends AutoSubscriber {
 
       $goonjCoordinatingPocId = $objectRef['Urban_Planned_Visit.Coordinating_Goonj_POC'] ?? '';
 
-      $goonjCoordinatingGoonjPoc = Contact::get(FALSE)
+      $coordinatingGoonjPoc = Contact::get(FALSE)
         ->addSelect('email.email', 'display_name', 'phone.phone_numeric')
         ->addJoin('Email AS email', 'LEFT')
         ->addWhere('id', '=', $goonjCoordinatingPocId)
         ->execute()->single();
   
-      $coordinatingGoonjPocEmail = $goonjCoordinatingGoonjPoc['email.email'];
-      $coordinatingGoonjPocName = $goonjCoordinatingGoonjPoc['display_name'];
+      $coordinatingGoonjPocEmail = $coordinatingGoonjPoc['email.email'];
+      $coordinatingGoonjPocName = $coordinatingGoonjPoc['display_name'];
   
       $from = HelperService::getDefaultFromEmail();
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -88,7 +88,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
         ->addWhere('id', '=', $goonjCoordinatingPocId)
         ->execute()->single();
   
-      $goonjCoordinatingGoonjPocEmail = $goonjCoordinatingGoonjPoc['email.email'];
+      $coordinatingGoonjPocEmail = $goonjCoordinatingGoonjPoc['email.email'];
       $coordinatingGoonjPocName = $goonjCoordinatingGoonjPoc['display_name'];
   
       $from = HelperService::getDefaultFromEmail();

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -135,7 +135,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
    /**
    *
    */
-  private static function sendEmailToVisitGuide($objectRef, $visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjVisitGuideId) {
+  private static function sendEmailToVisitGuide($objectRef, $visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjVisitGuideId, $goonjCoordinatingGoonjPocEmail, $goonjCoordinatingGoonjPocNam, $from, $goonjVisitGuideEmail) {
     $emailToGoonjVisitGuide = EckEntity::get('Institution_Visit', FALSE)
       ->addSelect('Urban_Planned_Visit.Email_To_Goonj_Visit_Guide',)
       ->addWhere('id', '=', $visitId)

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -93,15 +93,15 @@ class UrbanPlannedVisitService extends AutoSubscriber {
   
       $from = HelperService::getDefaultFromEmail();
 
-      self::sendEmailToCoordinatingPoc($objectRef, $visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjCoordinatingGoonjPocEmail, $goonjCoordinatingGoonjPocNam, $from);
-      self::sendEmailToVisitGuide($objectRef, $visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjVisitGuideId, $goonjCoordinatingGoonjPocEmail, $goonjCoordinatingGoonjPocNam, $from, $goonjVisitGuideEmail);
+      self::sendEmailToCoordinatingPoc($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjCoordinatingGoonjPocEmail, $coordinatingGoonjPocName, $from);
+      self::sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail);
     }
   }
 
   /**
    *
    */
-  private static function sendEmailToCoordinatingPoc($objectRef, $visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjCoordinatingGoonjPocEmail, $goonjCoordinatingGoonjPocNam, $from) {
+  private static function sendEmailToCoordinatingPoc($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjCoordinatingGoonjPocEmail, $coordinatingGoonjPocName, $from) {
     $emailToGoonjCoordPoc = EckEntity::get('Institution_Visit', FALSE)
       ->addSelect('Urban_Planned_Visit.Email_To_Goonj_Coord_Poc')
       ->addWhere('id', '=', $visitId)
@@ -119,7 +119,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       'from' => $from,
       'toEmail' => $goonjCoordinatingGoonjPocEmail,
       'replyTo' => $from,
-      'html' => self::getGoonjCoordPocEmailHtml($goonjCoordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName),
+      'html' => self::getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName),
     ];
 
     $emailSendResultToCoordinatingGoonjPoc = \CRM_Utils_Mail::send($mailParamsExternalPoc);
@@ -135,7 +135,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
    /**
    *
    */
-  private static function sendEmailToVisitGuide($objectRef, $visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $goonjVisitGuideId, $goonjCoordinatingGoonjPocEmail, $goonjCoordinatingGoonjPocNam, $from, $goonjVisitGuideEmail) {
+  private static function sendEmailToVisitGuide($visitId, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName, $coordinatingGoonjPocName, $from, $goonjVisitGuideEmail) {
     $emailToGoonjVisitGuide = EckEntity::get('Institution_Visit', FALSE)
       ->addSelect('Urban_Planned_Visit.Email_To_Goonj_Visit_Guide',)
       ->addWhere('id', '=', $visitId)
@@ -152,7 +152,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       'from' => $from,
       'toEmail' => $goonjVisitGuideEmail,
       'replyTo' => $from,
-      'html' => self::getGoonjCoordPocEmailHtml($goonjCoordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName),
+      'html' => self::getGoonjCoordPocEmailHtml($coordinatingGoonjPocName, $visitDate, $visitTime, $visitParticipation, $goonjVisitGuideName),
     ];
 
     $emailSendResultToVisitGuide = \CRM_Utils_Mail::send($mailParamsVisitGuide);


### PR DESCRIPTION
Send the email for the visit guide and poc after authorization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for sending authorization emails to external contacts and visit guides after database updates.
- **Bug Fixes**
	- Corrected the conditional statement in the existing email sending method for improved functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->