### PR TITLE
Add API Key Extension

### DIFF
--- a/wp-content/civi-extensions/apikey-1.5.0/CRM/Contact/Form/APIKey.php
+++ b/wp-content/civi-extensions/apikey-1.5.0/CRM/Contact/Form/APIKey.php
@@ -1,0 +1,101 @@
+<?php
+
+// phpcs:disable
+/*
++--------------------------------------------------------------------------+
+| Copyright IT Bliss LLC (c) 2013                                          |
++--------------------------------------------------------------------------+
+| This program is free software: you can redistribute it and/or modify     |
+| it under the terms of the GNU Affero General Public License as published |
+| by the Free Software Foundation, either version 3 of the License, or     |
+| (at your option) any later version.                                      |
+|                                                                          |
+| This program is distributed in the hope that it will be useful,          |
+| but WITHOUT ANY WARRANTY; without even the implied warranty of           |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            |
+| GNU Affero General Public License for more details.                      |
+|                                                                          |
+| You should have received a copy of the GNU Affero General Public License |
+| along with this program.  If not, see <http://www.gnu.org/licenses/>.    |
++--------------------------------------------------------------------------+
+*/
+// phpcs:enable
+
+use CRM_Apikey_ExtensionUtil as E;
+
+class CRM_Contact_Form_APIKey extends CRM_Core_Form {
+
+  function preProcess() {
+    $isAdmin = CRM_Core_Permission::check([['administer CiviCRM', 'edit all contacts']]);
+    $canEdit = CRM_Core_Permission::check([['edit own API key', 'edit all API keys']]);
+    if (!($isAdmin || $canEdit)) {
+      CRM_Core_Error::statusBounce(E::ts('You do not have permission to edit API keys for this contact.'));
+    }
+    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');
+    $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
+    $this->_apiKey = NULL;
+    if ($this->_contactId) {
+      $this->_apiKey = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $this->_contactId, 'api_key');
+    }
+  }
+
+  function buildQuickForm() {
+    $this->applyFilter('__ALL__', 'trim');
+    $this->add(
+      'text',
+      'api_key',
+      E::ts('API Key'),
+      ['size' => "32", 'maxlength' => "32"]
+    );
+    $buttons = [
+      [
+        'type' => 'upload',
+        'name' => E::ts('Save'),
+        'subName' => 'view',
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => E::ts('Cancel'),
+      ],
+    ];
+    $this->addButtons($buttons);
+  }
+
+  /**
+   * This function sets the default values for the form.
+   * 
+   * Note: In edit/view mode the default values are retrieved from the database.
+   *
+   * @access public
+   *
+   * @return None
+   */
+  function setDefaultValues() {
+    return ['api_key' => $this->_apiKey];
+  }
+
+  /**
+   * Form submission of new/edit api is processed.
+   *
+   * @access public
+   *
+   * @return None
+   */
+  public function postProcess() {
+    //Get the submitted values in an array.
+    $params = $this->controller->exportValues($this->_name);
+    if (!empty($this->_contactId)) {
+      CRM_Core_DAO::setFieldValue('CRM_Contact_DAO_Contact', $this->_contactId, 'api_key', $params['api_key']);
+    }
+
+    if (!empty($params['api_key'])) {
+      CRM_Core_Session::setStatus("This API key has been updated.");
+    } else {
+      CRM_Core_Session::setStatus("This API key has been deleted.");
+    }
+    $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$this->_contactId}");
+    CRM_Core_Session::singleton()->pushUserContext($url);
+  }
+
+}

