### PR TITLE
Add wordfence and dompdf cache files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,14 @@ wp-config.php
 # uncomment the next line
 #/wp-content/themes
 
+# Wordfence
+wordfence-waf.php
+/wp-content/wflogs/
+
+# dompdf font cache
+wp-content/plugins/civicrm/civicrm/vendor/dompdf/dompdf/lib/fonts/*.ufm.json
+wp-content/plugins/civicrm/civicrm/vendor/dompdf/dompdf/lib/fonts/*.afm.json
+
 # macos
 .DS_Store
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,8 @@ wordfence-waf.php
 /wp-content/wflogs/
 
 # dompdf font cache
-wp-content/plugins/civicrm/civicrm/vendor/dompdf/dompdf/lib/fonts/*.ufm.json
-wp-content/plugins/civicrm/civicrm/vendor/dompdf/dompdf/lib/fonts/*.afm.json
+/wp-content/plugins/civicrm/civicrm/vendor/dompdf/dompdf/lib/fonts/*.ufm.json
+/wp-content/plugins/civicrm/civicrm/vendor/dompdf/dompdf/lib/fonts/*.afm.json
 
 # macos
 .DS_Store


### PR DESCRIPTION
Add wordfence and dompdf cache files to gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project cleanup rules to exclude security logs, security configuration files, and generated font cache artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->