### PR TITLE
Remove unnecessary fonts

### DIFF
--- a/wp-content/themes/goonj-crm/theme.json
+++ b/wp-content/themes/goonj-crm/theme.json
@@ -19,6 +19,11 @@
 		"typography": {
 			"fontFamilies": [
 				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"name": "System Font",
+					"slug": "system-font"
+				},
+				{
 					"fontFace": [
 						{
 							"fontFamily": "\"Open Sans\"",

--- a/wp-content/themes/goonj-crm/theme.json
+++ b/wp-content/themes/goonj-crm/theme.json
@@ -19,113 +19,6 @@
 		"typography": {
 			"fontFamilies": [
 				{
-					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-					"name": "System Font",
-					"slug": "system-font"
-				},
-				{
-					"fontFace": [
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/XRXI3I6Li01BKofiOc5wtlZ2di8HDLshRTY9jo7eTWk.woff2"
-							]
-						},
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "normal",
-							"fontWeight": "700",
-							"src": [
-								"file:./assets/fonts/XRXI3I6Li01BKofiOc5wtlZ2di8HDFwmRTY9jo7eTWk.woff2"
-							]
-						},
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "normal",
-							"fontWeight": "900",
-							"src": [
-								"file:./assets/fonts/XRXI3I6Li01BKofiOc5wtlZ2di8HDBImRTY9jo7eTWk.woff2"
-							]
-						},
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "italic",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/XRXK3I6Li01BKofIMPyPbj8d7IEAGXNirXA3j6zbXWnoeg.woff2"
-							]
-						},
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "italic",
-							"fontWeight": "700",
-							"src": [
-								"file:./assets/fonts/XRXK3I6Li01BKofIMPyPbj8d7IEAGXNiSnc3j6zbXWnoeg.woff2"
-							]
-						},
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "italic",
-							"fontWeight": "900",
-							"src": [
-								"file:./assets/fonts/XRXK3I6Li01BKofIMPyPbj8d7IEAGXNiBHc3j6zbXWnoeg.woff2"
-							]
-						},
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "normal",
-							"fontWeight": "300",
-							"src": [
-								"file:./assets/fonts/XRXI3I6Li01BKofiOc5wtlZ2di8HDOUhRTY9jo7eTWk.woff2"
-							]
-						},
-						{
-							"fontFamily": "Nunito",
-							"fontStyle": "italic",
-							"fontWeight": "300",
-							"src": [
-								"file:./assets/fonts/XRXK3I6Li01BKofIMPyPbj8d7IEAGXNi83A3j6zbXWnoeg.woff2"
-							]
-						}
-					],
-					"fontFamily": "Nunito, sans-serif",
-					"name": "Nunito",
-					"slug": "nunito"
-				},
-				{
-					"fontFace": [
-						{
-							"fontFamily": "\"AR One Sans\"",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": "https://goonj-crm.staging.coloredcow.com/wp-content/uploads/fonts/TUZezwhrmbFp0Srr_tH6fv6RcUejHO_u7GF5aXfv-U2QzBLF6gslWn_9DWg3no5mBF4.woff2"
-						},
-						{
-							"fontFamily": "\"AR One Sans\"",
-							"fontStyle": "normal",
-							"fontWeight": "500",
-							"src": "https://goonj-crm.staging.coloredcow.com/wp-content/uploads/fonts/TUZezwhrmbFp0Srr_tH6fv6RcUejHO_u7GF5aXfv-U2QzBLF6gslWk39DWg3no5mBF4.woff2"
-						},
-						{
-							"fontFamily": "\"AR One Sans\"",
-							"fontStyle": "normal",
-							"fontWeight": "600",
-							"src": "https://goonj-crm.staging.coloredcow.com/wp-content/uploads/fonts/TUZezwhrmbFp0Srr_tH6fv6RcUejHO_u7GF5aXfv-U2QzBLF6gslWqH6DWg3no5mBF4.woff2"
-						},
-						{
-							"fontFamily": "\"AR One Sans\"",
-							"fontStyle": "normal",
-							"fontWeight": "700",
-							"src": "https://goonj-crm.staging.coloredcow.com/wp-content/uploads/fonts/TUZezwhrmbFp0Srr_tH6fv6RcUejHO_u7GF5aXfv-U2QzBLF6gslWpj6DWg3no5mBF4.woff2"
-						}
-					],
-					"fontFamily": "\"AR One Sans\", sans-serif",
-					"name": "AR One Sans",
-					"slug": "ar-one-sans"
-				},
-				{
 					"fontFace": [
 						{
 							"fontFamily": "\"Open Sans\"",
@@ -212,27 +105,27 @@
 		"blocks": {
 			"core/heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--nunito)"
+					"fontFamily": "var(--wp--preset--font-family--open-sans)"
 				}
 			},
 			"core/list": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--nunito)"
+					"fontFamily": "var(--wp--preset--font-family--open-sans)"
 				}
 			},
 			"core/list-item": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--nunito)"
+					"fontFamily": "var(--wp--preset--font-family--open-sans)"
 				}
 			},
 			"core/paragraph": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--nunito)"
+					"fontFamily": "var(--wp--preset--font-family--open-sans)"
 				}
 			},
 			"core/query-pagination": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--nunito)"
+					"fontFamily": "var(--wp--preset--font-family--open-sans)"
 				}
 			}
 		}


### PR DESCRIPTION
**Remove unnecessary fonts**

Here I have removed unnecessary fonts from the site to remove these fonts I have taken two steps:
1. Remove font from the `theme.json` file. The removed font are Nunito and AR One Sans
3. Remove font from WordPress Site Editor (under Appearance > Editor) https://goonj-crm.staging.coloredcow.com/wp-admin/site-editor.php?return=https%3A%2F%2Fgoonj-crm.staging.coloredcow.com%2Fwp-admin%2Fthemes.php&canvas=edit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Typography Updates**
  - Removed font definitions for "Nunito" and "AR One Sans"
  - Updated default font for multiple core blocks from "Nunito" to "Open Sans"
  - Applies changes to headings, lists, paragraphs, and query pagination components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->