### PR TITLE
Import opt out contacts

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -1,126 +1,135 @@
 <?php
 
 /**
+ * @file
  * CLI Script to Opt Out Contacts and Add to Group via CSV in CiviCRM.
  *
  * Usage:
- *   cv php:script opt-out-contacts.php
+ *   cv php:script opt-out-contacts.php.
  */
 
 use Civi\Api4\Email;
 use Civi\Api4\Contact;
-use Civi\Api4\GroupContact;
 
 if (php_sapi_name() != 'cli') {
-    exit("This script can only be run from the command line.\n");
+  exit("This script can only be run from the command line.\n");
 }
 
-// Configuration
-define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (5).csv'); // Replace with your CSV file path
-define('GROUP_ID', 1234); // Replace with the ID of the group to add contacts to
+// Configuration.
+// Replace with your CSV file path.
+define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (5).csv');
+// Replace with the ID of the group to add contacts to.
+define('GROUP_ID', 1234);
 
 /**
  * Reads email addresses from the provided CSV file.
  *
  * @param string $filePath Path to the CSV file.
+ *
  * @return array List of email addresses.
+ *
  * @throws Exception If the file is not readable or the 'email' column is missing.
  */
-// In the readContactsFromCsv function, you can check for 'Do Not Email' column value
+
+/**
+ * In the readContactsFromCsv function, you can check for 'Do Not Email' column value.
+ */
 function readContactsFromCsv(string $filePath): array {
-    if (!file_exists($filePath) || !is_readable($filePath)) {
-        throw new Exception("CSV file not found or not readable: $filePath");
-    }
+  if (!file_exists($filePath) || !is_readable($filePath)) {
+    throw new Exception("CSV file not found or not readable: $filePath");
+  }
 
-    $contacts = [];
-    if (($handle = fopen($filePath, 'r')) !== false) {
-        $header = fgetcsv($handle, 1000, ',');
-        if (in_array('email', $header)) {
-            while (($data = fgetcsv($handle, 1000, ',')) !== false) {
-                $row = array_combine($header, $data);
-                
-                // Check if the 'Do Not Email' column indicates opt-out
-                if (isset($row['Do Not Email (Opt out contact)']) && 
-                    strtolower($row['Do Not Email (Opt out contact)']) == 'yes') {
-                    
-                    // Clean email by trimming any extra spaces
-                    $email = trim($row['email']);
-                    $contacts[] = $email;
-                }
-            }
-        } else {
-            throw new Exception("Error: 'email' column not found in CSV.");
+  $contacts = [];
+  if (($handle = fopen($filePath, 'r')) !== FALSE) {
+    $header = fgetcsv($handle, 1000, ',');
+    if (in_array('email', $header)) {
+      while (($data = fgetcsv($handle, 1000, ',')) !== FALSE) {
+        $row = array_combine($header, $data);
+
+        // Check if the 'Do Not Email' column indicates opt-out.
+        if (isset($row['Do Not Email (Opt out contact)']) &&
+              strtolower($row['Do Not Email (Opt out contact)']) == 'yes') {
+
+          // Clean email by trimming any extra spaces.
+          $email = trim($row['email']);
+          $contacts[] = $email;
         }
-        fclose($handle);
+      }
     }
+    else {
+      throw new Exception("Error: 'email' column not found in CSV.");
+    }
+    fclose($handle);
+  }
 
-    return $contacts;
+  return $contacts;
 }
 
-// Improved query to ensure case-insensitive matching
+/**
+ * Improved query to ensure case-insensitive matching.
+ */
 function optOutContactByEmail(string $email): void {
-    try {
-        // Log the email being processed for debugging
-        error_log("Processing email: $email");
+  try {
+    // Log the email being processed for debugging.
+    error_log("Processing email: $email");
 
-        // Find contact by email with case-insensitive search
-        $result = Email::get(TRUE)
-            ->addSelect('contact_id')
-            ->addWhere('email', '=',  $email)
-            ->execute();
+    // Find contact by email with case-insensitive search.
+    $result = Email::get(TRUE)
+      ->addSelect('contact_id')
+      ->addWhere('email', '=', $email)
+      ->execute();
 
-        error_log("Result: " . print_r($result, TRUE));
+    error_log("Result: " . print_r($result, TRUE));
 
-        // If email is found, process the contact
-            $contactId = $result['contact_id'];
+    // If email is found, process the contact.
+    $contactId = $result['contact_id'];
 
-            // Optionally, log the contact ID
-            error_log("Contact found with ID: $contactId");
+    // Optionally, log the contact ID.
+    error_log("Contact found with ID: $contactId");
 
-            // Opt out the contact (update the contact status or attributes)
-            Contact::update(TRUE)
-                ->addWhere('id', '=', $contactId)
-                ->addValue('is_opt_out', TRUE)
-                ->execute();
+    // Opt out the contact (update the contact status or attributes)
+    Contact::update(TRUE)
+      ->addWhere('id', '=', $contactId)
+      ->addValue('is_opt_out', TRUE)
+      ->execute();
 
-            // // Optionally, add the contact to the group
-            // GroupContact::create(TRUE)
-            //     ->addValue('contact_id', $contactId)
-            //     ->addValue('group_id', GROUP_ID)
-            //     ->addValue('status', 'Added')
-            //     ->execute();
-
-            error_log("Successfully opted out contact with email $email (ID $contactId) and added to group.");
-    } catch (Exception $e) {
-        error_log("Error processing email $email: " . $e->getMessage());
-    }
+    // // Optionally, add the contact to the group
+    // GroupContact::create(TRUE)
+    //     ->addValue('contact_id', $contactId)
+    //     ->addValue('group_id', GROUP_ID)
+    //     ->addValue('status', 'Added')
+    //     ->execute();
+    error_log("Successfully opted out contact with email $email (ID $contactId) and added to group.");
+  }
+  catch (Exception $e) {
+    error_log("Error processing email $email: " . $e->getMessage());
+  }
 }
-
-
 
 /**
  * Main function to process the CSV and update contacts.
  */
 function main(): void {
-    try {
-        echo "=== Starting Opt-Out Process ===\n";
-        $emails = readContactsFromCsv(CSV_FILE_PATH);
-        error_log("All emails to process: " . print_r($emails, TRUE)); // Log all emails read from CSV
+  try {
+    echo "=== Starting Opt-Out Process ===\n";
+    $emails = readContactsFromCsv(CSV_FILE_PATH);
+    // Log all emails read from CSV.
+    error_log("All emails to process: " . print_r($emails, TRUE));
 
-        if (empty($emails)) {
-            echo "No emails to process.\n";
-            return;
-        }
-
-        foreach ($emails as $email) {
-            optOutContactByEmail($email);
-        }
-        echo "=== Opt-Out Process Completed ===\n";
-    } catch (Exception $e) {
-        echo "Error: " . $e->getMessage() . "\n";
+    if (empty($emails)) {
+      echo "No emails to process.\n";
+      return;
     }
+
+    foreach ($emails as $email) {
+      optOutContactByEmail($email);
+    }
+    echo "=== Opt-Out Process Completed ===\n";
+  }
+  catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+  }
 }
 
-
-// Run the main function
+// Run the main function.
 main();

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * CLI Script to Opt Out Contacts and Add to Group via CSV in CiviCRM.
+ *
+ * Usage:
+ *   cv php:script opt-out-contacts.php
+ */
+
+use Civi\Api4\Email;
+use Civi\Api4\Contact;
+use Civi\Api4\GroupContact;
+
+if (php_sapi_name() != 'cli') {
+    exit("This script can only be run from the command line.\n");
+}
+
+// Configuration
+define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (4).csv'); // Replace with your CSV file path
+define('GROUP_ID', 1); // Replace with the ID of the group to add contacts to
+
+/**
+ * Reads email addresses from the provided CSV file.
+ *
+ * @param string $filePath Path to the CSV file.
+ * @return array List of email addresses.
+ * @throws Exception If the file is not readable or the 'email' column is missing.
+ */
+// In the readContactsFromCsv function, you can check for 'Do Not Email' column value
+function readContactsFromCsv(string $filePath): array {
+    if (!file_exists($filePath) || !is_readable($filePath)) {
+        throw new Exception("CSV file not found or not readable: $filePath");
+    }
+
+    $contacts = [];
+    if (($handle = fopen($filePath, 'r')) !== false) {
+        $header = fgetcsv($handle, 1000, ',');
+        if (in_array('email', $header)) {
+            while (($data = fgetcsv($handle, 1000, ',')) !== false) {
+                error_log("Raw CSV Data: " . print_r($data, TRUE)); // Log each row from CSV
+
+                $row = array_combine($header, $data);
+
+                // Check if the 'Do Not Email' column indicates opt-out
+                if (isset($row['Do Not Email (Opt out contact)']) && 
+                    strtolower($row['Do Not Email (Opt out contact)']) == 'yes') {
+                    // Add contact to list if they should be opted out
+                    $contacts[] = $row['email'];
+                }
+            }
+        } else {
+            throw new Exception("Error: 'email' column not found in CSV.");
+        }
+        fclose($handle);
+    }
+
+    return $contacts;
+}
+
+
+/**
+ * Finds a contact by email, opts them out, and adds them to the specified group.
+ *
+ * @param string $email The email address of the contact.
+ * @return void
+ */
+function optOutContactByEmail(string $email): void {
+    try {
+        // Log the email being processed for debugging
+        echo "Processing email: $email\n";
+
+        // Find contact by email with case-insensitive query
+        $result = Email::get()
+            ->addSelect('contact_id')
+            ->addWhere('LOWER(email)', '=', strtolower($email)) // Case-insensitive search
+            ->execute();
+            error_log("result: " . print_r($result, TRUE));
+
+        if (count($result) > 0) {
+            $contactId = $result[0]['contact_id'];
+
+            // Opt out the contact
+            Contact::update()
+                ->addWhere('id', '=', $contactId)
+                ->setValue('is_opt_out', 1)
+                ->execute();
+
+            // Add the contact to the group
+            GroupContact::create()
+                ->addValue('contact_id', $contactId)
+                ->addValue('group_id', GROUP_ID)
+                ->addValue('status', 'Added')
+                ->execute();
+
+            echo "Successfully opted out contact with email $email (ID $contactId) and added to group.\n";
+        } else {
+            echo "Contact with email $email not found.\n";
+        }
+    } catch (Exception $e) {
+        echo "Error processing email $email: " . $e->getMessage() . "\n";
+    }
+}
+
+
+/**
+ * Main function to process the CSV and update contacts.
+ */
+function main(): void {
+    try {
+        echo "=== Starting Opt-Out Process ===\n";
+        $emails = readContactsFromCsv(CSV_FILE_PATH);
+        error_log("emails: " . print_r($emails, TRUE)); // Log all emails read from CSV
+
+        if (empty($emails)) {
+            echo "No emails to process.\n";
+            return;
+        }
+
+        foreach ($emails as $email) {
+            optOutContactByEmail($email);
+        }
+        echo "=== Opt-Out Process Completed ===\n";
+    } catch (Exception $e) {
+        echo "Error: " . $e->getMessage() . "\n";
+    }
+}
+
+
+// Run the main function
+main();

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -15,7 +15,7 @@ if (php_sapi_name() != 'cli') {
 
 // Configuration.
 // Replace with your CSV file path.
-define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (6).csv');
+define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (7).csv');
 // Replace with the ID of the group to add contacts to.
 define('GROUP_ID', 69);
 
@@ -101,7 +101,6 @@ function main(): void {
   try {
     echo "=== Starting Opt-Out Process ===\n";
     $emails = readContactsFromCsv(CSV_FILE_PATH);
-    error_log("All emails to process: " . print_r($emails, TRUE));
 
     if (empty($emails)) {
       return;

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -4,8 +4,6 @@
  * @file
  * CLI Script to Opt Out Contacts and Add to Group via CSV in CiviCRM.
  *
- * Usage:
- *   cv php:script opt-out-contacts.php.
  */
 
 use Civi\Api4\Email;
@@ -25,15 +23,12 @@ define('GROUP_ID', 69);
 /**
  * Reads email addresses from the provided CSV file.
  *
- * @param string $filePath Path to the CSV file.
+ * @param string $filePath
+ *   Path to the CSV file.
  *
  * @return array List of email addresses.
  *
  * @throws Exception If the file is not readable or the 'email' column is missing.
- */
-
-/**
- * In the readContactsFromCsv function, you can check for 'Do Not Email' column value.
  */
 function readContactsFromCsv(string $filePath): array {
   if (!file_exists($filePath) || !is_readable($filePath)) {
@@ -47,14 +42,9 @@ function readContactsFromCsv(string $filePath): array {
       while (($data = fgetcsv($handle, 1000, ',')) !== FALSE) {
         $row = array_combine($header, $data);
 
-        // Check if the 'Do Not Email' column indicates opt-out.
-        if (isset($row['Do Not Email (Opt out contact)']) &&
-              strtolower($row['Do Not Email (Opt out contact)']) == 'yes') {
-
-          // Clean email by trimming any extra spaces.
-          $email = trim($row['email']);
-          $contacts[] = $email;
-        }
+        // Clean email by trimming any extra spaces.
+        $email = trim($row['email']);
+        $contacts[] = $email;
       }
     }
     else {
@@ -74,7 +64,7 @@ function optOutContactByEmail(string $email): void {
     // Log the email being processed for debugging.
     error_log("Processing email: $email");
 
-    // Find contact by email with case-insensitive search.
+    // Find contact using Email API
     $result = Email::get(FALSE)
       ->addSelect('contact_id')
       ->addWhere('email', '=', $email)
@@ -83,27 +73,32 @@ function optOutContactByEmail(string $email): void {
     error_log("Result: " . print_r($result, TRUE));
 
     // If email is found, process the contact.
-    $contactId = $result['contact_id'];
+    if (isset($result['contact_id'])) {
+      $contactId = $result['contact_id'];
 
-    // Optionally, log the contact ID.
-    error_log("Contact found with ID: $contactId");
+      error_log("Contact found with ID: $contactId");
 
-    // Opt out the contact (update the contact status or attributes)
-    Contact::update(FALSE)
-      ->addWhere('id', '=', $contactId)
-      ->addValue('is_opt_out', TRUE)
-      ->execute();
+      // Opt out the contact
+      Contact::update(FALSE)
+        ->addWhere('id', '=', $contactId)
+        ->addValue('is_opt_out', TRUE)
+        ->execute();
 
-    // Add the contact to the group.
-    GroupContact::create(FALSE)
-      ->addValue('contact_id', $contactId)
-      ->addValue('group_id', GROUP_ID)
-      ->addValue('status', 'Added')
-      ->execute();
-    error_log("Successfully opted out contact with email $email (ID $contactId) and added to group.");
+      // Add the contact to the specified group
+      GroupContact::create(FALSE)
+        ->addValue('contact_id', $contactId)
+        ->addValue('group_id', GROUP_ID)
+        ->addValue('status', 'Added')
+        ->execute();
+
+        echo "Successfully opted out contact with email $email (ID $contactId) and added to group.\n";
+    }
+    else {
+        echo "Contact with email $email not found.\n";
+    }
   }
   catch (Exception $e) {
-    error_log("Error processing email $email: " . $e->getMessage());
+    echo "An error occurred while processing email $email: " . $e->getMessage() . "\n";
   }
 }
 
@@ -114,11 +109,9 @@ function main(): void {
   try {
     echo "=== Starting Opt-Out Process ===\n";
     $emails = readContactsFromCsv(CSV_FILE_PATH);
-    // Log all emails read from CSV.
     error_log("All emails to process: " . print_r($emails, TRUE));
 
     if (empty($emails)) {
-      echo "No emails to process.\n";
       return;
     }
 

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -74,10 +74,10 @@ function optOutContactByEmail(string $email): void {
     error_log("Processing email: $email");
 
     // Find contact by email with case-insensitive search.
-    $result = Email::get(TRUE)
+    $result = Email::get(FALSE)
       ->addSelect('contact_id')
       ->addWhere('email', '=', $email)
-      ->execute();
+      ->execute()->single();
 
     error_log("Result: " . print_r($result, TRUE));
 
@@ -88,13 +88,13 @@ function optOutContactByEmail(string $email): void {
     error_log("Contact found with ID: $contactId");
 
     // Opt out the contact (update the contact status or attributes)
-    Contact::update(TRUE)
+    Contact::update(FALSE)
       ->addWhere('id', '=', $contactId)
       ->addValue('is_opt_out', TRUE)
       ->execute();
 
     // // Optionally, add the contact to the group
-    // GroupContact::create(TRUE)
+    // GroupContact::create(FALSE)
     //     ->addValue('contact_id', $contactId)
     //     ->addValue('group_id', GROUP_ID)
     //     ->addValue('status', 'Added')

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -15,7 +15,7 @@ if (php_sapi_name() != 'cli') {
 
 // Configuration.
 // Replace with your CSV file path.
-define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (5).csv');
+define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (6).csv');
 // Replace with the ID of the group to add contacts to.
 define('GROUP_ID', 69);
 
@@ -60,22 +60,15 @@ function readContactsFromCsv(string $filePath): array {
  */
 function optOutContactByEmail(string $email): void {
   try {
-    // Log the email being processed for debugging.
-    error_log("Processing email: $email");
-
     // Find contact using Email API.
     $result = Email::get(FALSE)
       ->addSelect('contact_id')
       ->addWhere('email', '=', $email)
       ->execute()->single();
 
-    error_log("Result: " . print_r($result, TRUE));
-
     // If email is found, process the contact.
     if (isset($result['contact_id'])) {
       $contactId = $result['contact_id'];
-
-      error_log("Contact found with ID: $contactId");
 
       // Opt out the contact.
       Contact::update(FALSE)

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -3,7 +3,6 @@
 /**
  * @file
  * CLI Script to Opt Out Contacts and Add to Group via CSV in CiviCRM.
- *
  */
 
 use Civi\Api4\Email;
@@ -64,7 +63,7 @@ function optOutContactByEmail(string $email): void {
     // Log the email being processed for debugging.
     error_log("Processing email: $email");
 
-    // Find contact using Email API
+    // Find contact using Email API.
     $result = Email::get(FALSE)
       ->addSelect('contact_id')
       ->addWhere('email', '=', $email)
@@ -78,23 +77,23 @@ function optOutContactByEmail(string $email): void {
 
       error_log("Contact found with ID: $contactId");
 
-      // Opt out the contact
+      // Opt out the contact.
       Contact::update(FALSE)
         ->addWhere('id', '=', $contactId)
         ->addValue('is_opt_out', TRUE)
         ->execute();
 
-      // Add the contact to the specified group
+      // Add the contact to the specified group.
       GroupContact::create(FALSE)
         ->addValue('contact_id', $contactId)
         ->addValue('group_id', GROUP_ID)
         ->addValue('status', 'Added')
         ->execute();
 
-        echo "Successfully opted out contact with email $email (ID $contactId) and added to group.\n";
+      echo "Successfully opted out contact with email $email (ID $contactId) and added to group.\n";
     }
     else {
-        echo "Contact with email $email not found.\n";
+      echo "Contact with email $email not found.\n";
     }
   }
   catch (Exception $e) {

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -10,6 +10,7 @@
 
 use Civi\Api4\Email;
 use Civi\Api4\Contact;
+use Civi\Api4\GroupContact;
 
 if (php_sapi_name() != 'cli') {
   exit("This script can only be run from the command line.\n");
@@ -19,7 +20,7 @@ if (php_sapi_name() != 'cli') {
 // Replace with your CSV file path.
 define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (5).csv');
 // Replace with the ID of the group to add contacts to.
-define('GROUP_ID', 1234);
+define('GROUP_ID', 69);
 
 /**
  * Reads email addresses from the provided CSV file.
@@ -93,12 +94,12 @@ function optOutContactByEmail(string $email): void {
       ->addValue('is_opt_out', TRUE)
       ->execute();
 
-    // // Optionally, add the contact to the group
-    // GroupContact::create(FALSE)
-    //     ->addValue('contact_id', $contactId)
-    //     ->addValue('group_id', GROUP_ID)
-    //     ->addValue('status', 'Added')
-    //     ->execute();
+    // Add the contact to the group.
+    GroupContact::create(FALSE)
+      ->addValue('contact_id', $contactId)
+      ->addValue('group_id', GROUP_ID)
+      ->addValue('status', 'Added')
+      ->execute();
     error_log("Successfully opted out contact with email $email (ID $contactId) and added to group.");
   }
   catch (Exception $e) {

--- a/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/import-opt-out-contacts.php
@@ -13,11 +13,17 @@ if (php_sapi_name() != 'cli') {
   exit("This script can only be run from the command line.\n");
 }
 
-// Configuration.
-// Replace with your CSV file path.
-define('CSV_FILE_PATH', '/Users/tarunjoshi/Downloads/Opted out List - Pardot (Contact listing) - civicrm_contribution (7).csv');
-// Replace with the ID of the group to add contacts to.
-define('GROUP_ID', 69);
+// Fetch the CSV file path and Group ID from the constants defined in wp-config.php.
+$csvFilePath = CSV_FILE_PATH;
+$groupId = GROUP_ID;
+
+// Check if the required constants are set.
+if (!$csvFilePath || !$groupId) {
+  exit("Error: Both CSV_FILE_PATH and GROUP_ID constants must be set.\n");
+}
+
+echo "CSV File: $csvFilePath\n";
+echo "Group ID: $groupId\n";
 
 /**
  * Reads email addresses from the provided CSV file.


### PR DESCRIPTION
## Import opt-out contacts.
### To run the script we need to go to the uploads folder and run
`./cv scr ../civi-extensions/goonjcustom/cli/import-opt-out-contacts.php`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a CLI script for bulk contact opt-out and group assignment using a CSV file.
	- Enables administrators to efficiently manage contact communication preferences.
	- Supports importing email addresses and updating contact opt-out status in CiviCRM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->