### PR TITLE
Fix the error on glific extension

### DIFF
--- a/wp-content/civi-extensions/civiglific/CRM/Civiglific/GlificClient.php
+++ b/wp-content/civi-extensions/civiglific/CRM/Civiglific/GlificClient.php
@@ -9,6 +9,7 @@ use CRM\Civiglific\GlificHelper;
  * GlificClient
  * Acts as the API interface for everything Glific.
  */
+if (!class_exists('CRM\Civiglific\GlificClient')) {
 class GlificClient {
 
   protected $client;
@@ -255,5 +256,7 @@ class GlificClient {
 
     return $response['data']['contact']['contact'] ?? [];
   }
+
+}
 
 }

--- a/wp-content/civi-extensions/civiglific/CRM/Civiglific/GlificHelper.php
+++ b/wp-content/civi-extensions/civiglific/CRM/Civiglific/GlificHelper.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Client;
 /**
  *
  */
+if (!class_exists('CRM\Civiglific\GlificHelper')) {
 class GlificHelper {
 
   /**
@@ -53,5 +54,7 @@ class GlificHelper {
       return FALSE;
     }
   }
+
+}
 
 }

--- a/wp-content/civi-extensions/civiglific/CRM/Civiglific/GlificUtils.php
+++ b/wp-content/civi-extensions/civiglific/CRM/Civiglific/GlificUtils.php
@@ -5,6 +5,7 @@ namespace CRM\Civiglific;
 /**
  *
  */
+if (!class_exists('CRM\Civiglific\GlificUtils')) {
 class GlificUtils {
 
   /**
@@ -19,5 +20,7 @@ class GlificUtils {
   public static function normalizePhone($phone) {
     return preg_replace('/\D+/', '', $phone);
   }
+
+}
 
 }

--- a/wp-content/civi-extensions/civiglific/CRM/Civiglific/Service/GlificContactSyncService.php
+++ b/wp-content/civi-extensions/civiglific/CRM/Civiglific/Service/GlificContactSyncService.php
@@ -14,6 +14,7 @@ use Civi\Api4\GlificGroupMap;
 /**
  *
  */
+if (!class_exists('\CRM\Civiglific\Service\GlificContactSyncService')) {
 class GlificContactSyncService {
 
   protected $glific;
@@ -361,5 +362,7 @@ class GlificContactSyncService {
       }
     }
   }
+
+}
 
 }


### PR DESCRIPTION
Remove tabs for uops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents rare fatal errors caused by duplicate class declarations when the extension is loaded multiple times, improving overall stability.
  * Ensures smoother operation during cache clears, updates, or environments where autoloading may re-include classes.

* **Chores**
  * Added safeguards around class definitions to avoid redeclaration without altering existing functionality.
  * Maintains existing public APIs and behavior while enhancing robustness in varied deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->