### PR TITLE
Exempt dalgo_api_readonly role from Collection Camp state ACL filter

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -837,9 +837,10 @@ class CollectionBaseService extends AutoSubscriber {
       return FALSE;
     }
 
-    $restrictedRoles = ['admin', 'urban_ops_admin', 'ho_account', 'project_team_ho', 's2s_ho_team', 'njpc_ho_team', 'project_ho_and_accounts', 'dalgo_api_readonly'];
+    $restrictedRoles = ['admin', 'urban_ops_admin', 'ho_account', 'project_team_ho', 's2s_ho_team', 'njpc_ho_team', 'project_ho_and_accounts'];
 
-    $hasRestrictedRole = \CRM_Core_Permission::checkAnyPerm($restrictedRoles);
+    $hasRestrictedRole = \CRM_Core_Permission::checkAnyPerm($restrictedRoles)
+      || \CRM_Core_Permission::check('view any eck entity');
 
     if ($hasRestrictedRole) {
       return;

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionBaseService.php
@@ -837,7 +837,7 @@ class CollectionBaseService extends AutoSubscriber {
       return FALSE;
     }
 
-    $restrictedRoles = ['admin', 'urban_ops_admin', 'ho_account', 'project_team_ho', 's2s_ho_team', 'njpc_ho_team', 'project_ho_and_accounts'];
+    $restrictedRoles = ['admin', 'urban_ops_admin', 'ho_account', 'project_team_ho', 's2s_ho_team', 'njpc_ho_team', 'project_ho_and_accounts', 'dalgo_api_readonly'];
 
     $hasRestrictedRole = \CRM_Core_Permission::checkAnyPerm($restrictedRoles);
 


### PR DESCRIPTION
## Summary

- Adds `dalgo_api_readonly` to the `$restrictedRoles` bypass list in `aclCollectionCamp()` so the Dalgo integration user has global read access to all Collection Camp records
- Without this, the state-based ACL filter returns `WHERE id IN (null)` for users with no chapter-team group memberships, resulting in zero records

## Context

Part of ColoredCow/goonj-crm#290 — setting up CiviCRM API access for Dalgo. The `Dalgo API Readonly` WordPress role is a read-only integration role with no state-controlled group memberships, so it needs to bypass the chapter-level ACL the same way `admin`, `ho_account`, and other global roles do.

## Test plan

- [ ] Merge to `dev` → deploys to staging
- [ ] Run the following curl and confirm records are returned:
```bash
curl -sS -X POST "https://staging-crm.goonj.org/civicrm/ajax/api4/Eck_Collection_Camp/get?_authx=Bearer+d4686f28de0fae9aa35249a73baef165e929922659d047ad49c49229c169d934" \
  -H "X-Requested-With: XMLHttpRequest" \
  -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" \
  --data-urlencode 'params={"select":["id","title","subtype:name"],"orderBy":{"id":"ASC"},"limit":5}'
```
- [ ] Confirm other roles (non-admin, non-Dalgo) are still filtered by state as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted access control so users with the "view any" ECK permission are treated as restricted/read‑only, ensuring consistent visibility and preventing unintended broader access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->