### PR TITLE
Hide navigation bar for head office

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
@@ -62,6 +62,14 @@ class NavigationPermissionService extends AutoSubscriber {
           'Individuals'
         ],
       ],
+      'ho_account' => [
+        'hide_menus' => [
+          'Urban Visit',
+          'Account: Goonj Offices',
+          'Volunteers',
+          'Institute',
+        ],
+      ],
     ];
 
     foreach ($roleMenuMapping as $role => $menuConfig) {


### PR DESCRIPTION
Hide navigation bar for head office

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added navigation menu visibility controls for a new user role (`ho_account`)
  - Restricted access to specific menu items for the new role, including 'Urban Visit', 'Account: Goonj Offices', 'Volunteers', and 'Institute'

<!-- end of auto-generated comment: release notes by coderabbit.ai -->