### PR TITLE
Add POC email for self camp

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/CollectionCampCron.php
@@ -57,6 +57,7 @@ function civicrm_api3_goonjcustom_collection_camp_cron($params) {
       'Collection_Camp_Core_Details.Contact_Id',
       'Logistics_Coordination.Self_Managed_By_Camp_Organiser',
       'Collection_Camp_Core_Details.Contact_Id',
+      'Collection_Camp_Intent_Details.Coordinating_Urban_POC',
     )
     ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
     ->addWhere('subtype', '=', $collectionCampSubtype)


### PR DESCRIPTION
Add POC email for self camp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logistics emails for self-managed camp logistics are now routed to the designated coordinating Point of Contact instead of individual attendees
  * Email content, including greetings and referenced names, now uses the Point of Contact's information instead of attendee information
  * Point of Contact contact details are now retrieved and integrated into the logistics email system

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->