### PR TITLE
afform: restore Please-fill-required-fields popup on frontend pages

### DIFF
--- a/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
+++ b/wp-content/plugins/civicrm/civicrm/ext/afform/core/ang/af/afForm.component.js
@@ -596,9 +596,13 @@
           //
           // TODO: in the long run we should provide a way for callers of
           // CRM.alert to specify between interrupting vs non-interrupting alerts
-          if (document.getElementById('crm-notification-container')) {
-            CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
-          }
+          //
+          // GOONJ CUSTOM: removed the gate `if (document.getElementById('crm-notification-container'))`
+          // around this call. On frontend pages the container isn't present, so the gate
+          // silently swallowed the popup. CRM.alert's own fallback in Common.js creates
+          // a native <dialog> when the container is missing — so calling it unconditionally
+          // is safe and restores the 6.3.1 behaviour the team relied on.
+          CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
           return;
         }
         status = CRM.status({error: ts('Not saved')});


### PR DESCRIPTION
## Summary
- Removes the gate added by CiviCRM 6.13.x around `CRM.alert('Please fill all required fields.', 'Form Error')` in `afForm.component.js`
- Restores the missing validation popup on **frontend pages** (e.g. `/volunteer-registration/form/`, `/collection-camp/volunteer-with-intent/`, etc.) after the WordPress + CiviCRM upgrade

## Why this happened
**Before upgrade (CiviCRM 6.3.1 on prod):** Submitting an Afform with empty required fields showed a popup:
> `crm.goonj.org says: Form Error — Please fill all required fields.`

**After upgrade (CiviCRM 6.13.3 on staging):** Clicking Submit silently does nothing — no popup, no error, no submission. Users have no way to know which required field they missed.

### Investigation findings

CiviCRM 6.13.x upstream changed `afForm.component.js` line 599-601 to wrap the alert in a conditional:

```js
if (document.getElementById('crm-notification-container')) {
  CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
}
```

The intent (per the comment in upstream code) was: *"in the case of frontend, we are better off doing nothing and just letting the browser alerts do their work."* But:

1. On the **backend** (admin UI), the `crm-notification-container` div is injected, so the alert fires via jQuery UI `notify` plugin — works as before
2. On the **frontend**, the container is NOT present (and never was, even on 6.3.1) → the conditional is `false` → the alert is **never called**
3. The native browser validation the comment expected to "do its work" doesn't fire either, because Angular's `ng-click` on the submit button doesn't trigger native HTML5 form validation — the button handler intercepts everything

**Verified on local + staging:**
- `document.getElementById('crm-notification-container')` → `null` on frontend pages
- Calling `CRM.alert("Please fill all required fields.", "Form Error")` directly (bypassing the gate) → produces a native `<dialog class="crm-dialog crm-alert">` popup with text + OK button. CRM.alert's own fallback in `Common.js:1530` handles the no-container case correctly — it just was never reached because of the gate.

### What our custom code does NOT need to change

`customValidateFields()` (the Goonj custom block added in [`186dbddb0`](https://github.com/ColoredCow/goonj/commit/186dbddb0a)) at line 569 calls `CRM.alert(errorMessage, ts("Form Error"))` **without** any gate. That already works correctly on frontend (uses the native dialog fallback). Only the upstream-introduced gate at line 599 was broken.

## The fix
Remove the 3-line conditional wrapper around the alert. The call is unconditional, matching the 6.3.1 behaviour. Added a Goonj-prefixed comment explaining why we deviate from upstream here, in case of future upgrades.

```diff
- if (document.getElementById('crm-notification-container')) {
-   CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
- }
+ CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
```

## Test plan

- [ ] On staging (or local): go to `https://staging-crm.goonj.org/volunteer-registration/form/`
- [ ] Click **Submit** without filling required fields
- [ ] Expected: native `<dialog>` popup appears with title "Form Error" and message "Please fill all required fields." plus an OK button
- [ ] Fill some required fields with invalid values (e.g. invalid email, phone < 10 digits)
- [ ] Click Submit → expected: the existing `customValidateFields()` popup still works (already worked before this PR)
- [ ] Fill all required fields with valid values → expected: form submits and Volunteer record is created
- [ ] Repeat on `/collection-camp/volunteer-with-intent/` and any other public Afform to confirm

## Related
- WordPress + CiviCRM upgrade ([ColoredCow/goonj-crm#285](https://github.com/ColoredCow/goonj-crm/issues/285))
- Must NOT be reverted on future CiviCRM upgrades — see the inline `GOONJ CUSTOM:` comment in the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation feedback by ensuring alert notifications display consistently when required fields are missing, even in edge-case scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColoredCow/goonj/pull/1679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->