### PR TITLE
Remove the data from office receipt

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/MaterialContributionService.php
@@ -204,9 +204,9 @@ class MaterialContributionService extends AutoSubscriber {
     : $activityDate;
 
     $baseDir = plugin_dir_path(__FILE__) . '../../../themes/goonj-crm/';
-    $deliveredBy = empty($activity['Material_Contribution.Delivered_By']) ? $activity['contact.display_name'] : $activity['Material_Contribution.Delivered_By'];
+    $deliveredBy = !empty($activity['Material_Contribution.Delivered_By']) ? $activity['Material_Contribution.Delivered_By'] : '-';
 
-    $deliveredByContact = empty($activity['Material_Contribution.Delivered_By_Contact']) ? $phone : $activity['Material_Contribution.Delivered_By_Contact'];
+    $deliveredByContact = !empty($activity['Material_Contribution.Delivered_By_Contact']) ? $activity['Material_Contribution.Delivered_By_Contact'] : '-';
     $paths = [
       'logo' => $baseDir . 'images/goonj-logo.png',
       'qrCode' => $baseDir . 'images/qr-code.png',


### PR DESCRIPTION
Remove the data from office receipt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Receipt generation: When “Delivered by (Name & contact no.)” details are unavailable, the receipt now displays “-” instead of auto-filling from other contact or phone information.
  * Both the name and contact number fields follow this behavior, reducing confusion and preventing unintended disclosure of fallback details.
  * The visibility of the “Delivered by” row remains unchanged and continues to follow existing subtype, event, and office/subject rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->