### PR TITLE
Feat/enable monetary button

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -632,20 +632,20 @@ class DroppingCenterService extends AutoSubscriber {
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
         'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin'],
       ],
-      // 'monetaryContribution' => [
-      //   'title' => ts('Monetary Contribution'),
-      //   'module' => 'afsearchMonetaryContribution',
-      //   'directive' => 'afsearch-monetary-contribution',
-      //   'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      //   'permissions' => ['account_team', 'ho_account'],
-      // ],
-      // 'monetaryContributionForUrbanOps' => [
-      //   'title' => ts('Monetary Contribution'),
-      //   'module' => 'afsearchMonetaryContributionForUrbanOps',
-      //   'directive' => 'afsearch-monetary-contribution-for-urban-ops',
-      //   'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
-      //   'permissions' => ['goonj_chapter_admin', 'urbanops'],
-      // ],
+      'monetaryContribution' => [
+        'title' => ts('Monetary Contribution'),
+        'module' => 'afsearchMonetaryContribution',
+        'directive' => 'afsearch-monetary-contribution',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+        'permissions' => ['account_team', 'ho_account'],
+      ],
+      'monetaryContributionForUrbanOps' => [
+        'title' => ts('Monetary Contribution'),
+        'module' => 'afsearchMonetaryContributionForUrbanOps',
+        'directive' => 'afsearch-monetary-contribution-for-urban-ops',
+        'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp.tpl',
+        'permissions' => ['goonj_chapter_admin', 'urbanops'],
+      ],
     ];
 
     foreach ($tabConfigs as $key => $config) {

--- a/wp-content/plugins/goonj-blocks/build/render.php
+++ b/wp-content/plugins/goonj-blocks/build/render.php
@@ -344,7 +344,7 @@ if (in_array($target, ['collection-camp', 'institution-collection-camp', 'droppi
                 <?php esc_html_e('Record your Material Contribution', 'goonj-blocks'); ?>
             </a>
         <?php endif; ?>
-        <?php if (in_array($target, ['events'])) : ?>
+        <?php if (in_array($target, ['events', 'collection-camp', 'dropping-center'])) : ?>
             <a href="<?php echo esc_url($donation_link); ?>" class="wp-block-gb-action-button gb-button-spacing">
                 <?php esc_html_e('Monetary Contribution', 'goonj-blocks'); ?>
             </a>

--- a/wp-content/plugins/goonj-blocks/src/render.php
+++ b/wp-content/plugins/goonj-blocks/src/render.php
@@ -344,7 +344,7 @@ if (in_array($target, ['collection-camp', 'institution-collection-camp', 'droppi
                 <?php esc_html_e('Record your Material Contribution', 'goonj-blocks'); ?>
             </a>
         <?php endif; ?>
-        <?php if (in_array($target, ['events'])) : ?>
+        <?php if (in_array($target, ['events', 'collection-camp', 'dropping-center'])) : ?>
             <a href="<?php echo esc_url($donation_link); ?>" class="wp-block-gb-action-button gb-button-spacing">
                 <?php esc_html_e('Monetary Contribution', 'goonj-blocks'); ?>
             </a>


### PR DESCRIPTION
- Enabled monetary button for collection camp and dropping center
- Update action page to enable monetary button for `events`, `collection camp`, and `dropping-center` only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The monetary contribution link is now displayed only in relevant sections (e.g., events, collection camps, and dropping centers).
  - Access to monetary contribution features for events has been expanded to include an additional administrative role.

- **Refactor**
  - Monetary contribution options have been streamlined by removing redundant tabs across various sections, resulting in a cleaner and more focused user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->