### PR TITLE
Initial script to update the online monetary and cash contribution count

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -92,12 +92,11 @@ class CollectionBaseService extends AutoSubscriber {
 
     try {
       EckEntity::update('Collection_Camp', TRUE)
-        ->addValue('Camp_Outcome.Number_of_Contributors', $uniqueCount)
+        ->addValue('Core_Contribution_Details.Number_of_unique_contributors', $uniqueCount)
         ->addWhere('id', '=', $eventId)
         ->execute();
     }
     catch (\Exception $e) {
-      // Don nothinh.
     }
   }
 
@@ -145,6 +144,10 @@ class CollectionBaseService extends AutoSubscriber {
       }
     }
 
+    if(!$activeEntityId || !$currentContactId) {
+      return;
+    }
+
     self::updateUniqueContributorsCount($activeEntityId, $activeFieldName, $currentContactId);
 
     if (!$activeFieldName || !$activeEntityId || !$currentContactId) {
@@ -177,7 +180,7 @@ class CollectionBaseService extends AutoSubscriber {
 
     try {
       EckEntity::update($entityType, TRUE)
-        ->addValue('Camp_Outcome.Book_Sale', $uniqueCount)
+        ->addValue('Core_Contribution_Details.Number_of_unique_material_contributors', $uniqueCount)
         ->addWhere('id', '=', $activeEntityId)
         ->execute();
     }
@@ -243,7 +246,7 @@ class CollectionBaseService extends AutoSubscriber {
     $newCount = count($uniqueContactIds);
 
     EckEntity::update('Collection_Camp', TRUE)
-      ->addValue('Contributions_Details.Number_of_Monetary_Contributors', $newCount)
+      ->addValue('Core_Contribution_Details.Number_of_unique_monetary_contributors', $newCount)
       ->addWhere('id', '=', $eventId)
       ->execute();
 
@@ -287,27 +290,27 @@ class CollectionBaseService extends AutoSubscriber {
 
     $existing = EckEntity::get('Collection_Camp', FALSE)
       ->addSelect(
-        'Camp_Outcome.Online_Monetary_Contribution',
-        'Camp_Outcome.Cash_Contribution'
+        'Core_Contribution_Details.Total_online_monetary_contributions',
+        'Core_Contribution_Details.Total_cash_cheque_monetary_contributions'
       )
       ->addWhere('id', '=', $campId)
       ->execute()
       ->first();
 
-    $onlineCurrent = (float) ($existing['Camp_Outcome.Online_Monetary_Contribution'] ?? 0);
-    $cashCurrent = (float) ($existing['Camp_Outcome.Cash_Contribution'] ?? 0);
+    $onlineCurrent = (float) ($existing['Core_Contribution_Details.Total_online_monetary_contributions'] ?? 0);
+    $cashCurrent = (float) ($existing['Core_Contribution_Details.Total_cash_cheque_monetary_contributions'] ?? 0);
 
     $update = EckEntity::update('Collection_Camp', FALSE)
       ->addWhere('id', '=', $campId);
 
     if ($paymentMethod === 'Credit Card') {
       $onlineNew = $onlineCurrent + $totalAmount;
-      $update->addValue('Camp_Outcome.Online_Monetary_Contribution', $onlineNew);
+      $update->addValue('Core_Contribution_Details.Total_online_monetary_contributions', $onlineNew);
     }
 
     if (in_array($paymentMethod, ['Cash', 'Check'], TRUE)) {
       $cashNew = $cashCurrent + $totalAmount;
-      $update->addValue('Camp_Outcome.Cash_Contribution', $cashNew);
+      $update->addValue('Core_Contribution_Details.Total_cash_cheque_monetary_contributions', $cashNew);
     }
 
     $update->execute();

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -179,7 +179,7 @@ class CollectionBaseService extends AutoSubscriber {
     }
 
     try {
-      EckEntity::update($entityType, TRUE)
+      EckEntity::update($entityType, FALSE)
         ->addValue('Core_Contribution_Details.Number_of_unique_material_contributors', $uniqueCount)
         ->addWhere('id', '=', $activeEntityId)
         ->execute();
@@ -218,7 +218,7 @@ class CollectionBaseService extends AutoSubscriber {
 
     $eventId = $contribution['Contribution_Details.Source.id'];
 
-    $collectionCamps = EckEntity::get('Collection_Camp', TRUE)
+    $collectionCamps = EckEntity::get('Collection_Camp', FALSE)
       ->addSelect('subtype:name')
       ->addWhere('id', '=', $eventId)
       ->execute()
@@ -245,7 +245,7 @@ class CollectionBaseService extends AutoSubscriber {
     $uniqueContactIds = array_unique($contactIds);
     $newCount = count($uniqueContactIds);
 
-    EckEntity::update('Collection_Camp', TRUE)
+    EckEntity::update('Collection_Camp', FALSE)
       ->addValue('Core_Contribution_Details.Number_of_unique_monetary_contributors', $newCount)
       ->addWhere('id', '=', $eventId)
       ->execute();

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -1113,43 +1113,11 @@ class CollectionCampService extends AutoSubscriber {
   /**
    *
    */
-  public static function updateContributorCount($collectionCamp) {
-    $activities = Activity::get(FALSE)
-      ->addSelect('id')
-      ->addWhere('Material_Contribution.Collection_Camp', '=', $collectionCamp['id'])
-      ->execute();
-
-    $contributorCount = count($activities);
-
-    EckEntity::update('Collection_Camp', FALSE)
-      ->addValue('Camp_Outcome.Number_of_Contributors', $contributorCount)
-      ->addWhere('id', '=', $collectionCamp['id'])
-      ->execute();
-  }
 
   /**
    *
    */
-  public static function updateContributionCount($collectionCamp) {
-    $contributions = Contribution::get(FALSE)
-      ->addSelect('total_amount')
-      ->addWhere('Contribution_Details.Source', '=', $collectionCamp['id'])
-      ->addWhere('is_test', 'IS NOT NULL')
-      ->execute();
 
-    // Initialize sum variable.
-    $totalSum = 0;
-
-    // Iterate through the results and sum the total_amount.
-    foreach ($contributions as $contribution) {
-      $totalSum += $contribution['total_amount'];
-    }
-
-    EckEntity::update('Collection_Camp', FALSE)
-      ->addValue('Camp_Outcome.Monitory_Contribution', $totalSum)
-      ->addWhere('id', '=', $collectionCamp['id'])
-      ->execute();
-  }
 
   /**
    * This hook is called after a db write on entities.

--- a/wp-content/civi-extensions/goonjcustom/Civi/GoonjInitiatedEventsService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/GoonjInitiatedEventsService.php
@@ -135,7 +135,7 @@ class GoonjInitiatedEventsService extends AutoSubscriber {
 
     try {
       Event::update()
-        ->addValue('Goonj_Events_Outcome.Number_of_Material_Contributors', $uniqueCount)
+        ->addValue('Goonj_Events_Outcome.Number_of_unique_material_contributors', $uniqueCount)
         ->addWhere('id', '=', $eventId)
         ->execute();
     }
@@ -189,7 +189,7 @@ class GoonjInitiatedEventsService extends AutoSubscriber {
     $newCount = count($uniqueContactIds);
 
     Event::update(FALSE)
-      ->addValue('Goonj_Events_Outcome.Number_of_Monetary_Contributors', $newCount)
+      ->addValue('Goonj_Events_Outcome.Number_of_unique_monetary_contributors', $newCount)
       ->addWhere('id', '=', $eventId)
       ->execute();
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionCollectionCampService.php
@@ -1089,43 +1089,11 @@ class InstitutionCollectionCampService extends AutoSubscriber {
   /**
    *
    */
-  public static function updateContributorCount($collectionCamp) {
-    $activities = Activity::get(FALSE)
-      ->addSelect('id')
-      ->addWhere('Material_Contribution.Institution_Collection_Camp', '=', $collectionCamp['id'])
-      ->execute();
 
-    $contributorCount = count($activities);
-
-    EckEntity::update('Collection_Camp', FALSE)
-      ->addValue('Camp_Outcome.Number_of_Contributors', $contributorCount)
-      ->addWhere('id', '=', $collectionCamp['id'])
-      ->execute();
-  }
 
   /**
    *
    */
-  public static function updateContributionCount($collectionCamp) {
-    $contributions = Contribution::get(FALSE)
-      ->addSelect('total_amount')
-      ->addWhere('Contribution_Details.Source', '=', $collectionCamp['id'])
-      ->addWhere('is_test', 'IS NOT NULL')
-      ->execute();
-
-    // Initialize sum variable.
-    $totalSum = 0;
-
-    // Iterate through the results and sum the total_amount.
-    foreach ($contributions as $contribution) {
-      $totalSum += $contribution['total_amount'];
-    }
-
-    EckEntity::update('Collection_Camp', FALSE)
-      ->addValue('Camp_Outcome.Monitory_Contribution', $totalSum)
-      ->addWhere('id', '=', $collectionCamp['id'])
-      ->execute();
-  }
 
   /**
    *

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampCron.php
@@ -71,8 +71,6 @@ function civicrm_api3_goonjcustom_collection_camp_cron($params) {
 
     try {
       CollectionCampService::sendLogisticsEmail($camp);
-      CollectionCampService::updateContributorCount($camp);
-      CollectionCampService::updateContributionCount($camp);
     }
     catch (\Exception $e) {
       \Civi::log()->info('Error processing camp', [

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/GoonjEventsOutcomeDetailsUpdateCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/GoonjEventsOutcomeDetailsUpdateCron.php
@@ -100,8 +100,6 @@ function civicrm_api3_goonjcustom_goonj_events_outcome_details_update_cron($para
     ]);
     $results = Event::update(TRUE)
       ->addValue('Goonj_Events_Outcome.Footfall', $countUniqueParticipants)
-      ->addValue('Goonj_Events_Outcome.Online_Monetary_Contribution', $totalSum)
-      ->addValue('Goonj_Events_Outcome.Number_of_Contributors', $noOfContributions)
       ->addValue('Goonj_Events_Outcome.Number_of_New_Contacts', $countCreatedDuringEvent)
       ->addWhere('id', '=', $event['id'])
       ->execute();

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/InstitutionCollectionCampCron.php
@@ -74,8 +74,6 @@ function civicrm_api3_goonjcustom_institution_collection_camp_cron($params) {
   foreach ($collectionCamps as $camp) {
     try {
       InstitutionCollectionCampService::sendLogisticsEmail($camp);
-      InstitutionCollectionCampService::updateContributorCount($camp);
-      InstitutionCollectionCampService::updateContributionCount($camp);
     }
     catch (\Exception $e) {
       \Civi::log()->info('Error processing camp', [

--- a/wp-content/civi-extensions/goonjcustom/cli/update-contribution-count.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/update-contribution-count.php
@@ -48,8 +48,8 @@ foreach ($collectionCamps as $camp) {
   error_log("Online total: ₹$onlineTotal | Cash total: ₹$cashTotal");
 
   EckEntity::update('Collection_Camp', FALSE)
-    ->addValue('Camp_Outcome.Online_Monetary_Contribution', $onlineTotal)
-    ->addValue('Camp_Outcome.Cash_Contribution', $cashTotal)
+    ->addValue('Core_Contribution_Details.Total_online_monetary_contributions', $onlineTotal)
+    ->addValue('Core_Contribution_Details.Total_cash_cheque_monetary_contributions', $cashTotal)
     ->addWhere('id', '=', $campId)
     ->execute();
 

--- a/wp-content/civi-extensions/goonjcustom/cli/update-contribution-count.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/update-contribution-count.php
@@ -1,0 +1,59 @@
+<?php
+
+use Civi\Api4\EckEntity;
+use Civi\Api4\Contribution;
+
+if (php_sapi_name() !== 'cli') {
+  exit("This script can only be run from the command line.\n");
+}
+
+define('CIVICRM_SETTINGS_PATH', getenv('CIVICRM_SETTINGS_PATH'));
+require_once CIVICRM_SETTINGS_PATH;
+require_once 'CRM/Core/Config.php';
+CRM_Core_Config::singleton();
+
+echo "Starting contributor count update...\n";
+
+function getTotalContributionByPaymentMethods($campId, $paymentMethods) {
+  $contributions = Contribution::get(FALSE)
+    ->addSelect('total_amount')
+    ->addWhere('Contribution_Details.Source.id', '=', $campId)
+    ->addWhere('contribution_status_id:name', '=', 'Completed')
+    ->addWhere('payment_instrument_id:name', 'IN', (array) $paymentMethods)
+    ->execute();
+
+  $total = 0;
+  foreach ($contributions as $contribution) {
+    $total += $contribution['total_amount'];
+  }
+
+  return $total;
+}
+
+$collectionCamps = EckEntity::get('Collection_Camp', TRUE)
+  ->addSelect('id')
+  ->addWhere('subtype:name', 'IN', ['Collection_Camp', 'Dropping_Center', 'Institution_Collection_Camp', 'Institution_Dropping_Center', 'Goonj_Activities', 'Institution_Goonj_Activities'])
+  ->execute();
+
+foreach ($collectionCamps as $camp) {
+  $campId = $camp['id'];
+  echo "Processing camp ID: $campId\n";
+  error_log("Processing campId: $campId");
+
+  $onlineTotal = getTotalContributionByPaymentMethods($campId, ['Credit Card']);
+  $cashTotal = getTotalContributionByPaymentMethods($campId, ['Cash', 'Check']);
+
+  echo "→ Online Monetary Contribution: ₹$onlineTotal\n";
+  echo "→ Cash Contribution: ₹$cashTotal\n";
+  error_log("Online total: ₹$onlineTotal | Cash total: ₹$cashTotal");
+
+  EckEntity::update('Collection_Camp', FALSE)
+    ->addValue('Camp_Outcome.Online_Monetary_Contribution', $onlineTotal)
+    ->addValue('Camp_Outcome.Cash_Contribution', $cashTotal)
+    ->addWhere('id', '=', $campId)
+    ->execute();
+
+  echo "✓ Updated contributions for camp ID $campId.\n\n";
+}
+
+echo "✅ Update complete for all camps.\n";

--- a/wp-content/civi-extensions/goonjcustom/cli/update-event-contribution-count.php
+++ b/wp-content/civi-extensions/goonjcustom/cli/update-event-contribution-count.php
@@ -1,0 +1,57 @@
+<?php
+
+use Civi\Api4\Contribution;
+
+if (php_sapi_name() !== 'cli') {
+  exit("This script can only be run from the command line.\n");
+}
+
+define('CIVICRM_SETTINGS_PATH', getenv('CIVICRM_SETTINGS_PATH'));
+require_once CIVICRM_SETTINGS_PATH;
+require_once 'CRM/Core/Config.php';
+CRM_Core_Config::singleton();
+
+echo "Starting contributor count update...\n";
+
+function getTotalContributionByPaymentMethods($eventId, $paymentMethods) {
+  $contributions = Contribution::get(FALSE)
+    ->addSelect('total_amount')
+    ->addWhere('Contribution_Details.Events', '=', $eventId)
+    ->addWhere('contribution_status_id:name', '=', 'Completed')
+    ->addWhere('payment_instrument_id:name', 'IN', (array) $paymentMethods)
+    ->execute();
+
+  $total = 0;
+  foreach ($contributions as $contribution) {
+    $total += $contribution['total_amount'];
+  }
+
+  return $total;
+}
+
+$events = \Civi\Api4\Event::get(FALSE)
+->addSelect('id')
+->execute();
+
+foreach ($events as $event) {
+  $eventId = $event['id'];
+  echo "Processing event ID: $eventId\n";
+  error_log("Processing eventId: $eventId");
+
+  $onlineTotal = getTotalContributionByPaymentMethods($eventId, ['Credit Card']);
+  $cashTotal = getTotalContributionByPaymentMethods($eventId, ['Cash', 'Check']);
+
+  echo "→ Online Monetary Contribution: ₹$onlineTotal\n";
+  echo "→ Cash Contribution: ₹$cashTotal\n";
+  error_log("Online total: ₹$onlineTotal | Cash total: ₹$cashTotal");
+
+  \Civi\Api4\Event::update(FALSE)
+    ->addValue('Goonj_Events_Outcome.Online_Monetary_Contribution', $onlineTotal)
+    ->addValue('Goonj_Events_Outcome.Cash_Contribution', $cashTotal)
+    ->addWhere('id', '=', $eventId)
+    ->execute();
+
+  echo "✓ Updated contributions for event ID $eventId.\n\n";
+}
+
+echo "✅ Update complete for all events.\n";


### PR DESCRIPTION
Update :
1) Number of unique contributors
2) Number of unique material contributors
3) Number of unique monetary contributors
4) Total online monetary contributions
5) Total cash/cheque monetary contributions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced command-line tools to update contribution totals for collection camps and events, distinguishing online (credit card) and offline (cash/check) payments.
  - Enabled automatic updating of monetary contribution totals on collection camps and events immediately after contributions are completed.
  - Added automatic tracking and updating of unique contributor counts for events and collection campaigns, including material and monetary contributors.
  - Enhanced event handling to update contributor counts and contribution totals in real time based on form submissions and contributions.

- **Chores**
  - Removed legacy methods for contributor and contribution count updates from collection camp services and related cron jobs.
  - Simplified cron job logic by removing redundant contribution count updates and online contribution processing where no longer needed.
  - Improved progress reporting and error logging for contribution and contributor count updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->