### PR TITLE
fix: lock before generating invoice number

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1697,7 +1697,7 @@ class CollectionCampService extends AutoSubscriber {
         FROM civicrm_option_value ov
         JOIN civicrm_option_group og ON ov.option_group_id = og.id
         WHERE og.name = 'invoice_sequence'
-          AND ov.name = $invoiceSeqName
+          AND ov.name = '$invoiceSeqName'
         FOR UPDATE
       ");
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1669,7 +1669,7 @@ class CollectionCampService extends AutoSubscriber {
       return;
     }
 
-    $lock = \Civi::lockManager()->acquire('invoice_number_generation');
+    $lock = \Civi::lockManager()->acquire('worker.custom.invoice_number');
     if (!$lock->isAcquired()) {
       \Civi::log()->warning('Could not acquire lock for invoice number generation. Skipping for contribution ID: ' . $objectRef->id);
       return;

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1688,20 +1688,21 @@ class CollectionCampService extends AutoSubscriber {
         return;
       }
 
+      $invoiceSeqName = 'GNJCRM_25_26';
+
       \CRM_Core_DAO::executeQuery('START TRANSACTION');
 
-      // 🔐 Lock option_value row for this prefix
       $dao = \CRM_Core_DAO::executeQuery("
         SELECT ov.id, ov.value, ov.label
         FROM civicrm_option_value ov
         JOIN civicrm_option_group og ON ov.option_group_id = og.id
         WHERE og.name = 'invoice_sequence'
-          AND ov.name = 'GNJCRM_25_26'
+          AND ov.name = $invoiceSeqName
         FOR UPDATE
       ");
 
       if (!$dao->fetch()) {
-        throw new \Exception("Invoice sequence not initialized for prefix GNJCRM_25_26");
+        throw new \Exception("Invoice sequence not initialized for prefix $invoiceSeqName");
       }
 
       $last = (int) $dao->value;


### PR DESCRIPTION
Update logic for invoice number generation.

### Requirement to fix the issue

1. Lock one specific row.
2. Prevents any other transaction from accessing it until you’re done.
3. Makes your increment + update atomic.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or invalid data during campaign and invoice processing, reducing the chance of errors.
- **Refactor**
  - Enhanced the process for generating invoice numbers to ensure greater reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->