### PR TITLE
Fix feedback reminder cron

### DIFF
--- a/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
+++ b/wp-content/civi-extensions/goonjcustom/Civi/CollectionCampVolunteerFeedbackService.php
@@ -22,11 +22,15 @@ class CollectionCampVolunteerFeedbackService {
    */
   public static function processVolunteerFeedbackReminder($camp, $now, $from) {
     $initiatorId = $camp['Collection_Camp_Core_Details.Contact_Id'];
-    $initiator = Contact::get(TRUE)
+    // checkPermissions=FALSE because cron has no user context; with TRUE, ACL
+    // makes Contact::get return zero rows. The LEFT JOIN on Email can return
+    // one row per email — use ->first() to pick any email when the contact
+    // has multiple addresses.
+    $initiator = Contact::get(FALSE)
       ->addSelect('email.email', 'display_name')
       ->addJoin('Email AS email', 'LEFT')
       ->addWhere('id', '=', $initiatorId)
-      ->execute()->single();
+      ->execute()->first();
 
     $initiatorEmail = $initiator['email.email'];
     $initiatorName = $initiator['display_name'];
@@ -35,8 +39,21 @@ class CollectionCampVolunteerFeedbackService {
     $collectionCampId = $camp['id'];
     $campAddress = $camp['Collection_Camp_Intent_Details.Location_Area_of_camp'];
 
-    // Check last reminder sent.
-    $lastReminderSent = $camp['Collection_Source_Feedback.Last_Reminder_Sent'] ? new \DateTime($camp['Collection_Source_Feedback.Last_Reminder_Sent']) : NULL;
+    // Look for an existing Collection_Source_Feedback row linked to this camp.
+    // Feedback rows live on a separate Eck entity (Collection_Source_Feedback)
+    // and are normally created when the volunteer submits the form. Reminder
+    // tracking (Last_Reminder_Sent) lives on the same row, so the cron has to
+    // create a placeholder row on the first reminder if none exists yet.
+    $existingFeedback = EckEntity::get('Collection_Source_Feedback', FALSE)
+      ->addSelect('id', 'Collection_Source_Feedback.Last_Reminder_Sent')
+      ->addWhere('Collection_Source_Feedback.Collection_Camp_Code', '=', $collectionCampId)
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    $lastReminderSent = !empty($existingFeedback['Collection_Source_Feedback.Last_Reminder_Sent'])
+      ? new \DateTime($existingFeedback['Collection_Source_Feedback.Last_Reminder_Sent'])
+      : NULL;
 
     // Calculate hours since camp ended.
     $hoursSinceCampEnd = abs($now->getTimestamp() - $endDate->getTimestamp()) / 3600;
@@ -46,11 +63,12 @@ class CollectionCampVolunteerFeedbackService {
       // Send the first reminder email to the volunteer.
       self::sendVolunteerFeedbackReminderEmail($initiatorEmail, $from, $campAddress, $collectionCampId, $endDate, $initiatorName, $initiatorId);
 
-      // Update the Last_Reminder_Sent field in the database.
-      EckEntity::update('Collection_Camp', TRUE)
-        ->addWhere('id', '=', $collectionCampId)
-        ->addValue('Collection_Source_Feedback.Last_Reminder_Sent', $now->format('Y-m-d H:i:s'))
-        ->execute();
+      if (!empty($existingFeedback['id'])) {
+        EckEntity::update('Collection_Source_Feedback', FALSE)
+          ->addWhere('id', '=', $existingFeedback['id'])
+          ->addValue('Collection_Source_Feedback.Last_Reminder_Sent', $now->format('Y-m-d H:i:s'))
+          ->execute();
+      }
     }
   }
 
@@ -94,7 +112,6 @@ class CollectionCampVolunteerFeedbackService {
   public static function getVolunteerFeedbackReminderEmailHtml($initiatorName, $collectionCampId, $initiatorId, $campAddress) {
     $homeUrl = \CRM_Utils_System::baseCMSURL();
     $campVolunteerFeedback = $homeUrl . 'volunteer-camp-feedback/#?Collection_Source_Feedback.Collection_Camp_Code=' . $collectionCampId . '&Collection_Source_Feedback.Collection_Camp_Address=' . urlencode($campAddress) . '&Collection_Source_Feedback.Filled_By=' . $initiatorId;
-
 
     $html = "
       <p>Dear $initiatorName,</p>

--- a/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
+++ b/wp-content/civi-extensions/goonjcustom/api/v3/Goonjcustom/VolunteerFeedbackReminderCron.php
@@ -45,15 +45,44 @@ function civicrm_api3_goonjcustom_volunteer_feedback_reminder_cron($params) {
   // Get the default "from" email.
   $from = HelperService::getDefaultFromEmail();
 
-  // Fetch camps that have completed and volunteers have not filled the feedback form.
-  $campsNeedReminder = EckEntity::get('Collection_Camp', TRUE)
-    ->addSelect('Collection_Source_Feedback.Last_Reminder_Sent', 'Collection_Camp_Intent_Details.Location_Area_of_camp', 'Collection_Camp_Intent_Details.End_Date', 'Collection_Camp_Core_Details.Contact_Id')
-    ->addWhere('Collection_Source_Feedback.Rate_Your_Camp_Experience_1_Lowest_10_Highest_', 'IS NULL')
+  // Feedback now lives in its own Eck entity (Collection_Source_Feedback)
+  // linked back to the camp via Collection_Camp_Code. Exclude any camp that
+  // either already has submitted feedback OR has already been sent a reminder
+  // (Last_Reminder_Sent set on the feedback row).
+  $campIdsToSkip = EckEntity::get('Collection_Source_Feedback', FALSE)
+    ->addSelect('Collection_Source_Feedback.Collection_Camp_Code')
+    ->addClause('OR',
+      ['Collection_Source_Feedback.Rate_Your_Camp_Experience_1_Lowest_10_Highest_', 'IS NOT NULL'],
+      ['Collection_Source_Feedback.Last_Reminder_Sent', 'IS NOT NULL']
+    )
+    ->execute()
+    ->column('Collection_Source_Feedback.Collection_Camp_Code');
+
+  // Floor on End_Date so the cron does not blast reminders for historical camps
+  // when it resumes after being broken for a while. Only camps that ended on or
+  // after this cutoff are eligible for a reminder.
+  $reminderEligibleFrom = '2026-05-20 00:00:00';
+
+  // checkPermissions=FALSE because cron has no user context; with TRUE, ACL
+  // filters out every row (matches other Goonj crons in this directory).
+  $campsQuery = EckEntity::get('Collection_Camp', FALSE)
+    ->addSelect('Collection_Camp_Intent_Details.Location_Area_of_camp', 'Collection_Camp_Intent_Details.End_Date', 'Collection_Camp_Core_Details.Contact_Id')
     ->addWhere('Logistics_Coordination.Feedback_Email_Sent', '=', 1)
     ->addWhere('Collection_Camp_Core_Details.Status', '=', 'authorized')
+    ->addWhere('Collection_Camp_Intent_Details.End_Date', '>=', $reminderEligibleFrom)
     ->addWhere('Collection_Camp_Intent_Details.End_Date', '<=', $endOfDay)
-    ->addWhere('Collection_Camp_Intent_Details.Camp_Status', '!=', 'aborted')
-    ->execute();
+    // Camp_Status IS NULL for most camps; SQL "NULL != 'aborted'" evaluates to
+    // NULL and would drop those rows, so make the exclusion explicitly NULL-safe.
+    ->addClause('OR',
+      ['Collection_Camp_Intent_Details.Camp_Status', 'IS NULL'],
+      ['Collection_Camp_Intent_Details.Camp_Status', '!=', 'aborted']
+    );
+
+  if (!empty($campIdsToSkip)) {
+    $campsQuery->addWhere('id', 'NOT IN', $campIdsToSkip);
+  }
+
+  $campsNeedReminder = $campsQuery->execute();
 
   foreach ($campsNeedReminder as $camp) {
     try {


### PR DESCRIPTION
Fix feedback reminder cron

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined volunteer feedback reminder delivery for collection camps
  * Added May 20, 2026 as the earliest eligibility date for reminders
  * Improved duplicate reminder prevention to ensure volunteers receive messages accurately

<!-- end of auto-generated comment: release notes by coderabbit.ai -->