### PR TITLE
Fix: Remove extraneous bracket in DateTime parsing

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/InstitutionCollectionCamp.php
+++ b/wp-content/civi-extensions/goonjcustom/CRM/Goonjcustom/Token/InstitutionCollectionCamp.php
@@ -64,7 +64,7 @@ class CRM_Goonjcustom_Token_InstitutionCollectionCamp extends AbstractTokenSubsc
       case 'date':
       case 'time':
       case 'type':
-        $start = new DateTime($collectionSource['Institution_Collection_Camp_Intent.Collections_will_start_on_Date_]']);
+        $start = new DateTime($collectionSource['Institution_Collection_Camp_Intent.Collections_will_start_on_Date_']);
         $end = new DateTime($collectionSource['Institution_Collection_Camp_Intent.Collections_will_end_on_Date__']);
 
         if ($field === 'type') {


### PR DESCRIPTION
Removes the extra closing bracket in the DateTime object instantiation for `Collections_will_start_on_Date_`