### PR TITLE
ci: production deployment workflow (web leg; worker commented) — DO NOT MERGE until tree reconcile

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -1,0 +1,33 @@
+name: production-deployment
+
+on:
+  push:
+    branches: main
+
+jobs:
+  deploy:
+    strategy:
+      fail-fast: false          # once both legs are live, one host failing must NOT cancel the other
+      matrix:
+        include:
+          - { name: web, host_secret: PROD_SSH_HOST }        # only the HOST differs between web/worker
+          # --- WORKER LEG: uncomment once the worker is provisioned + reachable (Phase 2 Part 3) ---
+          # - { name: worker, host_secret: PROD_SSH_WORKER_HOST }
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to ${{ matrix.name }}
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets[matrix.host_secret] }}          # per-host (web vs worker)
+          username: ${{ secrets.PROD_SSH_USERNAME }}         # ubuntu (shared)
+          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}           # Key A (shared)
+          script_stop: true
+          script: |
+            set -eu
+            DIR="${{ secrets.PROD_SSH_BUILD_DIRECTORY }}"
+            # git runs as apache (tree owner); ubuntu -> apache is passwordless sudo
+            sudo -u apache bash -c "cd '$DIR' \
+              && rm -f .git/index.lock 2>/dev/null || true; \
+              git fetch --prune origin main \
+              && git reset --hard origin/main"


### PR DESCRIPTION
Adds `.github/workflows/production-deployment.yml` — continuous deployment for **production web** on push to `main`.

**What it does:** `appleboy/ssh-action` → SSH to prod web as `ubuntu` → `sudo -u apache git fetch --prune origin main && git reset --hard origin/main` (git runs as the tree owner `apache`). Matrix is built for both tiers; the **worker leg is commented out** and gets uncommented in Phase 2 Part 3 once the worker is provisioned.

**Secrets (already set, `PROD_`-prefixed, repo-level):** `PROD_SSH_HOST`, `PROD_SSH_USERNAME`, `PROD_SSH_PRIVATE_KEY`, `PROD_SSH_BUILD_DIRECTORY`.

### ⚠️ DO NOT MERGE YET
Merging to `main` triggers the first deploy (`git reset --hard`). The prod working tree is currently **dirty (37 entries)** — it must be reconciled first (see the implementation plan on coloredcow-admin/goonj-crm#351, "Reconcile the working tree"):
- gitignore + `git rm --cached` the tracked Wordfence `wp-content/wflogs/*` (runtime-mutated)
- confirm no local commits ahead of `origin/main`
- remove untracked `wp-config.php.bak-20260427`

Kept as a **draft** until that's done.

Ref: coloredcow-admin/goonj-crm#351