### PR TITLE
Remove tags from account team

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/ContactSummaryViewService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/ContactSummaryViewService.php
@@ -29,7 +29,7 @@ class ContactSummaryViewService extends AutoSubscriber {
     }
 
     $permissionsToHideTabs = [
-      'account_team' => ['participant', 'activity', 'group', 'log', 'rel'],
+      'account_team' => ['participant', 'activity', 'group', 'log', 'rel', 'tag'],
       'mmt' => ['participant', 'activity', 'group', 'log', 'rel', 'contribute'],
     ];
 


### PR DESCRIPTION
Remove tags from account team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced contact view permissions by hiding the 'tag' tab for users without 'account_team' access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->