### PR TITLE
Add pan card and campaign on recurring

### DIFF
--- a/wp-content/civi-extensions/civirazorpay/CRM/Core/Civirazorpay/Payment/Razorpay.php
+++ b/wp-content/civi-extensions/civirazorpay/CRM/Core/Civirazorpay/Payment/Razorpay.php
@@ -445,9 +445,8 @@ class CRM_Core_Civirazorpay_Payment_Razorpay extends CRM_Core_Payment {
     $paymentId = $event['payload']['payment']['entity']['id'] ?? NULL;
     // Convert from paise to INR.
     $amount = $event['payload']['payment']['entity']['amount'] / 100;
-    $panCard = $event['payload']['subscription']['entity']['notes']['identity_type'];
-    $campaignTitle = $event['payload']['subscription']['entity']['notes']['purpose'];
-    error_log('panCard: ' . print_r($panCard, TRUE));
+    $panCard = $event['payload']['subscription']['entity']['notes']['identity_type'] ?? NULL;
+    $campaignTitle = $event['payload']['subscription']['entity']['notes']['purpose'] ?? NULL;
 
     if (!$subscriptionId || !$paymentId) {
       \Civi::log()->error("Missing subscription or payment ID in charged event");
@@ -480,7 +479,7 @@ class CRM_Core_Civirazorpay_Payment_Razorpay extends CRM_Core_Payment {
         ->addWhere('title', '=', $campaignTitle)
         ->execute()->first();
 
-      $campaignId = $campaigns['id'];
+      $campaignId = $campaigns['id'] ?? NULL;
 
       if (!$pendingContribution) {
         $contributionToUpdate = civicrm_api3('Contribution', 'create', [

--- a/wp-content/civi-extensions/civirazorpay/CRM/Core/Civirazorpay/Payment/Razorpay.php
+++ b/wp-content/civi-extensions/civirazorpay/CRM/Core/Civirazorpay/Payment/Razorpay.php
@@ -474,12 +474,12 @@ class CRM_Core_Civirazorpay_Payment_Razorpay extends CRM_Core_Payment {
 
       $sourceFieldId = 'custom_' . $sourceField['id'];
 
-      $campaigns = Campaign::get(FALSE)
+      $campaign = Campaign::get(FALSE)
         ->addSelect('id')
         ->addWhere('title', '=', $campaignTitle)
         ->execute()->first();
 
-      $campaignId = $campaigns['id'] ?? NULL;
+      $campaignId = $campaign['id'] ?? NULL;
 
       if (!$pendingContribution) {
         $contributionToUpdate = civicrm_api3('Contribution', 'create', [


### PR DESCRIPTION
Add pan card on recurring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PAN Card numbers from Razorpay subscription payments are now automatically captured and stored with CiviCRM contributions for recurring payments.
  - Contributions from recurring payments are now linked to the appropriate campaign based on the payment purpose note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->