### PR TITLE
feat: add UPI payment methods with validation and receipt update

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -317,13 +317,14 @@ class CollectionCampService extends AutoSubscriber {
 
     /**
      * =========================
-     * WIRE TRANSFER (payment_instrument_id = 5) + UPI PAYMENTS
+     * WIRE TRANSFER + UPI PAYMENTS
      * =========================
      */
-    $upiInstrumentValues = OptionValue::get(FALSE)
+    $wireAndUpiIds = OptionValue::get(FALSE)
       ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'payment_instrument')
       ->addWhere('name', 'IN', [
+        'EFT',
         'Through_Paytm',
         'Through_Amazon',
         'Through_Google_Pay',
@@ -332,8 +333,6 @@ class CollectionCampService extends AutoSubscriber {
       ])
       ->execute()
       ->column('value');
-
-    $wireAndUpiIds = array_merge([5], $upiInstrumentValues);
 
     if (in_array($fields['payment_instrument_id'], $wireAndUpiIds)) {
 
@@ -2581,13 +2580,14 @@ class CollectionCampService extends AutoSubscriber {
 
     /**
      * =========================
-     * WIRE TRANSFER (payment_instrument_id = 5) + UPI PAYMENTS
+     * WIRE TRANSFER + UPI PAYMENTS
      * =========================
      */
-    $upiInstrumentValues = OptionValue::get(FALSE)
+    $wireAndUpiIds = OptionValue::get(FALSE)
       ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'payment_instrument')
       ->addWhere('name', 'IN', [
+        'EFT',
         'Through_Paytm',
         'Through_Amazon',
         'Through_Google_Pay',
@@ -2596,8 +2596,6 @@ class CollectionCampService extends AutoSubscriber {
       ])
       ->execute()
       ->column('value');
-
-    $wireAndUpiIds = array_merge([5], $upiInstrumentValues);
 
     if (in_array($fields['payment_instrument_id'], $wireAndUpiIds)) {
 

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -317,10 +317,18 @@ class CollectionCampService extends AutoSubscriber {
 
     /**
      * =========================
-     * WIRE TRANSFER (payment_instrument_id = 5)
+     * WIRE TRANSFER (payment_instrument_id = 5) + UPI PAYMENTS
      * =========================
      */
-    if ($fields['payment_instrument_id'] == 5) {
+    $upiInstrumentValues = \Civi\Api4\OptionValue::get(FALSE)
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'payment_instrument')
+      ->addWhere('name', 'IN', ['Through_Paytm', 'Through_Amazon', 'Through_Google_Pay', 'Through_UPI', 'Through_UPI_Paytm'])
+      ->execute()->column('value');
+
+    $wireAndUpiIds = array_merge([5], $upiInstrumentValues);
+
+    if (in_array($fields['payment_instrument_id'], $wireAndUpiIds)) {
 
       $transferDateField = CustomField::get(FALSE)
         ->addSelect('id')
@@ -2566,10 +2574,18 @@ class CollectionCampService extends AutoSubscriber {
 
     /**
      * =========================
-     * WIRE TRANSFER (payment_instrument_id = 5)
+     * WIRE TRANSFER (payment_instrument_id = 5) + UPI PAYMENTS
      * =========================
      */
-    if ($fields['payment_instrument_id'] == 5) {
+    $upiInstrumentValues = \Civi\Api4\OptionValue::get(FALSE)
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'payment_instrument')
+      ->addWhere('name', 'IN', ['Through_Paytm', 'Through_Amazon', 'Through_Google_Pay', 'Through_UPI', 'Through_UPI_Paytm'])
+      ->execute()->column('value');
+
+    $wireAndUpiIds = array_merge([5], $upiInstrumentValues);
+
+    if (in_array($fields['payment_instrument_id'], $wireAndUpiIds)) {
 
       $transactionIdField = CustomField::get(FALSE)
         ->addSelect('id')

--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -320,11 +320,18 @@ class CollectionCampService extends AutoSubscriber {
      * WIRE TRANSFER (payment_instrument_id = 5) + UPI PAYMENTS
      * =========================
      */
-    $upiInstrumentValues = \Civi\Api4\OptionValue::get(FALSE)
+    $upiInstrumentValues = OptionValue::get(FALSE)
       ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'payment_instrument')
-      ->addWhere('name', 'IN', ['Through_Paytm', 'Through_Amazon', 'Through_Google_Pay', 'Through_UPI', 'Through_UPI_Paytm'])
-      ->execute()->column('value');
+      ->addWhere('name', 'IN', [
+        'Through_Paytm',
+        'Through_Amazon',
+        'Through_Google_Pay',
+        'Through_UPI',
+        'Through_UPI_Paytm',
+      ])
+      ->execute()
+      ->column('value');
 
     $wireAndUpiIds = array_merge([5], $upiInstrumentValues);
 
@@ -2577,11 +2584,18 @@ class CollectionCampService extends AutoSubscriber {
      * WIRE TRANSFER (payment_instrument_id = 5) + UPI PAYMENTS
      * =========================
      */
-    $upiInstrumentValues = \Civi\Api4\OptionValue::get(FALSE)
+    $upiInstrumentValues = OptionValue::get(FALSE)
       ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'payment_instrument')
-      ->addWhere('name', 'IN', ['Through_Paytm', 'Through_Amazon', 'Through_Google_Pay', 'Through_UPI', 'Through_UPI_Paytm'])
-      ->execute()->column('value');
+      ->addWhere('name', 'IN', [
+        'Through_Paytm',
+        'Through_Amazon',
+        'Through_Google_Pay',
+        'Through_UPI',
+        'Through_UPI_Paytm',
+      ])
+      ->execute()
+      ->column('value');
 
     $wireAndUpiIds = array_merge([5], $upiInstrumentValues);
 


### PR DESCRIPTION
Summary:
Added support for UPI based payment methods in CiviCRM. This includes making required fields mandatory when these payment modes are selected, preventing future dates, and updating the email receipt to show payment details.

What's Done-

New Payment Methods Added:
Through Paytm
Through Amazon
Through Google Pay
Through UPI
Through UPI/Paytm

Validation:
Transaction ID and Transfer Date are now mandatory when any UPI or Wire Transfer payment method is selected.
Future dates are blocked.

Email Receipt:
When a UPI payment is made, the receipt now shows the Transfer Date and Transaction Reference Number in the email sent to the donor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation expanded so UPI payment methods follow wire-transfer rules.
  * Transfer date can no longer be a future date for wire-transfer and UPI payments.
  * Transaction ID and transfer date are now required when selecting wire-transfer or UPI payment methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColoredCow/goonj/pull/1680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->