### PR TITLE
Prevent null value in  by using empty array fallback

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionMaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionMaterialContributionService.php
@@ -61,7 +61,7 @@ class InstitutionMaterialContributionService extends AutoSubscriber {
       ->setLimit(1)
       ->execute();
 
-    $contribution = $activities->first();
+    $contribution = $activities->first() ?? [];
 
     // Determine target contact with fallback logic.
     if (!empty($institutionPOCId)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in institution material contribution processing by ensuring a default empty array when no activities are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->