### PR TITLE
Fix the timing for summary email

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/DroppingCenterService.php
@@ -787,9 +787,9 @@ class DroppingCenterService extends AutoSubscriber {
     $attendeeName  = $campAttendedBy['display_name'];
 
     // Define last month’s range.
-    $startDate = (new \DateTime('first day of this month'))->format('Y-m-d');
-    $endDate   = (new \DateTime('last day of this month'))->format('Y-m-d');
-    $monthName = (new \DateTime('first day of this month'))->format('F Y');
+    $startDate = (new \DateTime('first day of last month'))->format('Y-m-d');
+    $endDate   = (new \DateTime('last day of last month'))->format('Y-m-d');
+    $monthName = (new \DateTime('first day of last month'))->format('F Y');
 
     $dispatches = EckEntity::get('Collection_Source_Vehicle_Dispatch', FALSE)
       ->addSelect('Camp_Vehicle_Dispatch.Date_Time_of_Dispatch', 'Camp_Vehicle_Dispatch.Number_of_Bags_loaded_in_vehicle', 'Camp_Vehicle_Dispatch.Vehicle_Category', 'Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office')

--- a/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/InstitutionDroppingCenterService.php
@@ -1041,9 +1041,9 @@ class InstitutionDroppingCenterService extends AutoSubscriber {
     $attendeeName  = $campAttendedBy['display_name'];
 
     // Define last month’s range.
-    $startDate = (new \DateTime('first day of this month'))->format('Y-m-d');
-    $endDate   = (new \DateTime('last day of this month'))->format('Y-m-d');
-    $monthName = (new \DateTime('first day of this month'))->format('F Y');
+    $startDate = (new \DateTime('first day of last month'))->format('Y-m-d');
+    $endDate   = (new \DateTime('last day of last month'))->format('Y-m-d');
+    $monthName = (new \DateTime('first day of last month'))->format('F Y');
 
     $dispatches = EckEntity::get('Collection_Source_Vehicle_Dispatch', FALSE)
       ->addSelect('Camp_Vehicle_Dispatch.Date_Time_of_Dispatch', 'Camp_Vehicle_Dispatch.Number_of_Bags_loaded_in_vehicle', 'Camp_Vehicle_Dispatch.Vehicle_Category', 'Acknowledgement_For_Logistics.No_of_bags_received_at_PU_Office')

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/MonthlySummaryForDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/MonthlySummaryForDroppingCenterCron.php
@@ -36,10 +36,10 @@ function civicrm_api3_goonjcustom_monthly_summary_for_dropping_center_cron($para
 
   $today   = new \DateTime();
   // Calculate the 2nd day of the *next* month.
-  $secondOfNextMonth = (new \DateTime('first day of next month'))->modify('+1 day');
+  $secondOfCurrentMonth = (new \DateTime('first day of this month' ))->modify('+1 day');
 
   // Run this only on the 2nd day of next month.
-  if ($today->format('Y-m-d') !== $secondOfNextMonth->format('Y-m-d')) {
+  if ($today->format('Y-m-d') !== $secondOfCurrentMonth->format('Y-m-d')) {
     \Civi::log()->info('MonthlySummaryForDroppingCenterCron skipped (not 2nd day of next month)');
     return civicrm_api3_create_success([], $params, 'Goonjcustom', 'monthly_summary_for_dropping_center_cron');
   }

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/MonthlySummaryForInstituteDroppingCenterCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/MonthlySummaryForInstituteDroppingCenterCron.php
@@ -37,10 +37,10 @@ function civicrm_api3_goonjcustom_monthly_summary_for_institute_dropping_center_
 
   $today   = new \DateTime();
   // Calculate the 2nd day of the *next* month.
-  $secondOfNextMonth = (new \DateTime('first day of next month'))->modify('+1 day');
+  $secondOfCurrentMonth = (new \DateTime('first day of this month' ))->modify('+1 day');
 
   // Run this only on the 2nd day of next month.
-  if ($today->format('Y-m-d') !== $secondOfNextMonth->format('Y-m-d')) {
+  if ($today->format('Y-m-d') !== $secondOfCurrentMonth->format('Y-m-d')) {
     \Civi::log()->info('MonthlySummaryForInstituteDroppingCenterCron skipped (not 2nd day of next month)');
     return civicrm_api3_create_success([], $params, 'Goonjcustom', 'monthly_summary_for_institute_dropping_center_cron');
   }


### PR DESCRIPTION
Fix the timing for summary email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted monthly summary email timing to report on the previous month's data instead of the current month.
  * Updated cron job scheduling to execute on the 2nd day of the current month instead of the next month.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->