### PR TITLE
Fix the camp code

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/Traits/CollectionSource.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/Traits/CollectionSource.php
@@ -145,9 +145,8 @@ trait CollectionSource {
         // Fetch the Goonj-specific state code.
         $config = self::getConfig();
         $stateCode = $config['state_codes'][$stateAbbreviation] ?? 'UNKNOWN';
-
         // Get the current event title.
-        $currentTitle = $objectRef['title'] ?? 'Collection Camp';
+        $currentTitle = $sourceTitle ?? 'Collection Camp';
 
         // Fetch the event code.
         $eventCode = $config['event_codes'][$currentTitle] ?? 'UNKNOWN';


### PR DESCRIPTION
Fix the camp code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event code determination for collection sources by using the original source title from the linked record, ensuring accuracy when object titles have changed.
  - Retains fallback to "Collection Camp" when a source title isn’t available.
  - Results in more consistent event tagging and downstream processing (e.g., state code resolution and title updates).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->