--- a/wp-content/civi-extensions/apikey-1.5.0/CRM/Contact/Page/View/APIKey.php
+++ b/wp-content/civi-extensions/apikey-1.5.0/CRM/Contact/Page/View/APIKey.php
@@ -1,0 +1,107 @@
+<?php
+
+// phpcs:disable
+/*
++--------------------------------------------------------------------------+
+| Copyright IT Bliss LLC (c) 2013                                          |
++--------------------------------------------------------------------------+
+| This program is free software: you can redistribute it and/or modify     |
+| it under the terms of the GNU Affero General Public License as published |
+| by the Free Software Foundation, either version 3 of the License, or     |
+| (at your option) any later version.                                      |
+|                                                                          |
+| This program is distributed in the hope that it will be useful,          |
+| but WITHOUT ANY WARRANTY; without even the implied warranty of           |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            |
+| GNU Affero General Public License for more details.                      |
+|                                                                          |
+| You should have received a copy of the GNU Affero General Public License |
+| along with this program.  If not, see <http://www.gnu.org/licenses/>.    |
++--------------------------------------------------------------------------+
+*/
+// phpcs:enable
+
+use CRM_Apikey_ExtensionUtil as E;
+
+class CRM_Contact_Page_View_APIKey extends CRM_Core_Page {
+
+  function preProcess() {
+    $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
+    $this->assign('contactId', $this->_contactId);
+    $contact = new CRM_Contact_BAO_Contact();
+    $contact->get('id', $this->_contactId);
+    $this->_apiKey = $contact->api_key;
+    $this->assign('apiKey', $this->_apiKey);
+    // Check logged in url permission.
+    CRM_Contact_Page_View::checkUserPermission($this);
+    // Set page title.
+    CRM_Contact_Page_View::setTitle($this->_contactId);
+    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
+    $this->assign('action', $this->_action);
+    $isAdmin = CRM_Core_Permission::check([['administer CiviCRM', 'edit all contacts']]);
+    $canView = CRM_Core_Permission::check([['view own API key', 'view all API keys']]);
+    $canEdit = CRM_Core_Permission::check([['edit own API key', 'edit all API keys']]);
+    $canViewSiteKey = CRM_Core_Permission::check(['view site key']);
+    $this->assign('isAdmin', $isAdmin);
+    $this->assign('canView', $canView);
+    $this->assign('canEdit', $canEdit);
+    $this->assign('canViewSiteKey', $canViewSiteKey);
+    if ($canViewSiteKey) {
+      $siteKey = CRM_Utils_Constant::value('CIVICRM_SITE_KEY');
+      if ($siteKey) {
+        $this->assign('siteKey', $siteKey);
+      } else {
+        $message = E::ts('The administrator has restricted the ability to view the site key.');
+        $this->assign('siteKey', $message);
+      }      
+    }
+
+    $urlParam = 'reset=1&action=add&cid=' . $this->_contactId;
+    $buttonString = E::ts('Add API Key');
+    $buttonIcon = 'fa-plus';
+    if ($this->_apiKey) {
+      $urlParam = 'reset=1&action=edit&cid=' . $this->_contactId;
+      $buttonString = E::ts('Edit API Key');
+      $buttonIcon = 'fa-pencil';
+    }
+    $this->assign('addEditApiKeyPath', 'civicrm/contact/apikey');
+    $this->assign('addEditApiKeyQuery', $urlParam);
+    $this->assign('addEditApiButtonString', $buttonString);
+    $this->assign('addEditApiButtonIcon', $buttonIcon);
+  }
+
+  /**
+   * This function is called when action is update or new.
+   *
+   * @access public
+   */
+  function edit() {
+    $controller = new CRM_Core_Controller_Simple('CRM_Contact_Form_APIKey', E::ts('API Key'), $this->_action);
+    $controller->setEmbedded(TRUE);
+    // Set the userContext stack.
+    $session = CRM_Core_Session::singleton();
+    $url = CRM_Utils_System::url('civicrm/contact/view/apikey', 'action=browse&selectedChild=apikey&cid=' . $this->_contactId);
+    $session->pushUserContext($url);
+    $controller->reset();
+    $controller->set('contactId', $this->_contactId);
+    $controller->process();
+    $controller->run();
+  }
+
+  /**
+   * This function is the main function that is called when the page loads,
+   *
+   * This decides the which action has to be taken for the page.
+   *
+   * @return null
+   * @access public
+   */
+  function run() {
+    $this->preProcess();
+    if ($this->_action & (CRM_Core_Action::UPDATE | CRM_Core_Action::ADD)) {
+      $this->edit();
+    }
+    return parent::run();
+  }
+
+}

