### PR TITLE
Update the organization status

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateOrganizationStatusCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UpdateOrganizationStatusCron.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ */
+
+use Civi\Api4\Contact;
+use Civi\InstitutionService;
+
+/**
+ * Goonjcustom.UpdateOrganizationStatusCron API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ *
+ * @return void
+ */
+function _civicrm_api3_goonjcustom_update_organization_status_cron_spec(&$spec) {
+  // There are no parameters for the Goonjcustom cron.
+}
+
+/**
+ * Goonjcustom.UpdateOrganizationStatus API.
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_goonjcustom_update_organization_status_cron($params) {
+  $returnValues = [];
+
+  $contacts = Contact::get(TRUE)
+    ->addWhere('contact_sub_type', '=', 'Institute')
+    ->execute();
+
+  foreach ($contacts as $contact) {
+    try {
+      InstitutionService::updateOrganizationStatus($contact);
+    }
+    catch (\Exception $e) {
+      \Civi::log()->info('Error processing visit', [
+        'error' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  return civicrm_api3_create_success($returnValues, $params, 'Goonjcustom', 'update_organization_status_cron');
+}


### PR DESCRIPTION
Update the organization's status
1. When there is an activity associated with the institute, the status should change from initial to Active.
2. When there is no new activity for 12 months since the last activity the status should be set to Inactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an automated system to update organization status based on their latest activity date
	- Implemented a cron job to periodically check and update organization statuses
	- Automatically marks organizations as 'Inactive' if no activity is detected for over a year

- **Bug Fixes**
	- Introduced error handling to prevent disruptions during status update process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->