### PR TITLE
fix: correct UPI payment instrument name mismatch between DB values and validation lookup code.

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampService.php
@@ -325,11 +325,11 @@ class CollectionCampService extends AutoSubscriber {
       ->addWhere('option_group_id:name', '=', 'payment_instrument')
       ->addWhere('name', 'IN', [
         'EFT',
-        'Through_Paytm',
-        'Through_Amazon',
-        'Through_Google_Pay',
-        'Through_UPI',
-        'Through_UPI_Paytm',
+        'Through Paytm',
+        'Through Amazon',
+        'Through Google Pay',
+        'Through UPI',
+        'Through UPI/Paytm',
       ])
       ->execute()
       ->column('value');
@@ -2591,11 +2591,11 @@ class CollectionCampService extends AutoSubscriber {
       ->addWhere('option_group_id:name', '=', 'payment_instrument')
       ->addWhere('name', 'IN', [
         'EFT',
-        'Through_Paytm',
-        'Through_Amazon',
-        'Through_Google_Pay',
-        'Through_UPI',
-        'Through_UPI_Paytm',
+        'Through Paytm',
+        'Through Amazon',
+        'Through Google Pay',
+        'Through UPI',
+        'Through UPI/Paytm',
       ])
       ->execute()
       ->column('value');


### PR DESCRIPTION
Removed underscore from UPI payment instrument names to match the actual values stored in the DB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated payment instrument recognition to correctly identify wire transfers and UPI payments with current naming conventions, ensuring proper validation of transfer dates and transaction details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColoredCow/goonj/pull/1684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->