### PR TITLE
Hide event fields

### DIFF
--- a/wp-content/themes/goonj-crm/main.js
+++ b/wp-content/themes/goonj-crm/main.js
@@ -162,6 +162,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 });
 
+// Hide specific form items in the thank you page for events.
 document.addEventListener("DOMContentLoaded", function() {
 	var formItems = document.querySelectorAll('.crm-event-thankyou-form-block .crm-group.participant_info-group fieldset .crm-public-form-item');
   

--- a/wp-content/themes/goonj-crm/main.js
+++ b/wp-content/themes/goonj-crm/main.js
@@ -161,3 +161,23 @@ document.addEventListener("DOMContentLoaded", function () {
       });
     }
 });
+
+document.addEventListener("DOMContentLoaded", function() {
+	// Select all the crm-public-form-item elements within the fieldset
+	var formItems = document.querySelectorAll('.crm-event-thankyou-form-block .crm-group.participant_info-group fieldset .crm-public-form-item');
+  
+	// Loop through each form item and check its label
+	formItems.forEach(function(item) {
+	  var label = item.querySelector('.label');
+	  
+	  if (label) {
+		var labelText = label.textContent.trim();
+		
+		// Check if the label matches either of the two specific labels
+		if (labelText === "Number of Adults Including You" || labelText === "Number of Children Accompanying You") {
+			item.style.setProperty('display', 'none', 'important');
+		}
+	  }
+	});
+});
+  

--- a/wp-content/themes/goonj-crm/main.js
+++ b/wp-content/themes/goonj-crm/main.js
@@ -163,10 +163,8 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 document.addEventListener("DOMContentLoaded", function() {
-	// Select all the crm-public-form-item elements within the fieldset
 	var formItems = document.querySelectorAll('.crm-event-thankyou-form-block .crm-group.participant_info-group fieldset .crm-public-form-item');
   
-	// Loop through each form item and check its label
 	formItems.forEach(function(item) {
 	  var label = item.querySelector('.label');
 	  


### PR DESCRIPTION
Hide event fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Certain form fields ("Number of Adults Including You" and "Number of Children Accompanying You") are now hidden on the event thank you page for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->