### PR TITLE
Handle delete mapping

### DIFF
--- a/wp-content/civi-extensions/civiglific/CRM/Civiglific/Page/GroupMapping.php
+++ b/wp-content/civi-extensions/civiglific/CRM/Civiglific/Page/GroupMapping.php
@@ -32,6 +32,9 @@ class CRM_Civiglific_Page_GroupMapping extends CRM_Core_Page {
     if (!empty($_POST['add_rule'])) {
       $this->handleRuleSubmission();
     }
+    elseif (!empty($_POST['delete_rule']) && !empty($_POST['delete_mapping_id'])) {
+      $this->handleDeleteMapping((int) $_POST['delete_mapping_id']);
+    }
 
     $mappings = $this->getExistingMappings($civicrmGroups, $glificGroups);
 
@@ -143,6 +146,23 @@ class CRM_Civiglific_Page_GroupMapping extends CRM_Core_Page {
     }
 
     return $mappings;
+  }
+
+  /**
+   *
+   */
+  protected function handleDeleteMapping($mappingId) {
+    try {
+      GlificGroupMap::delete()
+        ->addWhere('id', '=', $mappingId)
+        ->execute();
+
+      $this->assign('success_message', 'Mapping deleted successfully.');
+    }
+    catch (Exception $e) {
+      CRM_Core_Error::debug_log_message('Error deleting Glific Group Map: ' . $e->getMessage());
+      $this->assign('error_message', 'Failed to delete mapping: ' . $e->getMessage());
+    }
   }
 
 }

--- a/wp-content/civi-extensions/civiglific/templates/CRM/Civiglific/Page/GroupMapping.tpl
+++ b/wp-content/civi-extensions/civiglific/templates/CRM/Civiglific/Page/GroupMapping.tpl
@@ -61,6 +61,7 @@
         <th>Glific Group ID</th>
         <th>Glific Group Name</th>
         <th>Last Sync Date</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -71,6 +72,12 @@
           <td>{$map.group_id}</td>
           <td>{$map.glific_group_name|escape}</td>
           <td>{$map.last_sync_date|default:'N/A'}</td>
+          <td>
+            <form method="post" action="" style="display:inline;">
+              <input type="hidden" name="delete_mapping_id" value="{$map.id}">
+              <input type="submit" name="delete_rule" value="Delete" class="crm-button crm-button-delete" onclick="return confirm('Are you sure you want to delete this mapping?');">
+            </form>
+          </td>
         </tr>
       {/foreach}
     </tbody>


### PR DESCRIPTION
Handle delete mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete individual group mappings directly from the "Existing Group Mappings" table, with a confirmation prompt to prevent accidental deletions.
- **User Interface**
  - Introduced an "Actions" column with a "Delete" button for each group mapping entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->