### PR TITLE
Do not send email on urban visit

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -313,7 +313,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
       $from = HelperService::getDefaultFromEmail();
 
       $mailParamsExternalPoc = [
-        'subject' => $externalCoordinatingGoonjPocName . ', your Learning Journey is Scheduled!',
+        'subject' => $externalCoordinatingGoonjPocName . ', your visit to Goonj is Scheduled!',
         'from' => $from,
         'toEmail' => $externalCoordinatingGoonjPocEmail,
         'replyTo' => $from,
@@ -344,7 +344,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
     <p>Thank you for coordinating the learning journey at Goonj. Below are the details:</p>
 
     <p>
-        Thank you for choosing to explore Goonj through a learning journey at Goonj Center of Circularity (GCOC) ! Your visit is scheduled as per the below details :
+        Thank you for choosing to explore Goonj through a <strong>learning journey at Goonj Center of Circularity</strong>. Your visit is scheduled as per the below details :
     </p>
     <ul>
         <li><strong>At:</strong> $visitAtName </li>

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -245,8 +245,8 @@ class UrbanPlannedVisitService extends AutoSubscriber {
         return;
       }
 
-      $sendEmail = $objectRef['Urban_Planned_Visit.Send_Email'] ?? NULL;
-      if ($sendEmail !== NULL) {
+      $skipEmail = $objectRef['Urban_Planned_Visit.Send_Email'] ?? false;
+      if ($skipEmail) {
         return;
       }
 
@@ -625,7 +625,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
     $from = HelperService::getDefaultFromEmail();
 
     $reminderMailParamsExternalPoc = [
-      'subject' => $externalCoordinatingGoonjPocName . ', your Learning Journey is scheduled for today !',
+      'subject' => $externalCoordinatingGoonjPocName . ', your visit to Goonj is scheduled for today !',
       'from' => $from,
       'toEmail' => $externalCoordinatingGoonjPocEmail,
       'replyTo' => $from,

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -590,6 +590,10 @@ class UrbanPlannedVisitService extends AutoSubscriber {
    */
   public static function sendReminderEmailToExtCoordPoc($visit) {
     $externalCoordinatingPocId = $visit['Urban_Planned_Visit.External_Coordinating_PoC'] ?? '';
+    $skipEmail = $visit['Urban_Planned_Visit.Send_Email'] ?? false;
+    if ($skipEmail) {
+      return;
+    }
 
     $externalCoordinatingGoonjPoc = Contact::get(FALSE)
       ->addSelect('email.email', 'display_name', 'phone.phone_numeric')

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -789,6 +789,11 @@ class UrbanPlannedVisitService extends AutoSubscriber {
    *
    */
   public static function sendFeedbackEmailToExtCoordPoc($visit) {
+    $skipEmail = $visit['Urban_Planned_Visit.Send_Email'] ?? false;
+    if ($skipEmail) {
+      return;
+    }
+
     $emailToExtCoordPoc = EckEntity::get('Institution_Visit', FALSE)
       ->addSelect('Visit_Feedback.Feedback_Email_Sent')
       ->addWhere('id', '=', $visit['id'])

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -245,6 +245,11 @@ class UrbanPlannedVisitService extends AutoSubscriber {
         return;
       }
 
+      $sendEmail = $objectRef['Urban_Planned_Visit.Send_Email'] ?? NULL;
+      if ($sendEmail !== NULL) {
+        return;
+      }
+
       $emailToExtCoordPoc = EckEntity::get('Institution_Visit', FALSE)
         ->addSelect('Urban_Planned_Visit.Email_To_Ext_Coord_Poc')
         ->addWhere('id', '=', $visitId)

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanFeedbackCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanFeedbackCron.php
@@ -39,7 +39,7 @@ function civicrm_api3_goonjcustom_urban_feedback_cron($params) {
   $nextDay = $today->modify('+1 day')->setTime(0, 0, 0)->format('Y-m-d H:i:s');
 
   $institutionVisit = EckEntity::get('Institution_Visit', FALSE)
-    ->addSelect('Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.External_Coordinating_PoC')
+    ->addSelect('Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.External_Coordinating_PoC', 'Urban_Planned_Visit.Send_Email')
     ->addWhere('Urban_Planned_Visit.External_Coordinating_PoC', 'IS NOT NULL')
     ->addWhere('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', '<', $nextDay)
     ->addClause('OR',

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToExternalCoordCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToExternalCoordCron.php
@@ -39,7 +39,7 @@ function civicrm_api3_goonjcustom_urban_reminder_email_to_external_coord_cron($p
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
   $institutionVisit = EckEntity::get('Institution_Visit', FALSE)
-    ->addSelect('Urban_Planned_Visit.External_Coordinating_PoC', 'Urban_Planned_Visit.Which_Goonj_Processing_Center_do_you_wish_to_visit_', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Coordinating_Goonj_POC')
+    ->addSelect('Urban_Planned_Visit.External_Coordinating_PoC', 'Urban_Planned_Visit.Which_Goonj_Processing_Center_do_you_wish_to_visit_', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.Skip_Email')
     ->addWhere('Urban_Planned_Visit.External_Coordinating_PoC', 'IS NOT NULL')
     ->addWhere('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', '<=', $endOfDay)
     ->addClause('OR',

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToExternalCoordCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/UrbanReminderEmailToExternalCoordCron.php
@@ -39,7 +39,7 @@ function civicrm_api3_goonjcustom_urban_reminder_email_to_external_coord_cron($p
   $endOfDay = $today->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
   $institutionVisit = EckEntity::get('Institution_Visit', FALSE)
-    ->addSelect('Urban_Planned_Visit.External_Coordinating_PoC', 'Urban_Planned_Visit.Which_Goonj_Processing_Center_do_you_wish_to_visit_', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.Skip_Email')
+    ->addSelect('Urban_Planned_Visit.External_Coordinating_PoC', 'Urban_Planned_Visit.Which_Goonj_Processing_Center_do_you_wish_to_visit_', 'Urban_Planned_Visit.What_time_do_you_wish_to_visit_', 'Urban_Planned_Visit.Coordinating_Goonj_POC', 'Urban_Planned_Visit.Send_Email')
     ->addWhere('Urban_Planned_Visit.External_Coordinating_PoC', 'IS NOT NULL')
     ->addWhere('Urban_Planned_Visit.When_do_you_wish_to_visit_Goonj', '<=', $endOfDay)
     ->addClause('OR',


### PR DESCRIPTION
Do not send email on urban visit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced email sending logic for Urban Planned Visit service to prevent unnecessary email notifications based on specific conditions.
	- Updated the subject line of the email sent to external coordinating POC for improved clarity.
- **New Features**
	- Expanded data retrieval capabilities by adding a new field to the API for Urban Planned Visits, enhancing the information available for processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->