--- a/wp-content/civi-extensions/apikey-1.5.0/apikey.civix.php
+++ b/wp-content/civi-extensions/apikey-1.5.0/apikey.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Apikey_ExtensionUtil {
+  const SHORT_NAME = 'apikey';
+  const LONG_NAME = 'com.cividesk.apikey';
+  const CLASS_PREFIX = 'CRM_Apikey';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Apikey_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _apikey_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _apikey_civix_civicrm_install() {
+  _apikey_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _apikey_civix_civicrm_enable(): void {
+  _apikey_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _apikey_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _apikey_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _apikey_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _apikey_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _apikey_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _apikey_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _apikey_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _apikey_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/wp-content/civi-extensions/apikey-1.5.0/apikey.php
+++ b/wp-content/civi-extensions/apikey-1.5.0/apikey.php
@@ -1,0 +1,99 @@
+<?php
+
+// phpcs:disable
+/*
++--------------------------------------------------------------------------+
+| Copyright IT Bliss LLC (c) 2013                                          |
++--------------------------------------------------------------------------+
+| This program is free software: you can redistribute it and/or modify     |
+| it under the terms of the GNU Affero General Public License as published |
+| by the Free Software Foundation, either version 3 of the License, or     |
+| (at your option) any later version.                                      |
+|                                                                          |
+| This program is distributed in the hope that it will be useful,          |
+| but WITHOUT ANY WARRANTY; without even the implied warranty of           |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            |
+| GNU Affero General Public License for more details.                      |
+|                                                                          |
+| You should have received a copy of the GNU Affero General Public License |
+| along with this program.  If not, see <http://www.gnu.org/licenses/>.    |
++--------------------------------------------------------------------------+
+*/
+// phpcs:enable
+
+require_once 'apikey.civix.php';
+use CRM_Apikey_ExtensionUtil as E;
+
+/**
+ * Implements hook_civicrm_config().
+ */
+function apikey_civicrm_config(&$config) {
+  _apikey_civix_civicrm_config($config);
+}
+
+/**
+ * Implements hook_civicrm_install().
+ */
+function apikey_civicrm_install() {
+  return _apikey_civix_civicrm_install();
+}
+
+/**
+ * Implements hook_civicrm_enable().
+ */
+function apikey_civicrm_enable() {
+  return _apikey_civix_civicrm_enable();
+}
+
+/**
+ * Implements hook_civicrm_tabset().
+ */
+function apikey_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName == 'civicrm/contact/view') {
+    $contactID = $context['contact_id'];
+    $isAdmin = CRM_Core_Permission::check([['administer CiviCRM', 'edit all contacts']]);
+    $canEdit = CRM_Core_Permission::check(['edit own API key', 'edit all API keys']);
+    $canView = CRM_Core_Permission::check(['view own API key', 'view all API keys']);
+    if ($isAdmin || $canEdit || $canView) {
+      $url = CRM_Utils_System::url('civicrm/contact/view/apikey', "reset=1&cid={$contactID}&snippet=1");
+      $tabs[] = [
+        'id' => 'apiKey',
+        'url' => $url,
+        'title' => E::ts('API Key'),
+        'weight' => 300,
+        'icon' => 'crm-i fa-key',
+        'contact_type' => ['Individual'],
+        'count' => $contactID && CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'api_key') ? 1 : 0,
+      ];
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_permission().
+ */
+function apikey_civicrm_permission(&$permissions, &$all_permissions = NULL) {
+  $prefix = E::ts('APIKey') . ': ';
+  $permissions += [
+    'view own API key' => [
+      'label' => $prefix . E::ts('View own API key'),
+      'description' => E::ts('Allows contacts to view their own API key on their contact summary screen/record.'),
+    ],
+    'edit own API key' => [
+      'label' => $prefix . E::ts('Edit own API key'),
+      'description' => E::ts('Allows contacts to edit their own API key on their contact summary screen/record'),
+    ],
+    'view site key' => [
+      'label' => $prefix . E::ts('View site key'),
+      'description' => E::ts('Allows contacts to view the site key on their contact summary screen/record.'),
+    ],
+    'view all API keys' => [
+      'label' => $prefix . E::ts('View all API keys'),
+      'description' => E::ts('Allows users to view API keys for all contacts.'),
+    ],
+    'edit all API keys' => [
+      'label' => $prefix . E::ts('Edit all API keys'),
+      'description' => E::ts('Allows users to edit API keys for all contacts.'),
+    ],
+  ];
+}

--- a/wp-content/civi-extensions/apikey-1.5.0/info.xml
+++ b/wp-content/civi-extensions/apikey-1.5.0/info.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<extension key="com.cividesk.apikey" type="module">
+  <file>apikey</file>
+  <name>API Key Management</name>
+  <description>This extension allows the management of user API access keys.</description>
+  <urls>
+    <url desc="Licensing">http://civicrm.org/licensing</url>
+    <url desc="Main Extension Page">http://www.cividesk.com</url>
+    <url desc="Support">http://forum.civicrm.org</url>
+  </urls>
+  <license>AGPL v3</license>
+  <maintainer>
+    <author>Nicolas Ganivet</author>
+    <email>nicolas@cividesk.com</email>
+  </maintainer>
+  <authors>
+    <author>
+      <name>Nicolas Ganivet</name>
+      <email>nicolas@cividesk.com</email>
+      <homepage>https://cividesk.com</homepage>
+      <role>Maintainer</role>
+    </author>
+    <author>
+      <name>Mikey O'Toole</name>
+      <email>mikey@mjco.uk</email>
+      <homepage>https://mjco.uk</homepage>
+      <role>Maintainer</role>
+    </author>
+  </authors>
+  <releaseDate>2024-04-09</releaseDate>
+  <version>1.5.0</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.69</ver>
+  </compatibility>
+  <downloadUrl>https://lab.civicrm.org/extensions/apikey/-/archive/v1.4.0/apikey-v1.4.0.zip</downloadUrl>
+  <comments>Once installed, an 'API Key' tab will be available on contact screens for which you are authorized to manage the key. You are authorized either if the contact if yourself, or if you are an administrator with the 'edit all contacts' permission.</comments>
+  <civix>
+    <namespace>CRM/Apikey</namespace>
+    <format>23.02.1</format>
+  </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>smarty-v2@1.0.1</mixin>
+  </mixins>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+</extension>

--- a/wp-content/civi-extensions/apikey-1.5.0/readme.md
+++ b/wp-content/civi-extensions/apikey-1.5.0/readme.md
@@ -1,0 +1,1 @@
+This repository has moved to CiviCRM's GitLab here: https://lab.civicrm.org/extensions/apikey

--- a/wp-content/civi-extensions/apikey-1.5.0/templates/CRM/Contact/Form/APIKey.tpl
+++ b/wp-content/civi-extensions/apikey-1.5.0/templates/CRM/Contact/Form/APIKey.tpl
@@ -1,0 +1,60 @@
+{* this template is used to add/edit the API Key for a contact *}
+
+<div class="form-item">
+  <fieldset><legend>{ts}API Key{/ts}</legend>
+    <div class="crm-block crm-form-block crm-cividesk-api-form-block">
+      <table class="form-layout-compressed">
+        <tr style="display:none;" class="crm-apikey-form-block">
+          <td class="label"></td>
+          <td><div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div></td>
+        </tr>
+        <tr style="display:none;" class="crm-apikey-form-block">
+          <td class="label"></td>
+          <td></td>
+        </tr>
+        <tr class="crm-apikey-form-block">
+          <td class="label">{$form.api_key.label}</td>
+          <td>
+            {$form.api_key.html}&nbsp;{crmButton style="display:inline-block;vertical-align:middle;float:none!important;" href="javascript:void(0);" id="api_key_generate" class="generate-apikey" title="Generate API Key" icon="fa-key"}{ts}Generate{/ts}{/crmButton}
+          </td>  
+        </tr>
+        <tr class="crm-apikey-form-block">
+          <td class="label"></td>
+          <td>
+            <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </fieldset>
+</div>
+                                            
+<style type="text/css">
+{literal}
+#crm-container .crm-error {
+    padding: 0;
+}
+{/literal}
+</style>
+                 
+
+{literal}
+<script type="text/javascript">
+cj(function(){
+  cj('#api_key_generate').on('click', function() {
+    cj('#api_key').val(randomString(24));
+    return true;
+  });
+});
+
+function randomString(length, charset) {
+  var text = "";
+  charset = charset || "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  for( var i=0; i < length; i++ )
+    text += charset.charAt(Math.floor(Math.random() * charset.length));
+  return text;
+}
+</script>
+{/literal}
+                                    

--- a/wp-content/civi-extensions/apikey-1.5.0/templates/CRM/Contact/Page/View/APIKey.tpl
+++ b/wp-content/civi-extensions/apikey-1.5.0/templates/CRM/Contact/Page/View/APIKey.tpl
@@ -1,0 +1,34 @@
+{* this template is used to display the 'API Key' tab for a contact *}
+
+<div class="form-item">
+  <fieldset><legend>{ts}API Keys{/ts}</legend>
+    <div class="crm-block crm-form-block crm-cividesk-apikey-form-block">
+      {if $isAdmin || $canView}
+        {if $apiKey}
+          <div class="label" style="float:left">{ts}Your API key is{/ts}:&nbsp;</div>
+          <div style="float:left"><strong>{$apiKey}</strong></div><br />
+          <br />
+        {/if}
+        {if $canEdit}
+        <div class="action-link">
+          {crmButton p="$addEditApiKeyPath" q="$addEditApiKeyQuery" class="edit-apikey" title="$addEditApiButtonString" icon="$addEditApiButtonIcon"}{$addEditApiButtonString}{/crmButton}
+        </div>
+        {/if}
+      {else}
+        <div>{ts}You are not authorized to display this API Key.{/ts}</div>
+      {/if}
+    </div>
+    <div class="crm-block crm-form-block crm-cividesk-sitekey-form-block">
+      {if $isAdmin || $canViewSiteKey}
+        {if $siteKey}
+          <div class="label" style="float:left">{ts}The Site Key is{/ts}:&nbsp;</div>
+          <div style="float:left"><strong>{$siteKey}</strong></div><br />
+          <br />
+        {/if}
+      {else}
+        <div>{ts}You are not authorized to display the Site Key.{/ts}</div>
+      {/if}
+    </div>
+  </fieldset>
+</div>
+

--- a/wp-content/civi-extensions/apikey-1.5.0/xml/Menu/apikey.xml
+++ b/wp-content/civi-extensions/apikey-1.5.0/xml/Menu/apikey.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<menu>
+ <item>
+    <path>civicrm/contact/view/apikey</path>
+    <page_callback>CRM_Contact_Page_View_APIKey</page_callback>
+    <title>API Key</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/contact/apikey</path>
+    <page_callback>CRM_Contact_Form_APIKey</page_callback>
+    <title>API Key</title>
+    <access_arguments>access CiviCRM</access_arguments>
+    <path_arguments>action=add&amp;reset=1</path_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
Add API Key extension to generate API key linked to contact - 'API Key' tab will be available on contact screens
https://civicrm.org/extensions/api-key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an "API Key" tab on contact pages for authorized users, allowing viewing, creation, and editing of API keys for individual contacts.
  - Added the ability to generate a random API key directly from the interface.
  - Display of the site-wide API key for users with appropriate permissions.
  - Granular permission controls for viewing and editing API keys.
- **Documentation**
  - Added a readme with updated repository information.
  - Included comprehensive extension metadata and usage details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->