### PR TITLE
Reminder email to coord person

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToCoordPersonCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToCoordPersonCron.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @file
+ */
+
+use Civi\Api4\EckEntity;
+use Civi\UrbanPlannedVisitService;
+
+/**
+ * Goonjcustom.UrbanReminderEmailToCoordPersonCron API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_urban_reminder_email_to_coord_person_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.UrbanPlannedVisit API.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_urban_reminder_email_to_coord_person_cron($params) {
+  $returnValues = [];
+
+  $today = new DateTimeImmutable();
+  $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
+
+  $institutionVisit = EckEntity::get('Institution_Visit', FALSE)
+    ->addSelect('Urban_Planned_Visit.Visit_Guide', 'Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Number_of_people_accompanying_you')
+    ->addWhere('Urban_Planned_Visit.Visit_Guide', 'IS NOT NULL')
+    ->addWhere('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', '<=', $endOfDay)
+    ->addClause('OR',
+    ['Urban_Planned_Visit.Reminder_Email_To_Coord_Person', 'IS NULL'],
+    ['Urban_Planned_Visit.Reminder_Email_To_Coord_Person', '=', 0]
+    )
+    ->execute();
+
+  foreach ($institutionVisit as $visit) {
+    try {
+      UrbanPlannedVisitService::sendReminderEmailToCoordPerson($visit);
+    }
+    catch (\Exception $e) {
+      \Civi::log()->info('Error processing visit', [
+        'error' => $e->getMessage(),
+        'visit_id' => $visit['id'],
+      ]);
+    }
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'urban_reminder_email_to_coord_person_cron');
+}

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToCoordPersonCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToCoordPersonCron.php
@@ -39,7 +39,7 @@ function civicrm_api3_goonjcustom_urban_reminder_email_to_coord_person_cron($par
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
   $institutionVisit = EckEntity::get('Institution_Visit', FALSE)
-    ->addSelect('Urban_Planned_Visit.Visit_Guide', 'Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Number_of_people_accompanying_you')
+    ->addSelect('Urban_Planned_Visit.Visit_Guide', 'Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Number_of_people_accompanying_you', 'Urban_Planned_Visit.Institution_Name')
     ->addWhere('Urban_Planned_Visit.Visit_Guide', 'IS NOT NULL')
     ->addWhere('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', '<=', $endOfDay)
     ->addClause('OR',


### PR DESCRIPTION
Reminder email to coord person

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new CiviCRM API endpoint for sending reminder emails to coordinating persons for urban planned visits.
	- Implemented automatic email reminder functionality for scheduled visits, including personalized email content.

- **Chores**
	- Created a new extension API file to handle urban visit reminder email processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->