### PR TITLE
feat: link QR code scanning for multiple activities

### DIFF
--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -35,28 +35,17 @@ function goonj_generate_button_html( $button_url, $button_text ) {
 }
 
 function goonj_get_contribution_source_field_id() {
-  try {
-    $result = CustomField::get(FALSE)
-      ->addSelect('id')
-      ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
-      ->addWhere('name', '=', 'Source')
-      ->execute();
+	$sourceField = CustomField::get(FALSE)
+	->addSelect('id')
+	->addWhere('custom_group_id:name', '=', 'Contribution_Details')
+	->addWhere('name', '=', 'Source')
+	->execute()->single();
 
-    if ($result->count() === 0) {
-      \Civi::log()->error('Source custom field not found');
-      return NULL;
-    }
-
-    $sourceField = $result->single();
-    return 'custom_' . $sourceField['id'];
-  }
-  catch (\Exception $e) {
-    \Civi::log()->info('Error retrieving contribution source field', [
-      'error' => $e->getMessage(),
-    ]);
-    return NULL;
-  }
+	if ($sourceField) {
+			return 'custom_' . $sourceField['id'];
+	}
 }
+
 
 /**
  *
@@ -111,23 +100,16 @@ function goonj_monetary_contribution_button() {
 	$activityId = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
 	if ($activityId) {
-			$activities = Activity::get(false)
+			$activity = Activity::get(false)
 					->addSelect('source_contact_id')
 					->addWhere('id', '=', $activityId)
 					->addWhere('activity_type_id:label', '=', 'Material Contribution')
-					->execute();
+					->execute()->first();
 
-			if ($activities->count() === 0) {
-					\Civi::log()->info('No activities found for Activity ID: ' . $activityId);
-					return;
-			}
-
-			$activity = $activities->first();
 			$individualId = $activity['source_contact_id'];
 	}
 
 	try {
-			// Fetch contact data
 			$contactData = Contact::get(FALSE)
 					->addSelect('source')
 					->addWhere('id', '=', $individualId)

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -106,10 +106,6 @@ function goonj_generate_monetary_button($contact_id, $selectedValue) {
  */
 function goonj_contribution_monetary_button() {
   $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
-  $source = $_GET['source'] ?? '';
-
-  error_log("source: " . print_r($source, TRUE));
-  error_log("activity_id: " . print_r($activity_id, TRUE));
 
   if (empty($activity_id)) {
     \Civi::log()->warning('Activity ID is missing');

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -62,7 +62,7 @@ function goonj_generate_checksum($individualId) {
  *
  */
 function goonj_generate_monetary_button($individualId, $collectionCampId) {
-  if (!$collectionCampId) {
+  if (empty($collectionCampId)) {
     return '';
   }
 
@@ -79,7 +79,7 @@ function goonj_generate_monetary_button($individualId, $collectionCampId) {
  *
  */
 function goonj_generate_material_contribution_button($individualId, $url = '') {
-  if (!$url) {
+  if (empty($url)) {
     return '';
   }
 

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -102,6 +102,7 @@ function goonj_generate_monetary_button($contact_id, $selectedValue) {
  */
 function goonj_contribution_monetary_button() {
   $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
+  
 
   if (empty($activity_id)) {
     \Civi::log()->warning('Activity ID is missing');
@@ -242,7 +243,7 @@ function goonj_pu_activity_button() {
       ->first();
 
     if (!$activity) {
-      \Civi::log()->info('No activity found', ['activityId' => $activityId]);
+      \Civi::log()->info('No activity found', ['activityId' => $activity_id]);
       return;
     }
 

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -33,56 +33,104 @@ function goonj_contribution_volunteer_signup_button() {
 	if ( empty( $activity_id ) ) {
 		\Civi::log()->warning( 'Activity ID is missing' );
 		return;
-	}
+    }
 
-	try {
+    try {
 		$activities = \Civi\Api4\Activity::get( false )
 			->addSelect( 'source_contact_id' )
 			->addJoin( 'ActivityContact AS activity_contact', 'LEFT' )
 			->addWhere( 'id', '=', $activity_id )
 			->addWhere( 'activity_type_id:label', '=', 'Material Contribution' )
-			->execute();
+            ->execute();
 
 		if ( $activities->count() === 0 ) {
 			\Civi::log()->info( 'No activities found for Activity ID:', array( 'activityId' => $activity_id ) );
 			return;
-		}
+        }
 
-		$activity = $activities->first();
-		$individual_id = $activity['source_contact_id'];
+        $activity = $activities->first();
+        $individual_id = $activity['source_contact_id'];
 
 		$contact = \Civi\Api4\Contact::get( false )
 			->addSelect( 'contact_sub_type' )
 			->addWhere( 'id', '=', $individual_id )
-			->execute()
-			->first();
+            ->execute()
+            ->first();
 
 		if ( empty( $contact ) ) {
 			\Civi::log()->info( 'Contact not found', array( 'contact' => $contact['id'] ) );
 			return;
-		}
+        }
 
 		$contactSubTypes = $contact['contact_sub_type'] ?? array();
+        $buttonsHtml = '';
 
-		// If the individual is already a volunteer, don't show the button
-		if ( in_array( 'Volunteer', $contactSubTypes ) ) {
-			return;
-		}
+        // Generate volunteer signup button if not already a volunteer
+        if (!in_array('Volunteer', $contactSubTypes)) {
+            $redirectPath = '/volunteer-registration/form-with-details/';
+            $redirectPathWithParams = $redirectPath . '#?' . http_build_query([
+                'Individual1' => $individual_id,
+                'message' => 'individual-user',
+            ]);
+            $buttonText = __('Wish to Volunteer?', 'goonj-crm');
+            $buttonsHtml .= goonj_generate_button_html($redirectPathWithParams, $buttonText);
+        }
 
-		$redirectPath = '/volunteer-registration/form-with-details/';
-		$redirectPathWithParams = $redirectPath . '#?' . http_build_query(
-			array(
-				'Individual1' => $individual_id,
-				'message' => 'individual-user',
-			)
-		);
-		$buttonText = __( 'Wish to Volunteer?', 'goonj-crm' );
+        $activityDetails = \Civi\Api4\Activity::get(false)
+            ->addSelect(
+                'Material_Contribution.Collection_Camp',
+                'Material_Contribution.Dropping_Center',
+                'Material_Contribution.Institution_Collection_Camp',
+                'Material_Contribution.Institution_Dropping_Center'
+            )
+            ->addWhere('id', '=', $activity_id)
+            ->execute()
+            ->first();
 
-		return goonj_generate_button_html( $redirectPathWithParams, $buttonText );
-	} catch ( \Exception $e ) {
-		\Civi::log()->error( 'Error in goonj_contribution_volunteer_signup_button: ' . $e->getMessage() );
-		return;
-	}
+        $fields = [
+            'Material_Contribution.Collection_Camp',
+            'Material_Contribution.Dropping_Center',
+            'Material_Contribution.Institution_Collection_Camp',
+            'Material_Contribution.Institution_Dropping_Center',
+        ];
+
+        $selectedValue = null;
+        foreach ($fields as $field) {
+            if (!empty($activityDetails[$field])) {
+                $selectedValue = $activityDetails[$field];
+                break;
+            }
+        }
+
+        // Generate monetary contribution button if a value is found
+        if ($selectedValue) {
+            // Get custom field ID for "Source"
+            $sourceField = \Civi\Api4\CustomField::get(false)
+                ->addSelect('id')
+                ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
+                ->addWhere('name', '=', 'Source')
+                ->execute()
+                ->single();
+
+            $sourceFieldId = 'custom_' . $sourceField['id'];
+
+            // Generate checksum for secure URL
+            $checksum = \Civi\Api4\Contact::getChecksum(false)
+                ->setContactId($individual_id)
+                ->setTtl(7 * 24 * 60 * 60)
+                ->execute()
+                ->first()['checksum'];
+
+            $monetaryUrl = "/contribute/?$sourceFieldId=$selectedValue&cid=$individual_id&cs=$checksum";
+            $monetaryButtonText = __('Monetary Contribution', 'goonj-crm');
+            $buttonsHtml .= goonj_generate_button_html($monetaryUrl, $monetaryButtonText);
+        }
+
+        return $buttonsHtml;
+    } catch (\Exception $e) {
+        \Civi::log()->error('Error in goonj_contribution_volunteer_signup_button: ' . $e->getMessage());
+        return '';
+    }
 }
 
 function goonj_pu_activity_button() {
@@ -134,57 +182,49 @@ function goonj_collection_camp_past_data() {
 }
 
 function goonj_induction_slot_details() {
-    // Retrieve parameters from the GET request
     $source_contact_id = intval($_GET['source_contact_id'] ?? 0);
     $slot_date = $_GET['slot_date'] ?? '';
     $slot_time = $_GET['slot_time'] ?? '';
     $inductionType = $_GET['induction_type'] ?? '';
 
     try {
-        // Fetch the induction activity for the specified source contact
         $inductionActivity = \Civi\Api4\Activity::get(FALSE)
             ->addSelect('id', 'activity_date_time', 'status_id:name', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
             ->addWhere('source_contact_id', '=', $source_contact_id)
             ->addWhere('activity_type_id:name', '=', 'Induction')
             ->execute()->single();
 
-        // Exit if no activity found or the status is not "To be Scheduled"
         if (!$inductionActivity || $inductionActivity['status_id:name'] !== 'To be scheduled') {
             \Civi::log()->info('No valid activity found or status is not To be Scheduled', ['contact_id' => $source_contact_id]);
             return;
         }
 
-		// Combine slot date (d-m-Y) and slot time (h:i A) to form new activity date and time
 		$newActivityDateTime = DateTime::createFromFormat('d-m-Y h:i A', "$slot_date $slot_time");
 		if (!$newActivityDateTime) {
 			\Civi::log()->error('Invalid date/time format', ['slot_date' => $slot_date, 'slot_time' => $slot_time]);
 			return;
 		}
 
-
-        // Update activity date and time and set the status to "Scheduled"
         \Civi\Api4\Activity::update(FALSE)
             ->addValue('activity_date_time', $newActivityDateTime->format('Y-m-d H:i:s'))
             ->addValue('status_id:name', 'Scheduled')
             ->addValue('Induction_Fields.Mode:name', $inductionType)
             ->addWhere('id', '=', $inductionActivity['id'])
             ->execute();
+
         \Civi::log()->info('Activity updated successfully', [
             'activity_id' => $inductionActivity['id'],
             'new_date_time' => $newActivityDateTime->format('Y-m-d H:i:s')
         ]);
 
-        // Select the email template based on the induction type
         $templateTitle = ($inductionType == 'Processing_Unit') 
             ? 'Acknowledgment_for_Induction_Slot_Booked' 
             : 'Acknowledgment_for_Online_Induction_Slot_Booked';
 
-        // Fetch the email template
         $template = \Civi\Api4\MessageTemplate::get(FALSE)
             ->addWhere('msg_title', 'LIKE', $templateTitle . '%')
             ->execute()->single();
 
-        // If a template is found, send the email notification
         if ($template) {
             $assigneeContact = \Civi\Api4\Contact::get(FALSE)
                 ->addSelect('email.email')
@@ -192,14 +232,12 @@ function goonj_induction_slot_details() {
                 ->addWhere('id', '=', $inductionActivity['Induction_Fields.Assign'])
 				->execute()->single();
 
-            // Prepare email parameters
             $emailParams = [
                 'contact_id' => $source_contact_id,
                 'template_id' => $template['id'],
                 'cc' => $assigneeContact['email.email']
             ];
 
-            // Send the email
             $emailResult = civicrm_api3('Email', 'send', $emailParams);
         }
     } catch (\Exception $e) {

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -168,12 +168,12 @@ function goonj_material_contribution_button() {
       ->first();
 
     $subtype = $collectionCamps['subtype:name'] ?? '';
-    $id = $collectionCamps['id'];
+    $collectionCampId = $collectionCamps['id'];
     $subtypeToUrlMap = [
-      'Collection_Camp' => "/material-contribution/#?Material_Contribution.Collection_Camp={$id}",
-      'Dropping_Center' => "/dropping-center/material-contribution/#?Material_Contribution.Dropping_Center={$id}",
-      'Institution_Collection_Camp' => "/collection-camp-material-contribution/#?Material_Contribution.Institution_Collection_Camp={$id}",
-      'Institution_Dropping_Center' => "/dropping-center-material-contribution/#?Material_Contribution.Institution_Dropping_Center={$id}",
+      'Collection_Camp' => "/material-contribution/#?Material_Contribution.Collection_Camp={$collectionCampId}",
+      'Dropping_Center' => "/dropping-center/material-contribution/#?Material_Contribution.Dropping_Center={$collectionCampId}",
+      'Institution_Collection_Camp' => "/collection-camp-material-contribution/#?Material_Contribution.Institution_Collection_Camp={$collectionCampId}",
+      'Institution_Dropping_Center' => "/dropping-center-material-contribution/#?Material_Contribution.Institution_Dropping_Center={$collectionCampId}",
     ];
 
     $url = $subtypeToUrlMap[$subtype] ?? '';

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -13,7 +13,7 @@ use Civi\Api4\MessageTemplate;
 add_shortcode('goonj_check_user_form', 'goonj_check_user_action');
 add_shortcode('goonj_volunteer_message', 'goonj_custom_message_placeholder');
 add_shortcode('goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button');
-add_shortcode('goonj_contribution_monetary_button', 'goonj_contribution_monetary_button');
+add_shortcode('goonj_monetary_contribution_button', 'goonj_monetary_contribution_button');
 add_shortcode('goonj_material_contribution_button', 'goonj_material_contribution_button');
 add_shortcode('goonj_pu_activity_button', 'goonj_pu_activity_button');
 add_shortcode('goonj_collection_landing_page', 'goonj_collection_camp_landing_page');
@@ -118,7 +118,7 @@ function goonj_generate_material_contribution_button($contact_id, $selectedValue
 /**
  * Monetary contribution button shortcode.
  */
-function goonj_contribution_monetary_button() {
+function goonj_monetary_contribution_button() {
   $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
   if (empty($activity_id)) {
@@ -148,7 +148,7 @@ function goonj_contribution_monetary_button() {
     return goonj_generate_monetary_button($activity_id, $selectedValue);
   }
   catch (\Exception $e) {
-    \Civi::log()->error('Error in goonj_contribution_monetary_button: ' . $e->getMessage());
+    \Civi::log()->error('Error in goonj_monetary_contribution_button: ' . $e->getMessage());
     return '';
   }
 }

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -42,7 +42,7 @@ function goonj_get_contribution_source_field_id() {
 	->execute()->single();
 
 	if ($sourceField) {
-			return 'custom_' . $sourceField['id'];
+		return 'custom_' . $sourceField['id'];
 	}
 }
 
@@ -67,7 +67,7 @@ function goonj_generate_monetary_button($individualId, $collectionCampId) {
   }
 
   $sourceFieldId = goonj_get_contribution_source_field_id();
-  $checksum = goonj_generate_checksum($collectionCampId);
+  $checksum = goonj_generate_checksum($individualId);
 
   $monetaryUrl = "/contribute/?$sourceFieldId=$collectionCampId&cid=$individualId&cs=$checksum";
   $buttonText = __('Monetary Contribution', 'goonj-crm');
@@ -100,21 +100,20 @@ function goonj_monetary_contribution_button() {
 	$activityId = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
 	if ($activityId) {
-			$activity = Activity::get(false)
-					->addSelect('source_contact_id')
-					->addWhere('id', '=', $activityId)
-					->addWhere('activity_type_id:label', '=', 'Material Contribution')
-					->execute()->first();
-
-			$individualId = $activity['source_contact_id'];
+		$activity = Activity::get(false)
+		->addSelect('source_contact_id')
+		->addWhere('id', '=', $activityId)
+		->addWhere('activity_type_id:label', '=', 'Material Contribution')
+		->execute()->first();
+		$individualId = $activity['source_contact_id'];
 	}
 
 	try {
-			$contactData = Contact::get(FALSE)
-					->addSelect('source')
-					->addWhere('id', '=', $individualId)
-					->execute()
-					->first();
+		$contactData = Contact::get(FALSE)
+		->addSelect('source')
+		->addWhere('id', '=', $individualId)
+		->execute()
+		->first();
 
 			if (empty($contactData)) {
 					return;

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -213,7 +213,6 @@ function goonj_material_contribution_button() {
       ->first();
 
     $subtype = $collectionCamps['subtype:name'] ?? '';
-    // $sourceContactId = $activity['source_contact_id'] ?? 0;
     $subtypeToUrlMap = [
       'Collection_Camp' => "/material-contribution/#?Material_Contribution.Collection_Camp={$selectedValue}",
       'Dropping_Center' => "/dropping-center/material-contribution/#?Material_Contribution.Dropping_Center={$selectedValue}",

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -99,6 +99,10 @@ function goonj_monetary_contribution_button() {
 	$individualId = isset($_GET['individualId']) ? intval($_GET['individualId']) : 0;
 	$activityId = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
+	if (empty($activityId) && empty($individualId)) {
+		return;
+	}	
+
 	if ($activityId) {
 		$activity = Activity::get(false)
 		->addSelect('source_contact_id')

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -12,7 +12,7 @@ use Civi\Api4\MessageTemplate;
 add_shortcode('goonj_check_user_form', 'goonj_check_user_action');
 add_shortcode('goonj_volunteer_message', 'goonj_custom_message_placeholder');
 add_shortcode('goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button');
-add_shortcode('goonj_contribution_monetory_button', 'goonj_contribution_monetory_button');
+add_shortcode('goonj_contribution_monetary_button', 'goonj_contribution_monetary_button');
 add_shortcode('goonj_pu_activity_button', 'goonj_pu_activity_button');
 add_shortcode('goonj_collection_landing_page', 'goonj_collection_camp_landing_page');
 add_shortcode('goonj_collection_camp_past', 'goonj_collection_camp_past_data');
@@ -103,7 +103,7 @@ function goonj_generate_monetary_button($contact_id, $selectedValue) {
 /**
  * Monetary contribution button shortcode.
  */
-function goonj_contribution_monetory_button() {
+function goonj_contribution_monetary_button() {
   $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
   $source = $_GET['source'] ?? '';
 
@@ -139,7 +139,7 @@ function goonj_contribution_monetory_button() {
     return goonj_generate_monetary_button($activity_id, $selectedValue);
   }
   catch (\Exception $e) {
-    \Civi::log()->error('Error in goonj_contribution_monetory_button: ' . $e->getMessage());
+    \Civi::log()->error('Error in goonj_contribution_monetary_button: ' . $e->getMessage());
     return '';
   }
 }

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -1,249 +1,290 @@
 <?php
 
-add_shortcode( 'goonj_check_user_form', 'goonj_check_user_action' );
-add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
-add_shortcode( 'goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button' );
-add_shortcode( 'goonj_pu_activity_button', 'goonj_pu_activity_button' );
-add_shortcode( 'goonj_collection_landing_page', 'goonj_collection_camp_landing_page' );
-add_shortcode( 'goonj_collection_camp_past', 'goonj_collection_camp_past_data' );
-add_shortcode( 'goonj_induction_slot_details', 'goonj_induction_slot_details' );
+/**
+ * @file
+ */
 
-function goonj_check_user_action( $atts ) {
-	get_template_part( 'templates/form', 'check-user', array( 'purpose' => $atts['purpose'] ) );
-	return ob_get_clean();
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\MessageTemplate;
+
+add_shortcode('goonj_check_user_form', 'goonj_check_user_action');
+add_shortcode('goonj_volunteer_message', 'goonj_custom_message_placeholder');
+add_shortcode('goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button');
+add_shortcode('goonj_pu_activity_button', 'goonj_pu_activity_button');
+add_shortcode('goonj_collection_landing_page', 'goonj_collection_camp_landing_page');
+add_shortcode('goonj_collection_camp_past', 'goonj_collection_camp_past_data');
+add_shortcode('goonj_induction_slot_details', 'goonj_induction_slot_details');
+
+/**
+ *
+ */
+function goonj_check_user_action($atts) {
+  get_template_part('templates/form', 'check-user', ['purpose' => $atts['purpose']]);
+  return ob_get_clean();
 }
 
-function goonj_generate_button_html( $button_url, $button_text ) {
-	ob_start();
-	get_template_part(
-		'templates/primary-button',
-		null,
-		array(
-			'button_url' => $button_url,
-			'button_text' => $button_text,
-		)
-	);
+/**
+ *
+ */
+function goonj_generate_button_html($button_url, $button_text) {
+  ob_start();
+  get_template_part(
+        'templates/primary-button',
+        NULL,
+        [
+          'button_url' => $button_url,
+          'button_text' => $button_text,
+        ]
+  );
 
-	return ob_get_clean();
+  return ob_get_clean();
 }
 
+/**
+ *
+ */
 function goonj_contribution_volunteer_signup_button() {
-	$activity_id = isset( $_GET['activityId'] ) ? intval( $_GET['activityId'] ) : 0;
+  $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
-	if ( empty( $activity_id ) ) {
-		\Civi::log()->warning( 'Activity ID is missing' );
-		return;
+  if (empty($activity_id)) {
+    \Civi::log()->warning('Activity ID is missing');
+    return;
+  }
+
+  try {
+    $activities = Activity::get(FALSE)
+      ->addSelect('source_contact_id')
+      ->addJoin('ActivityContact AS activity_contact', 'LEFT')
+      ->addWhere('id', '=', $activity_id)
+      ->addWhere('activity_type_id:label', '=', 'Material Contribution')
+      ->execute();
+
+    if ($activities->count() === 0) {
+      \Civi::log()->info('No activities found for Activity ID:', ['activityId' => $activity_id]);
+      return;
     }
 
-    try {
-		$activities = \Civi\Api4\Activity::get( false )
-			->addSelect( 'source_contact_id' )
-			->addJoin( 'ActivityContact AS activity_contact', 'LEFT' )
-			->addWhere( 'id', '=', $activity_id )
-			->addWhere( 'activity_type_id:label', '=', 'Material Contribution' )
-            ->execute();
+    $activity = $activities->first();
+    $individual_id = $activity['source_contact_id'];
 
-		if ( $activities->count() === 0 ) {
-			\Civi::log()->info( 'No activities found for Activity ID:', array( 'activityId' => $activity_id ) );
-			return;
-        }
+    $contact = Contact::get(FALSE)
+      ->addSelect('contact_sub_type')
+      ->addWhere('id', '=', $individual_id)
+      ->execute()
+      ->first();
 
-        $activity = $activities->first();
-        $individual_id = $activity['source_contact_id'];
-
-		$contact = \Civi\Api4\Contact::get( false )
-			->addSelect( 'contact_sub_type' )
-			->addWhere( 'id', '=', $individual_id )
-            ->execute()
-            ->first();
-
-		if ( empty( $contact ) ) {
-			\Civi::log()->info( 'Contact not found', array( 'contact' => $contact['id'] ) );
-			return;
-        }
-
-		$contactSubTypes = $contact['contact_sub_type'] ?? array();
-        $buttonsHtml = '';
-
-        // Generate volunteer signup button if not already a volunteer
-        if (!in_array('Volunteer', $contactSubTypes)) {
-            $redirectPath = '/volunteer-registration/form-with-details/';
-            $redirectPathWithParams = $redirectPath . '#?' . http_build_query([
-                'Individual1' => $individual_id,
-                'message' => 'individual-user',
-            ]);
-            $buttonText = __('Wish to Volunteer?', 'goonj-crm');
-            $buttonsHtml .= goonj_generate_button_html($redirectPathWithParams, $buttonText);
-        }
-
-        $activityDetails = \Civi\Api4\Activity::get(false)
-            ->addSelect(
-                'Material_Contribution.Collection_Camp',
-                'Material_Contribution.Dropping_Center',
-                'Material_Contribution.Institution_Collection_Camp',
-                'Material_Contribution.Institution_Dropping_Center'
-            )
-            ->addWhere('id', '=', $activity_id)
-            ->execute()
-            ->first();
-
-        $fields = [
-            'Material_Contribution.Collection_Camp',
-            'Material_Contribution.Dropping_Center',
-            'Material_Contribution.Institution_Collection_Camp',
-            'Material_Contribution.Institution_Dropping_Center',
-        ];
-
-        $selectedValue = null;
-        foreach ($fields as $field) {
-            if (!empty($activityDetails[$field])) {
-                $selectedValue = $activityDetails[$field];
-                break;
-            }
-        }
-
-        // Generate monetary contribution button if a value is found
-        if ($selectedValue) {
-            // Get custom field ID for "Source"
-            $sourceField = \Civi\Api4\CustomField::get(false)
-                ->addSelect('id')
-                ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
-                ->addWhere('name', '=', 'Source')
-                ->execute()
-                ->single();
-
-            $sourceFieldId = 'custom_' . $sourceField['id'];
-
-            // Generate checksum for secure URL
-            $checksum = \Civi\Api4\Contact::getChecksum(false)
-                ->setContactId($individual_id)
-                ->setTtl(7 * 24 * 60 * 60)
-                ->execute()
-                ->first()['checksum'];
-
-            $monetaryUrl = "/contribute/?$sourceFieldId=$selectedValue&cid=$individual_id&cs=$checksum";
-            $monetaryButtonText = __('Monetary Contribution', 'goonj-crm');
-            $buttonsHtml .= goonj_generate_button_html($monetaryUrl, $monetaryButtonText);
-        }
-
-        return $buttonsHtml;
-    } catch (\Exception $e) {
-        \Civi::log()->error('Error in goonj_contribution_volunteer_signup_button: ' . $e->getMessage());
-        return '';
+    if (empty($contact)) {
+      \Civi::log()->info('Contact not found', ['contact' => $contact['id']]);
+      return;
     }
+
+    $contactSubTypes = $contact['contact_sub_type'] ?? [];
+    $buttonsHtml = '';
+
+    // Generate volunteer signup button if not already a volunteer.
+    if (!in_array('Volunteer', $contactSubTypes)) {
+      $redirectPath = '/volunteer-registration/form-with-details/';
+      $redirectPathWithParams = $redirectPath . '#?' . http_build_query([
+        'Individual1' => $individual_id,
+        'message' => 'individual-user',
+      ]);
+      $buttonText = __('Wish to Volunteer?', 'goonj-crm');
+      $buttonsHtml .= goonj_generate_button_html($redirectPathWithParams, $buttonText);
+    }
+
+    $activityDetails = Activity::get(FALSE)
+      ->addSelect(
+              'Material_Contribution.Collection_Camp',
+              'Material_Contribution.Dropping_Center',
+              'Material_Contribution.Institution_Collection_Camp',
+              'Material_Contribution.Institution_Dropping_Center'
+          )
+      ->addWhere('id', '=', $activity_id)
+      ->execute()
+      ->first();
+
+    $fields = [
+      'Material_Contribution.Collection_Camp',
+      'Material_Contribution.Dropping_Center',
+      'Material_Contribution.Institution_Collection_Camp',
+      'Material_Contribution.Institution_Dropping_Center',
+    ];
+
+    $selectedValue = NULL;
+    foreach ($fields as $field) {
+      if (!empty($activityDetails[$field])) {
+        $selectedValue = $activityDetails[$field];
+        break;
+      }
+    }
+
+    // Generate monetary contribution button if a value is found.
+    if ($selectedValue) {
+      // Get custom field ID for "Source".
+      $sourceField = CustomField::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
+        ->addWhere('name', '=', 'Source')
+        ->execute()
+        ->single();
+
+      $sourceFieldId = 'custom_' . $sourceField['id'];
+
+      // Generate checksum for secure URL.
+      $checksum = Contact::getChecksum(FALSE)
+        ->setContactId($individual_id)
+        ->setTtl(7 * 24 * 60 * 60)
+        ->execute()
+        ->first()['checksum'];
+
+      $monetaryUrl = "/contribute/?$sourceFieldId=$selectedValue&cid=$individual_id&cs=$checksum";
+      $monetaryButtonText = __('Monetary Contribution', 'goonj-crm');
+      $buttonsHtml .= goonj_generate_button_html($monetaryUrl, $monetaryButtonText);
+    }
+
+    return $buttonsHtml;
+  }
+  catch (\Exception $e) {
+    \Civi::log()->error('Error in goonj_contribution_volunteer_signup_button: ' . $e->getMessage());
+    return '';
+  }
 }
 
+/**
+ *
+ */
 function goonj_pu_activity_button() {
-	if ( ! isset( $_GET['activityId'] ) ) {
-		return;
-	}
+  if (!isset($_GET['activityId'])) {
+    return;
+  }
 
-	$activity_id = absint( $_GET['activityId'] );
+  $activity_id = absint($_GET['activityId']);
 
-	try {
-		$activity = \Civi\Api4\Activity::get(false)
-			->addSelect('custom.*', 'source_contact_id', 'Office_Visit.Goonj_Processing_Center', 'Material_Contribution.Goonj_Office', 'activity_type_id:name')
-			->addWhere('id', '=', $activity_id)
-			->execute()
-			->first();
-		
-		if (!$activity) {
-			\Civi::log()->info('No activity found', ['activityId' => $activityId]);
-			return;
-		}
+  try {
+    $activity = Activity::get(FALSE)
+      ->addSelect('custom.*', 'source_contact_id', 'Office_Visit.Goonj_Processing_Center', 'Material_Contribution.Goonj_Office', 'activity_type_id:name')
+      ->addWhere('id', '=', $activity_id)
+      ->execute()
+      ->first();
 
-		$individual_id = $activity['source_contact_id'];
+    if (!$activity) {
+      \Civi::log()->info('No activity found', ['activityId' => $activityId]);
+      return;
+    }
 
-		$office_id = goonj_get_goonj_office_id( $activity );
+    $individual_id = $activity['source_contact_id'];
 
-		if ( ! $office_id ) {
-			\Civi::log()->info( 'Goonj Office ID is null for Activity ID:', array( 'activityId' => $activity_id ) );
-			return;
-		}
+    $office_id = goonj_get_goonj_office_id($activity);
 
-		return goonj_generate_activity_button( $activity, $office_id, $individual_id );
+    if (!$office_id) {
+      \Civi::log()->info('Goonj Office ID is null for Activity ID:', ['activityId' => $activity_id]);
+      return;
+    }
 
-	} catch ( \Exception $e ) {
-		\Civi::log()->error( 'Error in goonj_pu_activity_button: ' . $e->getMessage() );
-		return;
-	}
+    return goonj_generate_activity_button($activity, $office_id, $individual_id);
+
+  }
+  catch (\Exception $e) {
+    \Civi::log()->error('Error in goonj_pu_activity_button: ' . $e->getMessage());
+    return;
+  }
 }
 
+/**
+ *
+ */
 function goonj_collection_camp_landing_page() {
-	ob_start();
-	get_template_part( 'templates/collection-landing-page' );
-	return ob_get_clean();
+  ob_start();
+  get_template_part('templates/collection-landing-page');
+  return ob_get_clean();
 }
 
+/**
+ *
+ */
 function goonj_collection_camp_past_data() {
-	ob_start();
-	get_template_part( 'templates/collection-camp-data' );
-	return ob_get_clean();
+  ob_start();
+  get_template_part('templates/collection-camp-data');
+  return ob_get_clean();
 }
 
+/**
+ *
+ */
 function goonj_induction_slot_details() {
-    $source_contact_id = intval($_GET['source_contact_id'] ?? 0);
-    $slot_date = $_GET['slot_date'] ?? '';
-    $slot_time = $_GET['slot_time'] ?? '';
-    $inductionType = $_GET['induction_type'] ?? '';
+  // Retrieve parameters from the GET request.
+  $source_contact_id = intval($_GET['source_contact_id'] ?? 0);
+  $slot_date = $_GET['slot_date'] ?? '';
+  $slot_time = $_GET['slot_time'] ?? '';
+  $inductionType = $_GET['induction_type'] ?? '';
 
-    try {
-        $inductionActivity = \Civi\Api4\Activity::get(FALSE)
-            ->addSelect('id', 'activity_date_time', 'status_id:name', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
-            ->addWhere('source_contact_id', '=', $source_contact_id)
-            ->addWhere('activity_type_id:name', '=', 'Induction')
-            ->execute()->single();
+  try {
+    // Fetch the induction activity for the specified source contact.
+    $inductionActivity = Activity::get(FALSE)
+      ->addSelect('id', 'activity_date_time', 'status_id:name', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
+      ->addWhere('source_contact_id', '=', $source_contact_id)
+      ->addWhere('activity_type_id:name', '=', 'Induction')
+      ->execute()->single();
 
-        if (!$inductionActivity || $inductionActivity['status_id:name'] !== 'To be scheduled') {
-            \Civi::log()->info('No valid activity found or status is not To be Scheduled', ['contact_id' => $source_contact_id]);
-            return;
-        }
+    // Exit if no activity found or the status is not "To be Scheduled".
+    if (!$inductionActivity || $inductionActivity['status_id:name'] !== 'To be scheduled') {
+      \Civi::log()->info('No valid activity found or status is not To be Scheduled', ['contact_id' => $source_contact_id]);
+      return;
+    }
+    // Combine slot date (d-m-Y) and slot time (h:i A) to form new activity date and time.
+    $newActivityDateTime = DateTime::createFromFormat('d-m-Y h:i A', "$slot_date $slot_time");
+    if (!$newActivityDateTime) {
+      \Civi::log()->error('Invalid date/time format', ['slot_date' => $slot_date, 'slot_time' => $slot_time]);
+      return;
+    }
 
-		$newActivityDateTime = DateTime::createFromFormat('d-m-Y h:i A', "$slot_date $slot_time");
-		if (!$newActivityDateTime) {
-			\Civi::log()->error('Invalid date/time format', ['slot_date' => $slot_date, 'slot_time' => $slot_time]);
-			return;
-		}
+    // Update activity date and time and set the status to "Scheduled".
+    Activity::update(FALSE)
+      ->addValue('activity_date_time', $newActivityDateTime->format('Y-m-d H:i:s'))
+      ->addValue('status_id:name', 'Scheduled')
+      ->addValue('Induction_Fields.Mode:name', $inductionType)
+      ->addWhere('id', '=', $inductionActivity['id'])
+      ->execute();
 
-        \Civi\Api4\Activity::update(FALSE)
-            ->addValue('activity_date_time', $newActivityDateTime->format('Y-m-d H:i:s'))
-            ->addValue('status_id:name', 'Scheduled')
-            ->addValue('Induction_Fields.Mode:name', $inductionType)
-            ->addWhere('id', '=', $inductionActivity['id'])
-            ->execute();
+    \Civi::log()->info('Activity updated successfully', [
+      'activity_id' => $inductionActivity['id'],
+      'new_date_time' => $newActivityDateTime->format('Y-m-d H:i:s'),
+    ]);
 
-        \Civi::log()->info('Activity updated successfully', [
-            'activity_id' => $inductionActivity['id'],
-            'new_date_time' => $newActivityDateTime->format('Y-m-d H:i:s')
-        ]);
-
-        $templateTitle = ($inductionType == 'Processing_Unit') 
-            ? 'Acknowledgment_for_Induction_Slot_Booked' 
+    // Select the email template based on the induction type.
+    $templateTitle = ($inductionType == 'Processing_Unit')
+            ? 'Acknowledgment_for_Induction_Slot_Booked'
             : 'Acknowledgment_for_Online_Induction_Slot_Booked';
 
-        $template = \Civi\Api4\MessageTemplate::get(FALSE)
-            ->addWhere('msg_title', 'LIKE', $templateTitle . '%')
-            ->execute()->single();
+    // If a template is found, send the email notification.
+    $template = MessageTemplate::get(FALSE)
+      ->addWhere('msg_title', 'LIKE', $templateTitle . '%')
+      ->execute()->single();
 
-        if ($template) {
-            $assigneeContact = \Civi\Api4\Contact::get(FALSE)
-                ->addSelect('email.email')
-                ->addJoin('Email AS email', 'LEFT')
-                ->addWhere('id', '=', $inductionActivity['Induction_Fields.Assign'])
-				->execute()->single();
+    if ($template) {
+      $assigneeContact = Contact::get(FALSE)
+        ->addSelect('email.email')
+        ->addJoin('Email AS email', 'LEFT')
+        ->addWhere('id', '=', $inductionActivity['Induction_Fields.Assign'])
+        ->execute()->single();
 
-            $emailParams = [
-                'contact_id' => $source_contact_id,
-                'template_id' => $template['id'],
-                'cc' => $assigneeContact['email.email']
-            ];
+      // Prepare email parameters.
+      $emailParams = [
+        'contact_id' => $source_contact_id,
+        'template_id' => $template['id'],
+        'cc' => $assigneeContact['email.email'],
+      ];
 
-            $emailResult = civicrm_api3('Email', 'send', $emailParams);
-        }
-    } catch (\Exception $e) {
-        \Civi::log()->error('Error processing induction slot details', [
-            'contact_id' => $source_contact_id,
-            'error' => $e->getMessage()
-        ]);
+      // Send the email.
+      $emailResult = civicrm_api3('Email', 'send', $emailParams);
     }
+  }
+  catch (\Exception $e) {
+    \Civi::log()->error('Error processing induction slot details', [
+      'contact_id' => $source_contact_id,
+      'error' => $e->getMessage(),
+    ]);
+  }
 }

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -22,6 +22,7 @@ add_shortcode('goonj_induction_slot_details', 'goonj_induction_slot_details');
  *
  */
 function goonj_check_user_action($atts) {
+  ob_start();
   get_template_part('templates/form', 'check-user', ['purpose' => $atts['purpose']]);
   return ob_get_clean();
 }

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -63,7 +63,7 @@ function goonj_generate_checksum($individualId) {
  */
 function goonj_generate_monetary_button($individualId, $collectionCampId) {
   if (empty($collectionCampId)) {
-    return '';
+    return;
   }
 
   $sourceFieldId = goonj_get_contribution_source_field_id();
@@ -80,7 +80,7 @@ function goonj_generate_monetary_button($individualId, $collectionCampId) {
  */
 function goonj_generate_material_contribution_button($individualId, $url = '') {
   if (empty($url)) {
-    return '';
+	return;
   }
 
   $checksum = goonj_generate_checksum($individualId);
@@ -104,7 +104,7 @@ function goonj_monetary_contribution_button() {
 	}	
 
 	if ($activityId) {
-		$activity = Activity::get(false)
+		$activity = Activity::get(FALSE)
 		->addSelect('source_contact_id')
 		->addWhere('id', '=', $activityId)
 		->addWhere('activity_type_id:label', '=', 'Material Contribution')
@@ -125,18 +125,18 @@ function goonj_monetary_contribution_button() {
 
 			$title = $contactData['source'];
 
-			$collectionCamps = EckEntity::get('Collection_Camp', FALSE)
+			$collectionCamp = EckEntity::get('Collection_Camp', FALSE)
 					->addSelect('id')
 					->addWhere('title', '=', $title)
 					->execute()
 					->first();
 
-			if (empty($collectionCamps)) {
+			if (empty($collectionCamp)) {
 					\Civi::log()->info('No collection camp found for title: ' . $title);
 					return;
 			}
 
-			$collectionCampId = $collectionCamps['id'];
+			$collectionCampId = $collectionCamp['id'];
 
 			return goonj_generate_monetary_button($individualId, $collectionCampId);
 	} catch (\Exception $e) {
@@ -164,14 +164,14 @@ function goonj_material_contribution_button() {
       ->first();
 
     $title = $contactData['source'];
-    $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
+    $collectionCamp = EckEntity::get('Collection_Camp', FALSE)
       ->addSelect('subtype:name')
       ->addWhere('title', '=', $title)
       ->execute()
       ->first();
 
-    $subtype = $collectionCamps['subtype:name'] ?? '';
-    $collectionCampId = $collectionCamps['id'];
+    $subtype = $collectionCamp['subtype:name'] ?? '';
+    $collectionCampId = $collectionCamp['id'];
     $subtypeToUrlMap = [
       'Collection_Camp' => "/material-contribution/#?Material_Contribution.Collection_Camp={$collectionCampId}",
       'Dropping_Center' => "/dropping-center/material-contribution/#?Material_Contribution.Dropping_Center={$collectionCampId}",

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -122,7 +122,6 @@ function goonj_contribution_monetary_button() {
   $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
   if (empty($activity_id)) {
-    \Civi::log()->warning('Activity ID is missing');
     return;
   }
 
@@ -137,7 +136,6 @@ function goonj_contribution_monetary_button() {
     $contactData = Contact::get(FALSE)
       ->addSelect('source')
       ->addWhere('id', '=', $activity_id)
-      ->setLimit(1)
       ->execute()
       ->first();
 
@@ -162,7 +160,6 @@ function goonj_material_contribution_button() {
   $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
   if (empty($activity_id)) {
-    \Civi::log()->warning('Activity ID is missing');
     return '';
   }
 
@@ -227,7 +224,6 @@ function goonj_contribution_volunteer_signup_button() {
   $activity_id = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
 
   if (empty($activity_id)) {
-    \Civi::log()->warning('Activity ID is missing');
     return;
   }
 

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -47,10 +47,6 @@ function goonj_generate_button_html($button_url, $button_text) {
 /**
  *
  */
-
-/**
- * Common helper to fetch activity with contact ID.
- */
 function goonj_get_activity_with_contact($activity_id) {
   return Activity::get(FALSE)
     ->addSelect('source_contact_id')
@@ -61,7 +57,7 @@ function goonj_get_activity_with_contact($activity_id) {
 }
 
 /**
- * Common helper to get source field ID.
+ *
  */
 function goonj_get_contribution_source_field_id() {
   $sourceField = CustomField::get(FALSE)
@@ -74,7 +70,7 @@ function goonj_get_contribution_source_field_id() {
 }
 
 /**
- * Common helper to generate checksum for contact.
+ *
  */
 function goonj_generate_checksum($contact_id) {
   return Contact::getChecksum(FALSE)
@@ -85,7 +81,7 @@ function goonj_generate_checksum($contact_id) {
 }
 
 /**
- * Generate Monetary Contribution button if source is present.
+ *
  */
 function goonj_generate_monetary_button($contact_id, $selectedValue) {
   if (!$selectedValue) {

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -61,15 +61,15 @@ function goonj_generate_checksum($individualId) {
 /**
  *
  */
-function goonj_generate_monetary_button($individualId, $id) {
-  if (!$id) {
+function goonj_generate_monetary_button($individualId, $collectionCampId) {
+  if (!$collectionCampId) {
     return '';
   }
 
   $sourceFieldId = goonj_get_contribution_source_field_id();
-  $checksum = goonj_generate_checksum($id);
+  $checksum = goonj_generate_checksum($collectionCampId);
 
-  $monetaryUrl = "/contribute/?$sourceFieldId=$id&cid=$individualId&cs=$checksum";
+  $monetaryUrl = "/contribute/?$sourceFieldId=$collectionCampId&cid=$individualId&cs=$checksum";
   $buttonText = __('Monetary Contribution', 'goonj-crm');
 
   return goonj_generate_button_html($monetaryUrl, $buttonText);
@@ -133,9 +133,9 @@ function goonj_monetary_contribution_button() {
 					return;
 			}
 
-			$id = $collectionCamps['id'];
+			$collectionCampId = $collectionCamps['id'];
 
-			return goonj_generate_monetary_button($individualId, $id);
+			return goonj_generate_monetary_button($individualId, $collectionCampId);
 	} catch (\Exception $e) {
 			\Civi::log()->error('Error in goonj_monetary_contribution_button: ' . $e->getMessage());
 			return '';

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -1,428 +1,211 @@
 <?php
 
-/**
- * @file
- */
+add_shortcode( 'goonj_check_user_form', 'goonj_check_user_action' );
+add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
+add_shortcode( 'goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button' );
+add_shortcode( 'goonj_pu_activity_button', 'goonj_pu_activity_button' );
+add_shortcode( 'goonj_collection_landing_page', 'goonj_collection_camp_landing_page' );
+add_shortcode( 'goonj_collection_camp_past', 'goonj_collection_camp_past_data' );
+add_shortcode( 'goonj_induction_slot_details', 'goonj_induction_slot_details' );
 
-use Civi\Api4\Activity;
-use Civi\Api4\Contact;
-use Civi\Api4\CustomField;
-use Civi\Api4\EckEntity;
-use Civi\Api4\MessageTemplate;
-
-add_shortcode('goonj_check_user_form', 'goonj_check_user_action');
-add_shortcode('goonj_volunteer_message', 'goonj_custom_message_placeholder');
-add_shortcode('goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button');
-add_shortcode('goonj_monetary_contribution_button', 'goonj_monetary_contribution_button');
-add_shortcode('goonj_material_contribution_button', 'goonj_material_contribution_button');
-add_shortcode('goonj_pu_activity_button', 'goonj_pu_activity_button');
-add_shortcode('goonj_collection_landing_page', 'goonj_collection_camp_landing_page');
-add_shortcode('goonj_collection_camp_past', 'goonj_collection_camp_past_data');
-add_shortcode('goonj_induction_slot_details', 'goonj_induction_slot_details');
-
-/**
- *
- */
-function goonj_check_user_action($atts) {
-  ob_start();
-  get_template_part('templates/form', 'check-user', ['purpose' => $atts['purpose']]);
-  return ob_get_clean();
+function goonj_check_user_action( $atts ) {
+	get_template_part( 'templates/form', 'check-user', array( 'purpose' => $atts['purpose'] ) );
+	return ob_get_clean();
 }
 
-/**
- *
- */
-function goonj_generate_button_html($button_url, $button_text) {
-  ob_start();
-  get_template_part(
-        'templates/primary-button',
-        NULL,
-        [
-          'button_url' => $button_url,
-          'button_text' => $button_text,
-        ]
-  );
+function goonj_generate_button_html( $button_url, $button_text ) {
+	ob_start();
+	get_template_part(
+		'templates/primary-button',
+		null,
+		array(
+			'button_url' => $button_url,
+			'button_text' => $button_text,
+		)
+	);
 
-  return ob_get_clean();
+	return ob_get_clean();
 }
 
-/**
- *
- */
-function goonj_get_contribution_source_field_id() {
-  try {
-    $result = CustomField::get(FALSE)
-      ->addSelect('id')
-      ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
-      ->addWhere('name', '=', 'Source')
-      ->execute();
-
-    if ($result->count() === 0) {
-      \Civi::log()->error('Source custom field not found');
-      return NULL;
-    }
-
-    $sourceField = $result->single();
-    return 'custom_' . $sourceField['id'];
-  }
-  catch (\Exception $e) {
-    \Civi::log()->info('Error retrieving contribution source field', [
-      'error' => $e->getMessage(),
-    ]);
-    return NULL;
-  }
-}
-
-/**
- *
- */
-function goonj_generate_checksum($individualId) {
-  return Contact::getChecksum(FALSE)
-    ->setContactId($individualId)
-    ->setTtl(7 * 24 * 60 * 60)
-    ->execute()
-    ->first()['checksum'];
-}
-
-/**
- *
- */
-function goonj_generate_monetary_button($individualId, $selectedValue) {
-  if (!$selectedValue) {
-    return '';
-  }
-
-  $sourceFieldId = goonj_get_contribution_source_field_id();
-  $checksum = goonj_generate_checksum($individualId);
-
-  $monetaryUrl = "/contribute/?$sourceFieldId=$selectedValue&cid=$individualId&cs=$checksum";
-  $buttonText = __('Monetary Contribution', 'goonj-crm');
-
-  return goonj_generate_button_html($monetaryUrl, $buttonText);
-}
-
-/**
- *
- */
-function goonj_generate_material_contribution_button($individualId, $url = '') {
-  if (!$url) {
-    return '';
-  }
-
-  $checksum = goonj_generate_checksum($individualId);
-  $separator = (strpos($url, '?') !== FALSE) ? '&' : '?';
-  $fullUrl = $url . $separator . http_build_query(['cs' => $checksum]);
-
-  $buttonText = __('Material Contribution', 'goonj-crm');
-
-  return goonj_generate_button_html($fullUrl, $buttonText);
-}
-
-/**
- * Monetary contribution button shortcode.
- */
-function goonj_monetary_contribution_button() {
-  $individualId = isset($_GET['individualId']) ? intval($_GET['individualId']) : 0;
-
-  if (empty($individualId)) {
-    return;
-  }
-
-  try {
-
-    if (empty($individualId)) {
-      \Civi::log()->info('No individual id:', ['individualId' => $individualId]);
-      return;
-    }
-
-    $contactData = Contact::get(FALSE)
-      ->addSelect('source')
-      ->addWhere('id', '=', $individualId)
-      ->execute()
-      ->first();
-
-    $selectedValue = NULL;
-    if (!empty($contactData['source'])) {
-      $parts = explode('/', $contactData['source']);
-      $selectedValue = end($parts);
-    }
-
-    return goonj_generate_monetary_button($individualId, $selectedValue);
-  }
-  catch (\Exception $e) {
-    \Civi::log()->error('Error in goonj_monetary_contribution_button: ' . $e->getMessage());
-    return '';
-  }
-}
-
-/**
- *
- */
-function goonj_material_contribution_button() {
-  $individualId = isset($_GET['individualId']) ? intval($_GET['individualId']) : 0;
-
-  if (empty($individualId)) {
-    return '';
-  }
-
-  try {
-
-    $contactData = Contact::get(FALSE)
-      ->addSelect('source')
-      ->addWhere('id', '=', $individualId)
-      ->execute()
-      ->first();
-
-    $title = $contactData['source'];
-    $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
-      ->addSelect('subtype:name')
-      ->addWhere('title', '=', $title)
-      ->execute()
-      ->first();
-
-    $subtype = $collectionCamps['subtype:name'] ?? '';
-    $id = $collectionCamps['id'];
-    $subtypeToUrlMap = [
-      'Collection_Camp' => "/material-contribution/#?Material_Contribution.Collection_Camp={$id}",
-      'Dropping_Center' => "/dropping-center/material-contribution/#?Material_Contribution.Dropping_Center={$id}",
-      'Institution_Collection_Camp' => "/collection-camp-material-contribution/#?Material_Contribution.Institution_Collection_Camp={$id}",
-      'Institution_Dropping_Center' => "/dropping-center-material-contribution/#?Material_Contribution.Institution_Dropping_Center={$id}",
-    ];
-
-    $url = $subtypeToUrlMap[$subtype] ?? '';
-
-    if ($url) {
-      $separator = (strpos($url, '?') !== FALSE) ? '&' : '?';
-      $url .= $separator . http_build_query(['source_contact_id' => $individualId]);
-    }
-
-    return goonj_generate_material_contribution_button($individualId, $url);
-  }
-  catch (\Exception $e) {
-    \Civi::log()->error('Error in goonj_material_contribution_button: ' . $e->getMessage());
-    return '';
-  }
-}
-
-/**
- * Volunteer signup + monetary contribution button shortcode.
- */
 function goonj_contribution_volunteer_signup_button() {
-  $activityId = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
+	$activity_id = isset( $_GET['activityId'] ) ? intval( $_GET['activityId'] ) : 0;
 
-  if (empty($activityId)) {
-    return;
-  }
+	if ( empty( $activity_id ) ) {
+		\Civi::log()->warning( 'Activity ID is missing' );
+		return;
+	}
 
-  try {
-    $activity = Activity::get(FALSE)
-      ->addSelect('source_contact_id')
-      ->addJoin('ActivityContact AS activity_contact', 'LEFT')
-      ->addWhere('id', '=', $activityId)
-      ->addWhere('activity_type_id:label', '=', 'Material Contribution')
-      ->execute()
-      ->first();
+	try {
+		$activities = \Civi\Api4\Activity::get( false )
+			->addSelect( 'source_contact_id' )
+			->addJoin( 'ActivityContact AS activity_contact', 'LEFT' )
+			->addWhere( 'id', '=', $activity_id )
+			->addWhere( 'activity_type_id:label', '=', 'Material Contribution' )
+			->execute();
 
-    if (empty($activity)) {
-      \Civi::log()->info('No activities found for Activity ID:', ['activityId' => $activityId]);
-      return;
-    }
+		if ( $activities->count() === 0 ) {
+			\Civi::log()->info( 'No activities found for Activity ID:', array( 'activityId' => $activity_id ) );
+			return;
+		}
 
-    $individualId = $activity['source_contact_id'];
+		$activity = $activities->first();
+		$individual_id = $activity['source_contact_id'];
 
-    $contact = Contact::get(FALSE)
-      ->addSelect('contact_sub_type')
-      ->addWhere('id', '=', $individualId)
-      ->execute()
-      ->first();
+		$contact = \Civi\Api4\Contact::get( false )
+			->addSelect( 'contact_sub_type' )
+			->addWhere( 'id', '=', $individual_id )
+			->execute()
+			->first();
 
-    if (empty($contact)) {
-      \Civi::log()->info('Contact not found', ['contact' => $individualId]);
-      return;
-    }
+		if ( empty( $contact ) ) {
+			\Civi::log()->info( 'Contact not found', array( 'contact' => $contact['id'] ) );
+			return;
+		}
 
-    $contactSubTypes = $contact['contact_sub_type'] ?? [];
-    $buttonsHtml = '';
+		$contactSubTypes = $contact['contact_sub_type'] ?? array();
 
-    if (!in_array('Volunteer', $contactSubTypes)) {
-      $redirectPath = '/volunteer-registration/form-with-details/';
-      $redirectPathWithParams = $redirectPath . '#?' . http_build_query([
-        'Individual1' => $individualId,
-        'message' => 'individual-user',
-      ]);
-      $buttonText = __('Wish to Volunteer?', 'goonj-crm');
-      $buttonsHtml .= goonj_generate_button_html($redirectPathWithParams, $buttonText);
-    }
+		// If the individual is already a volunteer, don't show the button
+		if ( in_array( 'Volunteer', $contactSubTypes ) ) {
+			return;
+		}
 
-    $activityDetails = Activity::get(FALSE)
-      ->addSelect(
-          'Material_Contribution.Collection_Camp',
-          'Material_Contribution.Dropping_Center',
-          'Material_Contribution.Institution_Collection_Camp',
-          'Material_Contribution.Institution_Dropping_Center'
-    )
-      ->addWhere('id', '=', $activityId)
-      ->execute()
-      ->first();
+		$redirectPath = '/volunteer-registration/form-with-details/';
+		$redirectPathWithParams = $redirectPath . '#?' . http_build_query(
+			array(
+				'Individual1' => $individual_id,
+				'message' => 'individual-user',
+			)
+		);
+		$buttonText = __( 'Wish to Volunteer?', 'goonj-crm' );
 
-    $fields = [
-      'Material_Contribution.Collection_Camp',
-      'Material_Contribution.Dropping_Center',
-      'Material_Contribution.Institution_Collection_Camp',
-      'Material_Contribution.Institution_Dropping_Center',
-    ];
-
-    $selectedValue = NULL;
-    foreach ($fields as $field) {
-      if (!empty($activityDetails[$field])) {
-        $selectedValue = $activityDetails[$field];
-        break;
-      }
-    }
-
-    $buttonsHtml .= goonj_generate_monetary_button($individualId, $selectedValue);
-
-    return $buttonsHtml;
-  }
-  catch (\Exception $e) {
-    \Civi::log()->error('Error in goonj_contribution_volunteer_signup_button: ' . $e->getMessage());
-    return '';
-  }
+		return goonj_generate_button_html( $redirectPathWithParams, $buttonText );
+	} catch ( \Exception $e ) {
+		\Civi::log()->error( 'Error in goonj_contribution_volunteer_signup_button: ' . $e->getMessage() );
+		return;
+	}
 }
 
-/**
- *
- */
 function goonj_pu_activity_button() {
-  if (!isset($_GET['activityId'])) {
-    return;
-  }
+	if ( ! isset( $_GET['activityId'] ) ) {
+		return;
+	}
 
-  $activity_id = absint($_GET['activityId']);
+	$activity_id = absint( $_GET['activityId'] );
 
-  try {
-    $activity = Activity::get(FALSE)
-      ->addSelect('custom.*', 'source_contact_id', 'Office_Visit.Goonj_Processing_Center', 'Material_Contribution.Goonj_Office', 'activity_type_id:name')
-      ->addWhere('id', '=', $activity_id)
-      ->execute()
-      ->first();
+	try {
+		$activity = \Civi\Api4\Activity::get(false)
+			->addSelect('custom.*', 'source_contact_id', 'Office_Visit.Goonj_Processing_Center', 'Material_Contribution.Goonj_Office', 'activity_type_id:name')
+			->addWhere('id', '=', $activity_id)
+			->execute()
+			->first();
+		
+		if (!$activity) {
+			\Civi::log()->info('No activity found', ['activityId' => $activityId]);
+			return;
+		}
 
-    if (!$activity) {
-      \Civi::log()->info('No activity found', ['activityId' => $activity_id]);
-      return;
-    }
+		$individual_id = $activity['source_contact_id'];
 
-    $individual_id = $activity['source_contact_id'];
+		$office_id = goonj_get_goonj_office_id( $activity );
 
-    $office_id = goonj_get_goonj_office_id($activity);
+		if ( ! $office_id ) {
+			\Civi::log()->info( 'Goonj Office ID is null for Activity ID:', array( 'activityId' => $activity_id ) );
+			return;
+		}
 
-    if (!$office_id) {
-      \Civi::log()->info('Goonj Office ID is null for Activity ID:', ['activityId' => $activity_id]);
-      return;
-    }
+		return goonj_generate_activity_button( $activity, $office_id, $individual_id );
 
-    return goonj_generate_activity_button($activity, $office_id, $individual_id);
-
-  }
-  catch (\Exception $e) {
-    \Civi::log()->error('Error in goonj_pu_activity_button: ' . $e->getMessage());
-    return;
-  }
+	} catch ( \Exception $e ) {
+		\Civi::log()->error( 'Error in goonj_pu_activity_button: ' . $e->getMessage() );
+		return;
+	}
 }
 
-/**
- *
- */
 function goonj_collection_camp_landing_page() {
-  ob_start();
-  get_template_part('templates/collection-landing-page');
-  return ob_get_clean();
+	ob_start();
+	get_template_part( 'templates/collection-landing-page' );
+	return ob_get_clean();
 }
 
-/**
- *
- */
 function goonj_collection_camp_past_data() {
-  ob_start();
-  get_template_part('templates/collection-camp-data');
-  return ob_get_clean();
+	ob_start();
+	get_template_part( 'templates/collection-camp-data' );
+	return ob_get_clean();
 }
 
-/**
- *
- */
 function goonj_induction_slot_details() {
-  // Retrieve parameters from the GET request.
-  $source_contact_id = intval($_GET['source_contact_id'] ?? 0);
-  $slot_date = $_GET['slot_date'] ?? '';
-  $slot_time = $_GET['slot_time'] ?? '';
-  $inductionType = $_GET['induction_type'] ?? '';
+    // Retrieve parameters from the GET request
+    $source_contact_id = intval($_GET['source_contact_id'] ?? 0);
+    $slot_date = $_GET['slot_date'] ?? '';
+    $slot_time = $_GET['slot_time'] ?? '';
+    $inductionType = $_GET['induction_type'] ?? '';
 
-  try {
-    // Fetch the induction activity for the specified source contact.
-    $inductionActivity = Activity::get(FALSE)
-      ->addSelect('id', 'activity_date_time', 'status_id:name', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
-      ->addWhere('source_contact_id', '=', $source_contact_id)
-      ->addWhere('activity_type_id:name', '=', 'Induction')
-      ->execute()->single();
+    try {
+        // Fetch the induction activity for the specified source contact
+        $inductionActivity = \Civi\Api4\Activity::get(FALSE)
+            ->addSelect('id', 'activity_date_time', 'status_id:name', 'Induction_Fields.Goonj_Office', 'Induction_Fields.Assign')
+            ->addWhere('source_contact_id', '=', $source_contact_id)
+            ->addWhere('activity_type_id:name', '=', 'Induction')
+            ->execute()->single();
 
-    // Exit if no activity found or the status is not "To be Scheduled".
-    if (!$inductionActivity || $inductionActivity['status_id:name'] !== 'To be scheduled') {
-      \Civi::log()->info('No valid activity found or status is not To be Scheduled', ['contact_id' => $source_contact_id]);
-      return;
-    }
-    // Combine slot date (d-m-Y) and slot time (h:i A) to form new activity date and time.
-    $newActivityDateTime = DateTime::createFromFormat('d-m-Y h:i A', "$slot_date $slot_time");
-    if (!$newActivityDateTime) {
-      \Civi::log()->error('Invalid date/time format', ['slot_date' => $slot_date, 'slot_time' => $slot_time]);
-      return;
-    }
+        // Exit if no activity found or the status is not "To be Scheduled"
+        if (!$inductionActivity || $inductionActivity['status_id:name'] !== 'To be scheduled') {
+            \Civi::log()->info('No valid activity found or status is not To be Scheduled', ['contact_id' => $source_contact_id]);
+            return;
+        }
 
-    // Update activity date and time and set the status to "Scheduled".
-    Activity::update(FALSE)
-      ->addValue('activity_date_time', $newActivityDateTime->format('Y-m-d H:i:s'))
-      ->addValue('status_id:name', 'Scheduled')
-      ->addValue('Induction_Fields.Mode:name', $inductionType)
-      ->addWhere('id', '=', $inductionActivity['id'])
-      ->execute();
+		// Combine slot date (d-m-Y) and slot time (h:i A) to form new activity date and time
+		$newActivityDateTime = DateTime::createFromFormat('d-m-Y h:i A', "$slot_date $slot_time");
+		if (!$newActivityDateTime) {
+			\Civi::log()->error('Invalid date/time format', ['slot_date' => $slot_date, 'slot_time' => $slot_time]);
+			return;
+		}
 
-    \Civi::log()->info('Activity updated successfully', [
-      'activity_id' => $inductionActivity['id'],
-      'new_date_time' => $newActivityDateTime->format('Y-m-d H:i:s'),
-    ]);
 
-    // Select the email template based on the induction type.
-    $templateTitle = ($inductionType == 'Processing_Unit')
-            ? 'Acknowledgment_for_Induction_Slot_Booked'
+        // Update activity date and time and set the status to "Scheduled"
+        \Civi\Api4\Activity::update(FALSE)
+            ->addValue('activity_date_time', $newActivityDateTime->format('Y-m-d H:i:s'))
+            ->addValue('status_id:name', 'Scheduled')
+            ->addValue('Induction_Fields.Mode:name', $inductionType)
+            ->addWhere('id', '=', $inductionActivity['id'])
+            ->execute();
+        \Civi::log()->info('Activity updated successfully', [
+            'activity_id' => $inductionActivity['id'],
+            'new_date_time' => $newActivityDateTime->format('Y-m-d H:i:s')
+        ]);
+
+        // Select the email template based on the induction type
+        $templateTitle = ($inductionType == 'Processing_Unit') 
+            ? 'Acknowledgment_for_Induction_Slot_Booked' 
             : 'Acknowledgment_for_Online_Induction_Slot_Booked';
 
-    // If a template is found, send the email notification.
-    $template = MessageTemplate::get(FALSE)
-      ->addWhere('msg_title', 'LIKE', $templateTitle . '%')
-      ->execute()->single();
+        // Fetch the email template
+        $template = \Civi\Api4\MessageTemplate::get(FALSE)
+            ->addWhere('msg_title', 'LIKE', $templateTitle . '%')
+            ->execute()->single();
 
-    if ($template) {
-      $assigneeContact = Contact::get(FALSE)
-        ->addSelect('email.email')
-        ->addJoin('Email AS email', 'LEFT')
-        ->addWhere('id', '=', $inductionActivity['Induction_Fields.Assign'])
-        ->execute()->single();
+        // If a template is found, send the email notification
+        if ($template) {
+            $assigneeContact = \Civi\Api4\Contact::get(FALSE)
+                ->addSelect('email.email')
+                ->addJoin('Email AS email', 'LEFT')
+                ->addWhere('id', '=', $inductionActivity['Induction_Fields.Assign'])
+				->execute()->single();
 
-      // Prepare email parameters.
-      $emailParams = [
-        'contact_id' => $source_contact_id,
-        'template_id' => $template['id'],
-        'cc' => $assigneeContact['email.email'],
-      ];
+            // Prepare email parameters
+            $emailParams = [
+                'contact_id' => $source_contact_id,
+                'template_id' => $template['id'],
+                'cc' => $assigneeContact['email.email']
+            ];
 
-      // Send the email.
-      $emailResult = civicrm_api3('Email', 'send', $emailParams);
+            // Send the email
+            $emailResult = civicrm_api3('Email', 'send', $emailParams);
+        }
+    } catch (\Exception $e) {
+        \Civi::log()->error('Error processing induction slot details', [
+            'contact_id' => $source_contact_id,
+            'error' => $e->getMessage()
+        ]);
     }
-  }
-  catch (\Exception $e) {
-    \Civi::log()->error('Error processing induction slot details', [
-      'contact_id' => $source_contact_id,
-      'error' => $e->getMessage(),
-    ]);
-  }
 }

--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -1,8 +1,15 @@
 <?php
 
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\EckEntity;
+
 add_shortcode( 'goonj_check_user_form', 'goonj_check_user_action' );
 add_shortcode( 'goonj_volunteer_message', 'goonj_custom_message_placeholder' );
 add_shortcode( 'goonj_contribution_volunteer_signup_button', 'goonj_contribution_volunteer_signup_button' );
+add_shortcode('goonj_monetary_contribution_button', 'goonj_monetary_contribution_button');
+add_shortcode('goonj_material_contribution_button', 'goonj_material_contribution_button');
 add_shortcode( 'goonj_pu_activity_button', 'goonj_pu_activity_button' );
 add_shortcode( 'goonj_collection_landing_page', 'goonj_collection_camp_landing_page' );
 add_shortcode( 'goonj_collection_camp_past', 'goonj_collection_camp_past_data' );
@@ -25,6 +32,181 @@ function goonj_generate_button_html( $button_url, $button_text ) {
 	);
 
 	return ob_get_clean();
+}
+
+function goonj_get_contribution_source_field_id() {
+  try {
+    $result = CustomField::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('custom_group_id:name', '=', 'Contribution_Details')
+      ->addWhere('name', '=', 'Source')
+      ->execute();
+
+    if ($result->count() === 0) {
+      \Civi::log()->error('Source custom field not found');
+      return NULL;
+    }
+
+    $sourceField = $result->single();
+    return 'custom_' . $sourceField['id'];
+  }
+  catch (\Exception $e) {
+    \Civi::log()->info('Error retrieving contribution source field', [
+      'error' => $e->getMessage(),
+    ]);
+    return NULL;
+  }
+}
+
+/**
+ *
+ */
+function goonj_generate_checksum($individualId) {
+  return Contact::getChecksum(FALSE)
+    ->setContactId($individualId)
+    ->setTtl(7 * 24 * 60 * 60)
+    ->execute()
+    ->first()['checksum'];
+}
+
+/**
+ *
+ */
+function goonj_generate_monetary_button($individualId, $id) {
+  if (!$id) {
+    return '';
+  }
+
+  $sourceFieldId = goonj_get_contribution_source_field_id();
+  $checksum = goonj_generate_checksum($id);
+
+  $monetaryUrl = "/contribute/?$sourceFieldId=$id&cid=$individualId&cs=$checksum";
+  $buttonText = __('Monetary Contribution', 'goonj-crm');
+
+  return goonj_generate_button_html($monetaryUrl, $buttonText);
+}
+
+/**
+ *
+ */
+function goonj_generate_material_contribution_button($individualId, $url = '') {
+  if (!$url) {
+    return '';
+  }
+
+  $checksum = goonj_generate_checksum($individualId);
+  $separator = (strpos($url, '?') !== FALSE) ? '&' : '?';
+  $fullUrl = $url . $separator . http_build_query(['cs' => $checksum]);
+
+  $buttonText = __('Material Contribution', 'goonj-crm');
+
+  return goonj_generate_button_html($fullUrl, $buttonText);
+}
+
+/**
+ * Monetary contribution button shortcode.
+ */
+function goonj_monetary_contribution_button() {
+	$individualId = isset($_GET['individualId']) ? intval($_GET['individualId']) : 0;
+	$activityId = isset($_GET['activityId']) ? intval($_GET['activityId']) : 0;
+
+	if ($activityId) {
+			$activities = Activity::get(false)
+					->addSelect('source_contact_id')
+					->addWhere('id', '=', $activityId)
+					->addWhere('activity_type_id:label', '=', 'Material Contribution')
+					->execute();
+
+			if ($activities->count() === 0) {
+					\Civi::log()->info('No activities found for Activity ID: ' . $activityId);
+					return;
+			}
+
+			$activity = $activities->first();
+			$individualId = $activity['source_contact_id'];
+	}
+
+	try {
+			// Fetch contact data
+			$contactData = Contact::get(FALSE)
+					->addSelect('source')
+					->addWhere('id', '=', $individualId)
+					->execute()
+					->first();
+
+			if (empty($contactData)) {
+					return;
+			}
+
+			$title = $contactData['source'];
+
+			$collectionCamps = EckEntity::get('Collection_Camp', FALSE)
+					->addSelect('id')
+					->addWhere('title', '=', $title)
+					->execute()
+					->first();
+
+			if (empty($collectionCamps)) {
+					\Civi::log()->info('No collection camp found for title: ' . $title);
+					return;
+			}
+
+			$id = $collectionCamps['id'];
+
+			return goonj_generate_monetary_button($individualId, $id);
+	} catch (\Exception $e) {
+			\Civi::log()->error('Error in goonj_monetary_contribution_button: ' . $e->getMessage());
+			return '';
+	}
+}
+
+/**
+ *
+ */
+function goonj_material_contribution_button() {
+  $individualId = isset($_GET['individualId']) ? intval($_GET['individualId']) : 0;
+
+  if (empty($individualId)) {
+    return '';
+  }
+
+  try {
+
+    $contactData = Contact::get(FALSE)
+      ->addSelect('source')
+      ->addWhere('id', '=', $individualId)
+      ->execute()
+      ->first();
+
+    $title = $contactData['source'];
+    $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
+      ->addSelect('subtype:name')
+      ->addWhere('title', '=', $title)
+      ->execute()
+      ->first();
+
+    $subtype = $collectionCamps['subtype:name'] ?? '';
+    $id = $collectionCamps['id'];
+    $subtypeToUrlMap = [
+      'Collection_Camp' => "/material-contribution/#?Material_Contribution.Collection_Camp={$id}",
+      'Dropping_Center' => "/dropping-center/material-contribution/#?Material_Contribution.Dropping_Center={$id}",
+      'Institution_Collection_Camp' => "/collection-camp-material-contribution/#?Material_Contribution.Institution_Collection_Camp={$id}",
+      'Institution_Dropping_Center' => "/dropping-center-material-contribution/#?Material_Contribution.Institution_Dropping_Center={$id}",
+    ];
+
+    $url = $subtypeToUrlMap[$subtype] ?? '';
+
+    if ($url) {
+      $separator = (strpos($url, '?') !== FALSE) ? '&' : '?';
+      $url .= $separator . http_build_query(['source_contact_id' => $individualId]);
+    }
+
+    return goonj_generate_material_contribution_button($individualId, $url);
+  }
+  catch (\Exception $e) {
+    \Civi::log()->error('Error in goonj_material_contribution_button: ' . $e->getMessage());
+    return '';
+  }
 }
 
 function goonj_contribution_volunteer_signup_button() {


### PR DESCRIPTION
Add monetary contribution URL with prefilled source

1. Modified the goonj_contribution_volunteer_signup_button function and  goonj_contribution_monetary_button to fetch custom field values from the activity.
2. Added logic to select the appropriate custom field value for the 'Source' parameter.
3. Generated a secure URL with a checksum for the monetary contribution form.
4. Ensured the button is only displayed when a valid source value is available.

Add Material contribution button on 'volunteer with goonj` flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - The volunteer signup section now displays multiple action buttons, including a secure monetary contribution option when eligible.
  - Added new shortcodes to display monetary and material contribution buttons with secure, time-limited access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->