### PR TITLE
handle null case

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionReceiptGenerationService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionReceiptGenerationService.php
@@ -139,7 +139,11 @@ class InstitutionReceiptGenerationService extends AutoSubscriber {
   /**
    * Generate the email body for the acknowledgment.
    */
-  private static function generateEmailBody(string $institutionPOCName, string $goonjCoordinatorEmail, string $goonjCoordinatorPhone) {
+  private static function generateEmailBody(?string $institutionPOCName, ?string $goonjCoordinatorEmail, ?string $goonjCoordinatorPhone): string {
+    $institutionPOCName = $institutionPOCName ?? '';
+    $goonjCoordinatorEmail = $goonjCoordinatorEmail ?? '';
+    $goonjCoordinatorPhone = $goonjCoordinatorPhone ?? '';
+
     return "
       <html>
           <head>


### PR DESCRIPTION
Handle the case where $institutionPOCName, $goonjCoordinatorEmail and $goonjCoordinatorPhone return null value