### PR TITLE
Update edit tab permission

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -120,7 +120,7 @@ class CollectionCampService extends AutoSubscriber {
         'module' => 'afformCollectionCampIntentEdit',
         'directive' => 'afform-collection-camp-intent-edit',
         'template' => 'CRM/Goonjcustom/Tabs/CollectionCamp/Edit.tpl',
-        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin'],
+        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 'mmt_and_accounts_chapter_team', 'urban_ops_and_accounts_chapter_team'],
       ],
       'logistics' => [
         'title' => ts('Logistics'),

--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -601,7 +601,7 @@ class DroppingCenterService extends AutoSubscriber {
         'module' => 'afformDroppingCenterIntentEdit',
         'directive' => 'afform-dropping-center-intent-edit',
         'template' => 'CRM/Goonjcustom/Tabs/DroppingCenter/Edit.tpl',
-        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin'],
+        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 'mmt_and_accounts_chapter_team', 'urban_ops_and_accounts_chapter_team'],
       ],
       'logistics' => [
         'title' => ts('Logistics'),

--- a/wp-content/civi-extensions/goonjcustom/Civi/GoonjActivitiesService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/GoonjActivitiesService.php
@@ -372,7 +372,7 @@ class GoonjActivitiesService extends AutoSubscriber {
         'module' => 'afformGoonjActivitiesIntentEdit',
         'directive' => 'afform-goonj-activities-intent-edit',
         'template' => 'CRM/Goonjcustom/Tabs/GoonjActivities/Edit.tpl',
-        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin'],
+        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 'urban_ops_and_accounts_chapter_team', 'mmt_and_accounts_chapter_team'],
       ],
       'activities' => [
         'title' => ts('Activities'),

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -1158,7 +1158,7 @@ class InstitutionCollectionCampService extends AutoSubscriber {
         'module' => 'afformInstitutionCollectionCampIntentReviewEditForm',
         'directive' => 'afform-institution-collection-camp-intent-review-edit-form',
         'template' => 'CRM/Goonjcustom/Tabs/InstitutionCollectionCamp/Edit.tpl',
-        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 's2s_ho_team', 'project_team_ho', 'project_team_chapter', 'urban_ops_and_accounts_chapter_team'],
+        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 's2s_ho_team', 'project_team_ho', 'project_team_chapter', 'urban_ops_and_accounts_chapter_team', 'mmt_and_accounts_chapter_team'],
       ],
       'logistics' => [
         'title' => ts('Logistics'),

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
@@ -805,7 +805,7 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
         'module' => 'afformInstitutionDroppingCenterIntentReviewEditForm',
         'directive' => 'afform-institution-dropping-center-intent-review-edit-form',
         'template' => 'CRM/Goonjcustom/Tabs/InstitutionDroppingCenter/Edit.tpl',
-        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 's2s_ho_team', 'project_team_ho', 'project_team_chapter', 'urban_ops_and_accounts_chapter_team'],
+        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 's2s_ho_team', 'project_team_ho', 'project_team_chapter', 'urban_ops_and_accounts_chapter_team', 'mmt_and_accounts_chapter_team'],
       ],
       'eventCoordinators' => [
         'title' => ts('Center Coordinators'),

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionGoonjActivitiesService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionGoonjActivitiesService.php
@@ -546,7 +546,7 @@ class InstitutionGoonjActivitiesService extends AutoSubscriber {
         'module' => 'afsearchGoonjAllInstitutionActivity',
         'directive' => 'afsearch-goonj-all-institution-activity',
         'template' => 'CRM/Goonjcustom/Tabs/InstitutionGoonjActivities/Activities.tpl',
-        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 's2s_ho_team', 'project_team_ho', 'project_team_chapter', 'njpc_ho_team', 'sanjha_team', 'urban_ops_and_accounts_chapter_team'],
+        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 's2s_ho_team', 'project_team_ho', 'project_team_chapter', 'njpc_ho_team', 'sanjha_team', 'urban_ops_and_accounts_chapter_team', 'mmt_and_accounts_chapter_team'],
       ],
       'edit' => [
         'title' => ts('Edit'),

--- a/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/UrbanPlannedVisitService.php
@@ -456,7 +456,7 @@ class UrbanPlannedVisitService extends AutoSubscriber {
         'module' => 'afformUrbanPlannedVisitIntentReviewForm',
         'directive' => 'afform-Urban-Planned-Visit-Intent-Review-Form',
         'template' => 'CRM/Goonjcustom/Tabs/UrbanPlannedVisit/Edit.tpl',
-        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 'mmt', 'sanjha_team', 'project_team_ho', 'project_team_chapter', 'njpc_ho_team', 's2s_ho_team', 'communications_team', 'urban_ops_and_accounts_chapter_team', 'account_team'],
+        'permissions' => ['goonj_chapter_admin', 'urbanops', 'urban_ops_admin', 'mmt', 'sanjha_team', 'project_team_ho', 'project_team_chapter', 'njpc_ho_team', 's2s_ho_team', 'communications_team', 'urban_ops_and_accounts_chapter_team', 'account_team', 'mmt_and_accounts_chapter_team'],
       ],
       'visitOutcome' => [
         'title' => ts('Visit Outcome'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded access to the "Edit" and "Activities" tabs across various sections for users with the "mmt_and_accounts_chapter_team" and "urban_ops_and_accounts_chapter_team" roles. Eligible users in these roles can now view and edit relevant tabs where previously restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->