### PR TITLE
Disable Switching between user account

### DIFF
--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -909,7 +909,15 @@ function goonj_remove_logo_href( $html, $blog_id ) {
     $html = preg_replace( '/<a([^>]*?) href="[^"]*"/', '<a\1', $html );
     return $html;
 }
-
+/**
+* Prevent user switching to different roles.
+*
+* @param array   $allcaps Array of key/value pairs where keys represent a capability name.
+* @param array   $cap     Required primitive capabilities for the requested capability.
+* @param array   $args    Arguments that accompany the requested capability check.
+* @param WP_User $user    The user object.
+* @return array Modified capabilities array.
+*/
 add_filter('user_has_cap', function($allcaps, $cap, $args, $user) {
     if (!defined('ROLE_SWITCH_RESTRICTIONS')) {
         return $allcaps;

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -911,19 +911,19 @@ function goonj_remove_logo_href( $html, $blog_id ) {
 }
 
 add_filter('user_has_cap', function($allcaps, $cap, $args, $user) {
-    // Check if this is a switch attempt
-    if ( isset($args[0]) && $args[0] === 'switch_to_user' ) {
-        $target_user_id = $args[2];
-        $target_user = get_userdata($target_user_id);
+    if (in_array('urban_ops_admin', (array) $user->roles)) {
+        // Check if this is a switch attempt
+        if (isset($args[0]) && $args[0] === 'switch_to_user') {
+            $target_user_id = $args[2];
+            $target_user = get_userdata($target_user_id);
 
-        if ($target_user) {
-            $target_roles = $target_user->roles;
+            if ($target_user) {
+                $target_roles = $target_user->roles;
 
-            // Block switch if target has ho_account or admin role
-            if (in_array('ho_account', $target_roles) || in_array('administrator', $target_roles)) {
-                error_log("Switch attempt blocked for user ID {$user->ID} to target ID {$target_user_id} due to restricted role.");
-                // Remove capability to switch
-                $allcaps[$cap[0]] = false;
+                if (in_array('ho_account', $target_roles) || in_array('administrator', $target_roles)) {
+                    error_log("Switch attempt blocked for user ID {$user->ID} to target ID {$target_user_id} due to restricted role.");
+                    $allcaps[$cap[0]] = false;
+                }
             }
         }
     }

--- a/wp-content/themes/goonj-crm/functions.php
+++ b/wp-content/themes/goonj-crm/functions.php
@@ -909,3 +909,23 @@ function goonj_remove_logo_href( $html, $blog_id ) {
     $html = preg_replace( '/<a([^>]*?) href="[^"]*"/', '<a\1', $html );
     return $html;
 }
+
+add_filter('user_has_cap', function($allcaps, $cap, $args, $user) {
+    // Check if this is a switch attempt
+    if ( isset($args[0]) && $args[0] === 'switch_to_user' ) {
+        $target_user_id = $args[2];
+        $target_user = get_userdata($target_user_id);
+
+        if ($target_user) {
+            $target_roles = $target_user->roles;
+
+            // Block switch if target has ho_account or admin role
+            if (in_array('ho_account', $target_roles) || in_array('administrator', $target_roles)) {
+                error_log("Switch attempt blocked for user ID {$user->ID} to target ID {$target_user_id} due to restricted role.");
+                // Remove capability to switch
+                $allcaps[$cap[0]] = false;
+            }
+        }
+    }
+    return $allcaps;
+}, 10, 4);


### PR DESCRIPTION
Disable Switching between user account

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforces configured role-based restrictions during user-switch attempts to prevent switching into protected roles (e.g., Administrator, HO Account).
  * Blocks the relevant capability when a restricted switch is attempted.
  * Ensures regular permissions remain unchanged outside of switch attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->