### PR TITLE
Return first non-empty collection camp ID from activity fields

### DIFF
--- a/wp-content/themes/goonj-crm/engine/shortcodes.php
+++ b/wp-content/themes/goonj-crm/engine/shortcodes.php
@@ -177,7 +177,10 @@ function getCollectionCampIdFromActivity($activityId) {
     return;
   }
 
-  foreach ($activities as $value) {
+  foreach ($activities as $key => $value) {
+    if ($key === 'id') {
+      continue;
+    }
     if (!empty($value)) {
       return $value;
     }


### PR DESCRIPTION
This update modifies the getCollectionCampIdFromActivity function to return the first non-empty value from a predefined list of collection-related fields instead of returning the id.