### PR TITLE
Hide contribution navigation tab for account team

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
@@ -43,7 +43,8 @@ class NavigationPermissionService extends AutoSubscriber {
           'Induction Tab',
           'Volunteers',
           'Urban Visit',
-          'Individuals'
+          'Individuals',
+          'Contributions'
         ],
       ],
       'mmt' => [


### PR DESCRIPTION
Hide contribution navigation tab for account team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated navigation permissions to hide 'Contributions' menu for account team roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->