### PR TITLE
hide action and edit button for mmt role

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
@@ -15,7 +15,21 @@ class NavigationPermissionService extends AutoSubscriber {
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_navigationMenu' => ['hideNavForRoles'],
+      '&hook_civicrm_pageRun' => 'hideButtonsForMMT',
     ];
+  }
+
+  /**
+   *
+   */
+  public function hideButtonsForMMT(&$page) {
+    if ($page->getVar('_name') === 'CRM_Contact_Page_View_Summary') {
+      if (\CRM_Core_Permission::check('mmt') && !\CRM_Core_Permission::check('admin')) {
+        \CRM_Core_Resources::singleton()->addScript("
+              document.querySelectorAll('.crm-actions-ribbon').forEach(el => el.style.display = 'none');
+          ");
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
checks permissions and hides specific elements on the "Contact Summary" page for a mmt role