### PR TITLE
Feat/hide api key tab

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
@@ -22,9 +22,6 @@ class NavigationPermissionService extends AutoSubscriber {
     ];
   }
 
-  /**
-   *
-   */
   public function hideAPIKeyTab(&$page) {
     if ($page->getVar('_name') === 'CRM_Contact_Page_View_Summary') {
       if (!\CRM_Core_Permission::check('admin')) {
@@ -48,9 +45,11 @@ class NavigationPermissionService extends AutoSubscriber {
       if (\CRM_Core_Permission::check('mmt') && !\CRM_Core_Permission::check('admin')) {
         \CRM_Core_Resources::singleton()->addScript("
                 document.addEventListener('DOMContentLoaded', function() {
-                    document.querySelectorAll('.crm-actions-ribbon').forEach(el => el.style.display = 'none');.
-  document.querySelectorAll('afsearch-induction-details-of-contact').forEach(el => el.style.display = 'none');
-  document.querySelectorAll('.crm-collapsible').forEach(function(el) {
+                    document.querySelectorAll('.crm-actions-ribbon').forEach(el => el.style.display = 'none');
+                    
+                    document.querySelectorAll('afsearch-induction-details-of-contact').forEach(el => el.style.display = 'none');
+                    
+                    document.querySelectorAll('.crm-collapsible').forEach(function(el) {
                         const title = el.querySelector('.collapsible-title');
                         if (title && title.textContent.trim() === 'Volunteer Details') {
                             el.style.display = 'none';  // Hides the entire collapsible section
@@ -60,7 +59,7 @@ class NavigationPermissionService extends AutoSubscriber {
             ");
       }
     }
-  } .
+  }
 
   /**
    *
@@ -95,16 +94,16 @@ class NavigationPermissionService extends AutoSubscriber {
         'hide_child_menus' => [
           'Material Contributions',
           'hide_child_menus' => [
-            'Dashboard',
-            'Contribution Reports',
-            'Import Contributions',
-            'Batch Data Entry',
-            'Accounting Batches',
-            'Manage Contribution Pages',
-            'Personal Campaign Pages',
-            'Premiums',
-            'Manage Price Sets',
-          ],
+          'Dashboard',
+          'Contribution Reports',
+          'Import Contributions',
+          'Batch Data Entry',
+          'Accounting Batches',
+          'Manage Contribution Pages',
+          'Personal Campaign Pages',
+          'Premiums',
+          'Manage Price Sets',
+        ],
         ],
       ],
       'mmt' => [
@@ -186,7 +185,7 @@ class NavigationPermissionService extends AutoSubscriber {
           'Institution Collection Camps',
           'Dropping Center',
           'Institution Goonj Activities',
-        ],
+        ],    
       ],
       'sanjha_team' => [
         'hide_menus' => [
@@ -354,5 +353,4 @@ class NavigationPermissionService extends AutoSubscriber {
       }
     }
   }
-
 }

--- a/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/NavigationPermissionService.php
@@ -15,8 +15,29 @@ class NavigationPermissionService extends AutoSubscriber {
   public static function getSubscribedEvents() {
     return [
       '&hook_civicrm_navigationMenu' => ['hideNavForRoles'],
-      '&hook_civicrm_pageRun' => 'hideButtonsForMMT',
+      '&hook_civicrm_pageRun' => [
+        ['hideButtonsForMMT'],
+        ['hideAPIKeyTab'],
+      ],
     ];
+  }
+
+  /**
+   *
+   */
+  public function hideAPIKeyTab(&$page) {
+    if ($page->getVar('_name') === 'CRM_Contact_Page_View_Summary') {
+      if (!\CRM_Core_Permission::check('admin')) {
+        \CRM_Core_Resources::singleton()->addScript("
+          document.addEventListener('DOMContentLoaded', function() {
+            const apiTab = document.querySelector('#tab_apiKey');
+            if (apiTab) {
+              apiTab.style.display = 'none';
+            }
+          });
+        ");
+      }
+    }
   }
 
   /**
@@ -27,11 +48,9 @@ class NavigationPermissionService extends AutoSubscriber {
       if (\CRM_Core_Permission::check('mmt') && !\CRM_Core_Permission::check('admin')) {
         \CRM_Core_Resources::singleton()->addScript("
                 document.addEventListener('DOMContentLoaded', function() {
-                    document.querySelectorAll('.crm-actions-ribbon').forEach(el => el.style.display = 'none');
-                    
-                    document.querySelectorAll('afsearch-induction-details-of-contact').forEach(el => el.style.display = 'none');
-                    
-                    document.querySelectorAll('.crm-collapsible').forEach(function(el) {
+                    document.querySelectorAll('.crm-actions-ribbon').forEach(el => el.style.display = 'none');.
+  document.querySelectorAll('afsearch-induction-details-of-contact').forEach(el => el.style.display = 'none');
+  document.querySelectorAll('.crm-collapsible').forEach(function(el) {
                         const title = el.querySelector('.collapsible-title');
                         if (title && title.textContent.trim() === 'Volunteer Details') {
                             el.style.display = 'none';  // Hides the entire collapsible section
@@ -41,7 +60,7 @@ class NavigationPermissionService extends AutoSubscriber {
             ");
       }
     }
-  }
+  } .
 
   /**
    *
@@ -76,16 +95,16 @@ class NavigationPermissionService extends AutoSubscriber {
         'hide_child_menus' => [
           'Material Contributions',
           'hide_child_menus' => [
-          'Dashboard',
-          'Contribution Reports',
-          'Import Contributions',
-          'Batch Data Entry',
-          'Accounting Batches',
-          'Manage Contribution Pages',
-          'Personal Campaign Pages',
-          'Premiums',
-          'Manage Price Sets',
-        ],
+            'Dashboard',
+            'Contribution Reports',
+            'Import Contributions',
+            'Batch Data Entry',
+            'Accounting Batches',
+            'Manage Contribution Pages',
+            'Personal Campaign Pages',
+            'Premiums',
+            'Manage Price Sets',
+          ],
         ],
       ],
       'mmt' => [
@@ -167,7 +186,7 @@ class NavigationPermissionService extends AutoSubscriber {
           'Institution Collection Camps',
           'Dropping Center',
           'Institution Goonj Activities',
-        ],    
+        ],
       ],
       'sanjha_team' => [
         'hide_menus' => [
@@ -335,4 +354,5 @@ class NavigationPermissionService extends AutoSubscriber {
       }
     }
   }
+
 }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/ContributionFilter.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/ContributionFilter.php
@@ -22,13 +22,13 @@ class CRM_Goonjcustom_APIWrappers_ContributionFilter implements API_Wrapper {
 
     $params = $apiRequest->getParams();
 
-    // $allowedIPs = ['20.235.42.26'];
-    // $clientIP = $_SERVER['REMOTE_ADDR'] ?? '';
+    $allowedIPs = unserialize(CIVICRM_ALLOWED_IPS);
+    $clientIP = $_SERVER['REMOTE_ADDR'] ?? '';
 
-    // if (!in_array($clientIP, $allowedIPs)) {
-    //   echo 'Access denied: Unauthorized IP address.';
-    //   exit;
-    // }
+    if (!in_array($clientIP, $allowedIPs, TRUE)) {
+      echo 'Access denied: Unauthorized IP address.';
+      exit;
+    }
 
     $id = NULL;
     if (isset($params['where']) && is_array($params['where'])) {

--- a/wp-content/civi-extensions/goonjcustom/api/v3/ContributionFilter.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/ContributionFilter.php
@@ -4,6 +4,7 @@ require_once 'api/Wrapper.php';
 
 use Civi\Api4\Campaign;
 use Civi\Api4\Generic\AbstractAction;
+use Civi\API\Exception\UnauthorizedException;
 
 /**
  *
@@ -26,8 +27,7 @@ class CRM_Goonjcustom_APIWrappers_ContributionFilter implements API_Wrapper {
     $clientIP = $_SERVER['REMOTE_ADDR'] ?? '';
 
     if (!in_array($clientIP, $allowedIPs, TRUE)) {
-      echo 'Access denied: Unauthorized IP address.';
-      exit;
+      throw new UnauthorizedException('Access denied. You do not have permission to perform this action.');
     }
 
     $id = NULL;

--- a/wp-content/civi-extensions/goonjcustom/goonjcustom.php
+++ b/wp-content/civi-extensions/goonjcustom/goonjcustom.php
@@ -14,6 +14,8 @@ use Civi\Token\Event\TokenValueEvent;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 require_once __DIR__ . '/api/v3/ContributionFilter.php';
+use Civi\API\Exception\UnauthorizedException;
+
 
 /**
  * Implements hook_civicrm_config().
@@ -69,9 +71,11 @@ function goonjcustom_civicrm_container(ContainerBuilder $container) {
 
 function goonjcustom_civicrm_apiWrappers(&$wrappers, $apiRequest) {
   $apiUserId = \CRM_Core_Session::getLoggedInContactID();
-  if ($apiUserId != 356791) {
-   return ;
+
+  if ($apiUserId != CIVICRM_ALLOWED_API_USER_ID) {
+    throw new UnauthorizedException('Access denied. You do not have permission to perform this action.');
   }
+
   if ($apiRequest['entity'] == 'Campaign' && $apiRequest['action'] == 'get') {
     $wrappers[] = new \CRM_Goonjcustom_APIWrappers_ContributionFilter();
   }


### PR DESCRIPTION
1. Hide api key tab from contact summary
2. Enable goonj crm and goonj website only to access the campaign details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced API Key management for contacts, including a new tab in the contact view for authorized users to view, edit, and generate API keys.
  - Added granular permissions for API key access and editing.
  - Added a new CLI tool to update invoice numbers and send confirmation emails for duplicate contributions.
  - Added a CLI script to synchronize dropping center statuses with collection camps.
  - Added a custom API to update campaign contribution totals and contributor counts.
  - Added new event subscribers to sync dropping center statuses and institution dropping center statuses.

- **Enhancements**
  - Improved receipt generation and email notifications for institution material acknowledgments, with enhanced PDF and email formatting.
  - Updated permissions for various tabs and navigation items based on user roles.
  - Improved invoice number generation with transactional database-backed sequences.
  - Added finer control over navigation menu and tab visibility based on user roles.

- **Bug Fixes**
  - Fixed filtering logic for subscription imports to handle more statuses.
  - Improved validation and logging in induction and email processes.
  - Fixed UI issues in recurring contribution form with a new dropdown for installment selection.

- **Refactor**
  - Separated concerns in receipt generation and notification logic for institutions.
  - Cleaned up logging and improved early returns in several service methods.

- **Chores**
  - Added documentation and metadata files for new extensions and features.
  - Removed obsolete receipt generation service for institution dropping centers.

- **Style**
  - Minor formatting and code organization improvements in several files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->