### PR TITLE
fix(*) share outcome link

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/templates/CRM/Goonjcustom/Form/GoonjActivitiesLinks.tpl
+++ b/wp-content/civi-extensions/goonjcustom/templates/CRM/Goonjcustom/Form/GoonjActivitiesLinks.tpl
@@ -7,10 +7,10 @@
 {/foreach}
 
 {if $goonjActivitiesLinks}
-  {foreach from=$goonjActivitiesLinks item=goonjActivitiesLinks}
+  {foreach from=$goonjActivitiesLinks item=goonjActivityLink}
     <div class="crm-section">
-      <div class="label">{$goonjActivitiesLinks.label}</div>
-      <div class="content"><a href="{$goonjActivitiesLinks.url}">{$goonjActivitiesLinks.url}</a></div>
+      <div class="label">{$goonjActivityLink.label}</div>
+      <div class="content"><a href="{$goonjActivityLink.url}">{$goonjActivityLink.url}</a></div>
       <div class="clear"></div>
     </div>
   {/foreach}


### PR DESCRIPTION
Changed the item variable in the second foreach loop from goonjActivitiesLinks to goonjActivityLink to avoid conflict with the from variable.
Ensured consistent naming for clarity (goonjActivityLink represents a single item in goonjActivitiesLinks)